### PR TITLE
test: add live PLC endurance coverage

### DIFF
--- a/src/OmronPlcRx.Tests/OmronCs1gHardwareTests.cs
+++ b/src/OmronPlcRx.Tests/OmronCs1gHardwareTests.cs
@@ -1,0 +1,222 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if OMRON_CS1G_HARDWARE_TESTS
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using IoT.DriverCore.OmronPlcRx.Enums;
+using TUnit.Core;
+
+namespace IoT.DriverCore.OmronPlcRx.Tests;
+
+/// <summary>
+/// Read-only endurance coverage for the dedicated CS1G CPU42H Toolbus connection.
+/// Compile this file explicitly with <c>OMRON_CS1G_HARDWARE_TESTS</c>; it is excluded from
+/// normal and CI test runs because it opens physical serial port COM3.
+/// </summary>
+[NotInParallel("omron-cs1g-com3")]
+public sealed class OmronCs1gHardwareTests
+{
+    /// <summary>Local FINS source node for the direct Toolbus connection.</summary>
+    private const byte LocalNode = 11;
+
+    /// <summary>Direct CPU destination node.</summary>
+    private const byte RemoteNode = 0;
+
+    /// <summary>Maximum duration for a single serial request.</summary>
+    private const int RequestTimeoutMilliseconds = 2_000;
+
+    /// <summary>Default number of sequential read-only clock and cycle-time pairs.</summary>
+    private const int DefaultReadPairCount = 100;
+
+    /// <summary>Maximum number of configured clock and cycle-time pairs.</summary>
+    private const int MaximumReadPairCount = 10_000;
+
+    /// <summary>Default delay between read pairs.</summary>
+    private const int DefaultReadPairDelayMilliseconds = 50;
+
+    /// <summary>Maximum configured delay between read pairs.</summary>
+    private const int MaximumReadPairDelayMilliseconds = 10_000;
+
+    /// <summary>Default physical serial port assigned to the CS1G Toolbus connection.</summary>
+    private const string DefaultPortName = "COM3";
+
+    /// <summary>Controller model reported by the documented CS1G hardware.</summary>
+    private const string ExpectedControllerModel = "CS1G_CPU42H";
+
+    /// <summary>Controller version reported by the documented CS1G hardware.</summary>
+    private const string ExpectedControllerVersion = "02.20";
+
+    /// <summary>Poll interval used solely to initialize the read-only facade.</summary>
+    private const int PollIntervalSeconds = 30;
+
+    /// <summary>Maximum wait for initial controller-information discovery.</summary>
+    private const int InitializationTimeoutSeconds = 10;
+
+    /// <summary>Minimum supported CS1G clock year.</summary>
+    private const int MinimumClockYear = 1998;
+
+    /// <summary>Maximum supported CS1G clock year.</summary>
+    private const int MaximumClockYear = 2069;
+
+    /// <summary>Polling delay while controller information is being discovered.</summary>
+    private const int InitializationPollMilliseconds = 50;
+
+    /// <summary>
+    /// Repeats only controller-information, clock-read, and cycle-time-read operations. No PLC
+    /// memory or clock write command is issued.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token enforced by the TUnit timeout.</param>
+    /// <returns>A task representing the hardware validation.</returns>
+    [Test]
+    [Timeout(900_000)]
+    public async Task Cs1gToolbus_ReadOnlyClockAndCycleTimeEnduranceAsync(
+        CancellationToken cancellationToken)
+    {
+        var portName = Environment.GetEnvironmentVariable("OMRON_CS1G_COM_PORT");
+        var readPairCount = GetBoundedEnvironmentValue(
+            "OMRON_CS1G_READ_PAIR_COUNT",
+            DefaultReadPairCount,
+            1,
+            MaximumReadPairCount);
+        var readPairDelayMilliseconds = GetBoundedEnvironmentValue(
+            "OMRON_CS1G_READ_PAIR_DELAY_MS",
+            DefaultReadPairDelayMilliseconds,
+            0,
+            MaximumReadPairDelayMilliseconds);
+        var options = OmronSerialOptions.CreateToolbus(
+            string.IsNullOrWhiteSpace(portName) ? DefaultPortName : portName);
+        using var plc = new OmronPlcRx(
+            LocalNode,
+            RemoteNode,
+            options,
+            RequestTimeoutMilliseconds,
+            retries: 0,
+            pollInterval: TimeSpan.FromSeconds(PollIntervalSeconds));
+        Exception? initializationError = null;
+        using var errors = plc.Errors.Subscribe(
+            new ActionObserver<OmronPLCException?>(error => initializationError ??= error));
+
+        await WaitForControllerInformationAsync(
+            plc,
+            TimeSpan.FromSeconds(InitializationTimeoutSeconds),
+            () => initializationError,
+            cancellationToken).ConfigureAwait(false);
+
+        await Assert.That(plc.PlcType).IsEqualTo(PlcType.C_Series);
+        await Assert.That(plc.ControllerModel).IsEqualTo(ExpectedControllerModel);
+        await Assert.That(plc.ControllerVersion).IsEqualTo(ExpectedControllerVersion);
+
+        for (var iteration = 0; iteration < readPairCount; iteration++)
+        {
+            await AssertReadPairAsync(plc, cancellationToken).ConfigureAwait(false);
+            if (iteration + 1 < readPairCount && readPairDelayMilliseconds > 0)
+            {
+                await Task.Delay(readPairDelayMilliseconds, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        Trace.WriteLine(
+            $"Omron CS1G read-only endurance succeeded: port={options.PortName}; pairs={readPairCount}; delayMs={readPairDelayMilliseconds}.");
+        Trace.WriteLine($"Controller model={plc.ControllerModel}; version={plc.ControllerVersion}.");
+    }
+
+    /// <summary>Reads and validates one clock and cycle-time pair.</summary>
+    /// <param name="plc">The live Omron client.</param>
+    /// <param name="cancellationToken">The TUnit timeout token.</param>
+    /// <returns>A task representing the read and assertions.</returns>
+    private static async Task AssertReadPairAsync(
+        OmronPlcRx plc,
+        CancellationToken cancellationToken)
+    {
+        var clock = await plc.ReadClockAsync(cancellationToken).ConfigureAwait(false);
+        var cycle = await plc.ReadCycleTimeAsync(cancellationToken).ConfigureAwait(false);
+
+        await Assert.That(clock.BytesSent).IsGreaterThan(0);
+        await Assert.That(clock.BytesReceived).IsGreaterThan(0);
+        await Assert.That(clock.PacketsSent).IsEqualTo(1);
+        await Assert.That(clock.PacketsReceived).IsEqualTo(1);
+        await Assert.That(clock.Clock.Year).IsGreaterThanOrEqualTo(MinimumClockYear);
+        await Assert.That(clock.Clock.Year).IsLessThanOrEqualTo(MaximumClockYear);
+        await Assert.That(cycle.BytesSent).IsGreaterThan(0);
+        await Assert.That(cycle.BytesReceived).IsGreaterThan(0);
+        await Assert.That(cycle.PacketsSent).IsEqualTo(1);
+        await Assert.That(cycle.PacketsReceived).IsEqualTo(1);
+        await Assert.That(cycle.MinimumCycleTime).IsGreaterThanOrEqualTo(0D);
+        await Assert.That(cycle.AverageCycleTime).IsGreaterThanOrEqualTo(cycle.MinimumCycleTime);
+        await Assert.That(cycle.MaximumCycleTime).IsGreaterThanOrEqualTo(cycle.AverageCycleTime);
+    }
+
+    /// <summary>Waits for the facade's background initialization to identify the controller.</summary>
+    /// <param name="plc">Read-only facade owning the Toolbus serial channel.</param>
+    /// <param name="timeout">Maximum wait for controller information.</param>
+    /// <param name="getInitializationError">Returns the serial initialization error, if one was raised.</param>
+    /// <param name="cancellationToken">Cancellation token enforced by the TUnit timeout.</param>
+    /// <returns>A task representing the wait.</returns>
+    private static async Task WaitForControllerInformationAsync(
+        OmronPlcRx plc,
+        TimeSpan timeout,
+        Func<Exception?> getInitializationError,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            if (plc.ControllerModel is not null && plc.ControllerVersion is not null)
+            {
+                return;
+            }
+
+            await Task.Delay(InitializationPollMilliseconds, cancellationToken).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException(
+            "CS1G Toolbus controller-information read did not complete within 10 seconds.",
+            getInitializationError());
+    }
+
+    /// <summary>Gets a bounded integer environment option.</summary>
+    /// <param name="name">Environment variable name.</param>
+    /// <param name="defaultValue">Value used when the variable is absent or invalid.</param>
+    /// <param name="minimum">Minimum accepted value.</param>
+    /// <param name="maximum">Maximum accepted value.</param>
+    /// <returns>The configured or default value.</returns>
+    private static int GetBoundedEnvironmentValue(
+        string name,
+        int defaultValue,
+        int minimum,
+        int maximum)
+    {
+        var configuredValue = Environment.GetEnvironmentVariable(name);
+        return int.TryParse(configuredValue, out var value) && value >= minimum && value <= maximum
+            ? value
+            : defaultValue;
+    }
+
+    /// <summary>Adapts a value callback to the BCL observable contract used by the public driver API.</summary>
+    /// <typeparam name="T">Observable value type.</typeparam>
+    private sealed class ActionObserver<T> : IObserver<T>
+    {
+        /// <summary>Receives values from the observed sequence.</summary>
+        private readonly Action<T> _onNext;
+
+        /// <summary>Initializes a new instance of the <see cref="ActionObserver{T}"/> class.</summary>
+        /// <param name="onNext">Callback invoked for each observed value.</param>
+        public ActionObserver(Action<T> onNext) => _onNext = onNext;
+
+        /// <inheritdoc/>
+        public void OnCompleted()
+        {
+        }
+
+        /// <inheritdoc/>
+        public void OnError(Exception error) => _onNext(default!);
+
+        /// <inheritdoc/>
+        public void OnNext(T value) => _onNext(value);
+    }
+}
+#endif

--- a/src/OmronPlcRx.Tests/OmronPlcRx.Tests.csproj
+++ b/src/OmronPlcRx.Tests/OmronPlcRx.Tests.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <DefineConstants Condition="'$(EnableOmronCs1gHardwareTests)' == 'true'">$(DefineConstants);OMRON_CS1G_HARDWARE_TESTS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/S7PlcRx.Tests/S7LiveHardwareIntegrationTests.cs
+++ b/src/S7PlcRx.Tests/S7LiveHardwareIntegrationTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if LIVE_S7_TESTS
+using System.Diagnostics;
+using TUnitAssert = TUnit.Assertions.Assert;
+
+namespace IoT.DriverCore.S7PlcRx.Tests;
+
+/// <summary>Read-only hardware integration coverage for an S7-1500 test endpoint.</summary>
+/// <remarks>
+/// This source is compiled only when <c>LIVE_S7_TESTS</c> is explicitly defined. It creates no watchdog,
+/// registers no tags, and performs only ISO-on-TCP/S7 setup plus CPU diagnostic reads.
+/// </remarks>
+[NotInParallel]
+public sealed class S7LiveHardwareIntegrationTests
+{
+    /// <summary>Default authorized S7-1500 endpoint.</summary>
+    private const string DefaultEndpoint = "172.16.13.1";
+
+    /// <summary>Default number of CPU diagnostic reads in a live endurance run.</summary>
+    private const int DefaultReadCount = 120;
+
+    /// <summary>Upper bound for an explicitly configured live endurance run.</summary>
+    private const int MaximumReadCount = 10_000;
+
+    /// <summary>Default delay between diagnostic reads so endurance runs do not hammer the CPU.</summary>
+    private const int DefaultReadDelayMilliseconds = 250;
+
+    /// <summary>Upper bound for an explicitly configured delay between diagnostic reads.</summary>
+    private const int MaximumReadDelayMilliseconds = 10_000;
+
+    /// <summary>Connection and individual CPU-read timeout.</summary>
+    private static readonly TimeSpan OperationTimeout = TimeSpan.FromSeconds(15);
+
+    /// <summary>Repeatedly connects to the S7-1500 and reads CPU diagnostics without accessing user data or writing.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task S71500_ConnectsAndReadsCpuDiagnostics_ReadOnlyEnduranceAsync()
+    {
+        var endpoint = GetEndpoint();
+        var readCount = GetReadCount();
+        var readDelay = GetReadDelay();
+        var stopwatch = Stopwatch.StartNew();
+        var completedReads = 0;
+
+        using var plc = S71500.Create(endpoint, interval: 250);
+
+        var connected = await plc.IsConnected
+            .Where(static value => value)
+            .Take(1)
+            .Timeout(OperationTimeout)
+            .FirstAsync();
+        await TUnitAssert.That(connected).IsTrue();
+
+        for (var index = 0; index < readCount; index++)
+        {
+            var cpuInfo = await plc.GetCpuInfo()
+                .Take(1)
+                .Timeout(OperationTimeout)
+                .FirstAsync();
+
+            await TUnitAssert.That(cpuInfo).IsNotNull();
+            await TUnitAssert.That(cpuInfo.Length).IsGreaterThan(0);
+            completedReads++;
+            if (index + 1 < readCount && readDelay > TimeSpan.Zero)
+            {
+                await Task.Delay(readDelay);
+            }
+        }
+
+        stopwatch.Stop();
+        Trace.WriteLine(
+            $"S7-1500 read-only endurance succeeded: endpoint={endpoint}; reads={completedReads}; delayMs={readDelay.TotalMilliseconds:F0}; elapsedMs={stopwatch.Elapsed.TotalMilliseconds:F0}.");
+        await TUnitAssert.That(completedReads).IsEqualTo(readCount);
+        await TUnitAssert.That(plc.IsConnectedValue).IsTrue();
+    }
+
+    /// <summary>Gets the explicit endpoint override or the authorized default endpoint.</summary>
+    /// <returns>The endpoint to connect to.</returns>
+    private static string GetEndpoint()
+    {
+        var endpoint = Environment.GetEnvironmentVariable("S7PLCRX_LIVE_IP");
+        return string.IsNullOrWhiteSpace(endpoint) ? DefaultEndpoint : endpoint;
+    }
+
+    /// <summary>Gets a bounded positive iteration count from the environment.</summary>
+    /// <returns>The number of diagnostic reads to perform.</returns>
+    private static int GetReadCount()
+    {
+        var configuredReadCount = Environment.GetEnvironmentVariable("S7PLCRX_LIVE_READ_COUNT");
+        return int.TryParse(configuredReadCount, out var readCount) && readCount is > 0 and <= MaximumReadCount
+            ? readCount
+            : DefaultReadCount;
+    }
+
+    /// <summary>Gets a bounded delay between diagnostic reads from the environment.</summary>
+    /// <returns>The delay between reads.</returns>
+    private static TimeSpan GetReadDelay()
+    {
+        var configuredDelay = Environment.GetEnvironmentVariable("S7PLCRX_LIVE_READ_DELAY_MS");
+        var delayMilliseconds =
+            int.TryParse(configuredDelay, out var readDelay)
+            && readDelay is >= 0 and <= MaximumReadDelayMilliseconds
+                ? readDelay
+                : DefaultReadDelayMilliseconds;
+        return TimeSpan.FromMilliseconds(delayMilliseconds);
+    }
+}
+#endif

--- a/src/S7PlcRx.Tests/S7PlcRx.Tests.csproj
+++ b/src/S7PlcRx.Tests/S7PlcRx.Tests.csproj
@@ -11,6 +11,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <TUnitAssertionsImplicitUsings>false</TUnitAssertionsImplicitUsings>
     <UseAppHost>false</UseAppHost>
+    <DefineConstants Condition="'$(EnableLiveS7Tests)' == 'true'">$(DefineConstants);LIVE_S7_TESTS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <PlatformTarget>x86</PlatformTarget>

--- a/src/TwinCATRx.Tests/Rx/LiveAdsReadOnlyHardwareTests.cs
+++ b/src/TwinCATRx.Tests/Rx/LiveAdsReadOnlyHardwareTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if LIVE_ADS_READ_ONLY_TESTS
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using IoT.DriverCore.TwinCATRx.Core;
+using TwinCAT.Ads;
+
+namespace IoT.DriverCore.TwinCATRx.Tests.Rx;
+
+/// <summary>Opt-in, read-only hardware probes for the documented TwinCAT routes.</summary>
+[Category("LiveAds")]
+public sealed class LiveAdsReadOnlyHardwareTests
+{
+    /// <summary>TwinCAT 3 AMS Net ID.</summary>
+    private const string TwinCat3Address = "10.1.180.147.1.1";
+
+    /// <summary>TwinCAT 3 PLC runtime port.</summary>
+    private const int TwinCat3Port = 851;
+
+    /// <summary>TwinCAT 2 AMS Net ID.</summary>
+    private const string TwinCat2Address = "5.35.59.10.1.1";
+
+    /// <summary>TwinCAT 2 PLC runtime port.</summary>
+    private const int TwinCat2Port = 801;
+
+    /// <summary>Default number of ADS state reads per endpoint.</summary>
+    private const int DefaultEnduranceReads = 120;
+
+    /// <summary>Maximum configured ADS state reads per endpoint.</summary>
+    private const int MaximumEnduranceReads = 10_000;
+
+    /// <summary>Default delay between ADS state reads.</summary>
+    private const int DefaultReadDelayMilliseconds = 500;
+
+    /// <summary>Maximum configured delay between ADS state reads.</summary>
+    private const int MaximumReadDelayMilliseconds = 10_000;
+
+    /// <summary>Verifies the TwinCAT 3 AMS route without issuing any PLC write.</summary>
+    /// <param name="cancellationToken">The TUnit timeout token.</param>
+    /// <returns>The test task.</returns>
+    [Test]
+    [Timeout(900_000)]
+    public async Task TwinCat3_ReadOnlyRoute_IsReachable_AndLoadsSymbols(CancellationToken cancellationToken)
+    {
+        await VerifyEndpointAsync(TwinCat3Address, TwinCat3Port, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Verifies the TwinCAT 2 AMS route without issuing any PLC write.</summary>
+    /// <param name="cancellationToken">The TUnit timeout token.</param>
+    /// <returns>The test task.</returns>
+    [Test]
+    [Timeout(900_000)]
+    public async Task TwinCat2_ReadOnlyRoute_IsReachable_AndLoadsSymbols(CancellationToken cancellationToken)
+    {
+        await VerifyEndpointAsync(TwinCat2Address, TwinCat2Port, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Reads ADS state repeatedly and loads the endpoint symbol table once.</summary>
+    /// <param name="adsAddress">The AMS Net ID.</param>
+    /// <param name="port">The ADS runtime port.</param>
+    /// <param name="cancellationToken">The TUnit timeout token.</param>
+    /// <returns>The test task.</returns>
+    private static async Task VerifyEndpointAsync(
+        string adsAddress,
+        int port,
+        CancellationToken cancellationToken)
+    {
+        var readCount = GetBoundedEnvironmentValue(
+            "TWINCATRX_LIVE_ADS_READ_COUNT",
+            DefaultEnduranceReads,
+            1,
+            MaximumEnduranceReads);
+        var readDelayMilliseconds = GetBoundedEnvironmentValue(
+            "TWINCATRX_LIVE_ADS_READ_DELAY_MS",
+            DefaultReadDelayMilliseconds,
+            0,
+            MaximumReadDelayMilliseconds);
+        using var client = new AdsClient();
+        client.Connect(adsAddress, port);
+
+        for (var attempt = 0; attempt < readCount; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var state = client.ReadState();
+            await TUnitAssert.That(state.AdsState).IsEqualTo(AdsState.Run);
+            if (attempt + 1 < readCount && readDelayMilliseconds > 0)
+            {
+                await Task.Delay(readDelayMilliseconds, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        using var generator = new CodeGenerator();
+        var symbols = generator.LoadSymbols(adsAddress, port);
+        await TUnitAssert.That(symbols.Count).IsGreaterThan(0);
+    }
+
+    /// <summary>Gets a bounded integer environment option.</summary>
+    /// <param name="name">Environment variable name.</param>
+    /// <param name="defaultValue">Value used when the variable is absent or invalid.</param>
+    /// <param name="minimum">Minimum accepted value.</param>
+    /// <param name="maximum">Maximum accepted value.</param>
+    /// <returns>The configured or default value.</returns>
+    private static int GetBoundedEnvironmentValue(
+        string name,
+        int defaultValue,
+        int minimum,
+        int maximum)
+    {
+        var configuredValue = Environment.GetEnvironmentVariable(name);
+        return int.TryParse(configuredValue, out var value) && value >= minimum && value <= maximum
+            ? value
+            : defaultValue;
+    }
+}
+#endif

--- a/src/TwinCATRx.Tests/TwinCATRx.Tests.csproj
+++ b/src/TwinCATRx.Tests/TwinCATRx.Tests.csproj
@@ -11,6 +11,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <UseAppHost>false</UseAppHost>
     <TUnitAssertionsImplicitUsings>false</TUnitAssertionsImplicitUsings>
+    <DefineConstants Condition="'$(EnableLiveAdsReadOnlyTests)' == 'true'">$(DefineConstants);LIVE_ADS_READ_ONLY_TESTS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <PlatformTarget>x86</PlatformTarget>


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is a test-infrastructure change that adds opt-in, read-only TUnit hardware endurance coverage for the supported Siemens S7, Beckhoff TwinCAT ADS, and Omron PLC drivers. No production driver code is changed.

## What is the new behavior?

- Adds an opt-in S7-1500 suite for repeated connection and CPU diagnostic reads against `172.16.13.1`.
- Adds separate opt-in TwinCAT 3 and TwinCAT 2 suites for repeated ADS Run-state reads and symbol-table loading against `10.1.180.147.1.1:851` and `5.35.59.10.1.1:801`.
- Adds an opt-in Omron CS1G Toolbus suite for controller identity, clock, and cycle-time reads over `COM3`.
- Provides bounded environment-variable overrides for endpoints, iteration counts, and pacing.
- Keeps every physical-hardware suite excluded from normal and CI runs unless its MSBuild enable switch is explicitly set.

## What is the current behavior?

The repository does not currently contain reusable, explicitly enabled endurance tests covering all four supplied PLC endpoints. Existing normal unit tests validate driver behavior without exercising these live communication paths for sustained periods.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows Conventional Commits

## Additional information

Live read-only validation completed with zero hardware failures:

| Endpoint | Exercise | Result |
|---|---|---|
| S7-1500 `172.16.13.1` | 1,200 CPU diagnostic reads | Passed in 5m 04s |
| TwinCAT 3 `10.1.180.147.1.1:851` | 1,200 ADS state reads plus symbol loading | Passed in 5m 04s |
| TwinCAT 2 `5.35.59.10.1.1:801` | 1,200 ADS state reads plus symbol loading | Passed in 5m 03s |
| Omron CS1G `COM3` | 1,800 clock/cycle pairs, 3,600 serial services | Passed in 4m 12s |

Normal hardware-disabled TUnit regressions also passed: S7 386/386, TwinCAT 251/251, and Omron 158/158, for 795 total tests with zero failures. All affected Release `net10.0` test projects built with zero warnings and zero errors.

The live tests intentionally issue no PLC writes. Write, watchdog, and mutable-tag testing remains excluded because no approved disposable address or symbol was supplied.
