### PR TITLE
docs: complete IoT driver package guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,162 @@
+![A central industrial edge gateway connecting PLCs, field instruments, serial links, and reactive data streams](images/iot-drivercore-hero.png)
+
 # IoT-DriverCore
-IoT‑DriverCore is a modular, vendor‑neutral framework for building and managing drivers for PLCs and industrial IoT devices. 
-It provides a unified API, consistent driver lifecycle, and scalable integration for edge, gateway, and automation systems.
+
+## NuGet packages
+
+The badges below report the current NuGet version and total downloads for every package produced by this repository.
+
+| Family | Package | Version | Downloads |
+| --- | --- | --- | --- |
+| Shared core | [`CP.IoT.Core`](https://www.nuget.org/packages/CP.IoT.Core) | [![CP.IoT.Core version](https://img.shields.io/nuget/v/CP.IoT.Core?label=version)](https://www.nuget.org/packages/CP.IoT.Core) | [![CP.IoT.Core downloads](https://img.shields.io/nuget/dt/CP.IoT.Core?label=downloads)](https://www.nuget.org/packages/CP.IoT.Core) |
+| Allen-Bradley | [`ABPlcRx`](https://www.nuget.org/packages/ABPlcRx) | [![ABPlcRx version](https://img.shields.io/nuget/v/ABPlcRx?label=version)](https://www.nuget.org/packages/ABPlcRx) | [![ABPlcRx downloads](https://img.shields.io/nuget/dt/ABPlcRx?label=downloads)](https://www.nuget.org/packages/ABPlcRx) |
+| Allen-Bradley | [`ABPlcRx.Reactive`](https://www.nuget.org/packages/ABPlcRx.Reactive) | [![ABPlcRx.Reactive version](https://img.shields.io/nuget/v/ABPlcRx.Reactive?label=version)](https://www.nuget.org/packages/ABPlcRx.Reactive) | [![ABPlcRx.Reactive downloads](https://img.shields.io/nuget/dt/ABPlcRx.Reactive?label=downloads)](https://www.nuget.org/packages/ABPlcRx.Reactive) |
+| Allen-Bradley | [`ABPlcRx.Generators`](https://www.nuget.org/packages/ABPlcRx.Generators) | [![ABPlcRx.Generators version](https://img.shields.io/nuget/v/ABPlcRx.Generators?label=version)](https://www.nuget.org/packages/ABPlcRx.Generators) | [![ABPlcRx.Generators downloads](https://img.shields.io/nuget/dt/ABPlcRx.Generators?label=downloads)](https://www.nuget.org/packages/ABPlcRx.Generators) |
+| Mitsubishi | [`MitsubishiRx`](https://www.nuget.org/packages/MitsubishiRx) | [![MitsubishiRx version](https://img.shields.io/nuget/v/MitsubishiRx?label=version)](https://www.nuget.org/packages/MitsubishiRx) | [![MitsubishiRx downloads](https://img.shields.io/nuget/dt/MitsubishiRx?label=downloads)](https://www.nuget.org/packages/MitsubishiRx) |
+| Mitsubishi | [`MitsubishiRx.Reactive`](https://www.nuget.org/packages/MitsubishiRx.Reactive) | [![MitsubishiRx.Reactive version](https://img.shields.io/nuget/v/MitsubishiRx.Reactive?label=version)](https://www.nuget.org/packages/MitsubishiRx.Reactive) | [![MitsubishiRx.Reactive downloads](https://img.shields.io/nuget/dt/MitsubishiRx.Reactive?label=downloads)](https://www.nuget.org/packages/MitsubishiRx.Reactive) |
+| Mitsubishi | [`MitsubishiRx.Generators`](https://www.nuget.org/packages/MitsubishiRx.Generators) | [![MitsubishiRx.Generators version](https://img.shields.io/nuget/v/MitsubishiRx.Generators?label=version)](https://www.nuget.org/packages/MitsubishiRx.Generators) | [![MitsubishiRx.Generators downloads](https://img.shields.io/nuget/dt/MitsubishiRx.Generators?label=downloads)](https://www.nuget.org/packages/MitsubishiRx.Generators) |
+| Modbus | [`ModbusRx`](https://www.nuget.org/packages/ModbusRx) | [![ModbusRx version](https://img.shields.io/nuget/v/ModbusRx?label=version)](https://www.nuget.org/packages/ModbusRx) | [![ModbusRx downloads](https://img.shields.io/nuget/dt/ModbusRx?label=downloads)](https://www.nuget.org/packages/ModbusRx) |
+| Modbus | [`ModbusRx.Reactive`](https://www.nuget.org/packages/ModbusRx.Reactive) | [![ModbusRx.Reactive version](https://img.shields.io/nuget/v/ModbusRx.Reactive?label=version)](https://www.nuget.org/packages/ModbusRx.Reactive) | [![ModbusRx.Reactive downloads](https://img.shields.io/nuget/dt/ModbusRx.Reactive?label=downloads)](https://www.nuget.org/packages/ModbusRx.Reactive) |
+| Modbus | [`ModbusRx.Generators`](https://www.nuget.org/packages/ModbusRx.Generators) | [![ModbusRx.Generators version](https://img.shields.io/nuget/v/ModbusRx.Generators?label=version)](https://www.nuget.org/packages/ModbusRx.Generators) | [![ModbusRx.Generators downloads](https://img.shields.io/nuget/dt/ModbusRx.Generators?label=downloads)](https://www.nuget.org/packages/ModbusRx.Generators) |
+| Omron | [`OmronPlcRx`](https://www.nuget.org/packages/OmronPlcRx) | [![OmronPlcRx version](https://img.shields.io/nuget/v/OmronPlcRx?label=version)](https://www.nuget.org/packages/OmronPlcRx) | [![OmronPlcRx downloads](https://img.shields.io/nuget/dt/OmronPlcRx?label=downloads)](https://www.nuget.org/packages/OmronPlcRx) |
+| Omron | [`OmronPlcRx.Reactive`](https://www.nuget.org/packages/OmronPlcRx.Reactive) | [![OmronPlcRx.Reactive version](https://img.shields.io/nuget/v/OmronPlcRx.Reactive?label=version)](https://www.nuget.org/packages/OmronPlcRx.Reactive) | [![OmronPlcRx.Reactive downloads](https://img.shields.io/nuget/dt/OmronPlcRx.Reactive?label=downloads)](https://www.nuget.org/packages/OmronPlcRx.Reactive) |
+| Omron | [`OmronPlcRx.Generators`](https://www.nuget.org/packages/OmronPlcRx.Generators) | [![OmronPlcRx.Generators version](https://img.shields.io/nuget/v/OmronPlcRx.Generators?label=version)](https://www.nuget.org/packages/OmronPlcRx.Generators) | [![OmronPlcRx.Generators downloads](https://img.shields.io/nuget/dt/OmronPlcRx.Generators?label=downloads)](https://www.nuget.org/packages/OmronPlcRx.Generators) |
+| Siemens S7 | [`S7PlcRx`](https://www.nuget.org/packages/S7PlcRx) | [![S7PlcRx version](https://img.shields.io/nuget/v/S7PlcRx?label=version)](https://www.nuget.org/packages/S7PlcRx) | [![S7PlcRx downloads](https://img.shields.io/nuget/dt/S7PlcRx?label=downloads)](https://www.nuget.org/packages/S7PlcRx) |
+| Siemens S7 | [`S7PlcRx.Reactive`](https://www.nuget.org/packages/S7PlcRx.Reactive) | [![S7PlcRx.Reactive version](https://img.shields.io/nuget/v/S7PlcRx.Reactive?label=version)](https://www.nuget.org/packages/S7PlcRx.Reactive) | [![S7PlcRx.Reactive downloads](https://img.shields.io/nuget/dt/S7PlcRx.Reactive?label=downloads)](https://www.nuget.org/packages/S7PlcRx.Reactive) |
+| Siemens S7 | [`S7PlcRx.Generators`](https://www.nuget.org/packages/S7PlcRx.Generators) | [![S7PlcRx.Generators version](https://img.shields.io/nuget/v/S7PlcRx.Generators?label=version)](https://www.nuget.org/packages/S7PlcRx.Generators) | [![S7PlcRx.Generators downloads](https://img.shields.io/nuget/dt/S7PlcRx.Generators?label=downloads)](https://www.nuget.org/packages/S7PlcRx.Generators) |
+| Serial and sockets | [`SerialPortRx`](https://www.nuget.org/packages/SerialPortRx) | [![SerialPortRx version](https://img.shields.io/nuget/v/SerialPortRx?label=version)](https://www.nuget.org/packages/SerialPortRx) | [![SerialPortRx downloads](https://img.shields.io/nuget/dt/SerialPortRx?label=downloads)](https://www.nuget.org/packages/SerialPortRx) |
+| Serial and sockets | [`SerialPortRx.Reactive`](https://www.nuget.org/packages/SerialPortRx.Reactive) | [![SerialPortRx.Reactive version](https://img.shields.io/nuget/v/SerialPortRx.Reactive?label=version)](https://www.nuget.org/packages/SerialPortRx.Reactive) | [![SerialPortRx.Reactive downloads](https://img.shields.io/nuget/dt/SerialPortRx.Reactive?label=downloads)](https://www.nuget.org/packages/SerialPortRx.Reactive) |
+| Beckhoff TwinCAT | [`CP.TwinCATRx`](https://www.nuget.org/packages/CP.TwinCATRx) | [![CP.TwinCATRx version](https://img.shields.io/nuget/v/CP.TwinCATRx?label=version)](https://www.nuget.org/packages/CP.TwinCATRx) | [![CP.TwinCATRx downloads](https://img.shields.io/nuget/dt/CP.TwinCATRx?label=downloads)](https://www.nuget.org/packages/CP.TwinCATRx) |
+| Beckhoff TwinCAT | [`CP.TwinCATRx.Reactive`](https://www.nuget.org/packages/CP.TwinCATRx.Reactive) | [![CP.TwinCATRx.Reactive version](https://img.shields.io/nuget/v/CP.TwinCATRx.Reactive?label=version)](https://www.nuget.org/packages/CP.TwinCATRx.Reactive) | [![CP.TwinCATRx.Reactive downloads](https://img.shields.io/nuget/dt/CP.TwinCATRx.Reactive?label=downloads)](https://www.nuget.org/packages/CP.TwinCATRx.Reactive) |
+| Beckhoff TwinCAT | [`TwinCATRx.Generators`](https://www.nuget.org/packages/TwinCATRx.Generators) | [![TwinCATRx.Generators version](https://img.shields.io/nuget/v/TwinCATRx.Generators?label=version)](https://www.nuget.org/packages/TwinCATRx.Generators) | [![TwinCATRx.Generators downloads](https://img.shields.io/nuget/dt/TwinCATRx.Generators?label=downloads)](https://www.nuget.org/packages/TwinCATRx.Generators) |
+| Beckhoff TwinCAT | [`CP.TwinCATRx.Core`](https://www.nuget.org/packages/CP.TwinCATRx.Core) | [![CP.TwinCATRx.Core version](https://img.shields.io/nuget/v/CP.TwinCATRx.Core?label=version)](https://www.nuget.org/packages/CP.TwinCATRx.Core) | [![CP.TwinCATRx.Core downloads](https://img.shields.io/nuget/dt/CP.TwinCATRx.Core?label=downloads)](https://www.nuget.org/packages/CP.TwinCATRx.Core) |
+| Beckhoff TwinCAT | [`CP.TwinCATRx.Core.Reactive`](https://www.nuget.org/packages/CP.TwinCATRx.Core.Reactive) | [![CP.TwinCATRx.Core.Reactive version](https://img.shields.io/nuget/v/CP.TwinCATRx.Core.Reactive?label=version)](https://www.nuget.org/packages/CP.TwinCATRx.Core.Reactive) | [![CP.TwinCATRx.Core.Reactive downloads](https://img.shields.io/nuget/dt/CP.TwinCATRx.Core.Reactive?label=downloads)](https://www.nuget.org/packages/CP.TwinCATRx.Core.Reactive) |
+
+## Overview
+
+IoT-DriverCore is a collection of reactive .NET drivers and shared contracts for PLCs, industrial networks, serial devices, and edge applications. The migrated libraries retain their protocol-specific capabilities while using consistent package metadata, modern `IoT.DriverCore.*` namespaces, observable and async-observable streams, logical tags, deterministic test seams, and TUnit tests on Microsoft Testing Platform.
+
+The repository is intentionally modular. Install only the protocol family required by an application. Each family has a default package built on the lean `ReactiveUI.Primitives` stack and, where listed, a `.Reactive` package for consumers that need the System.Reactive-compatible bridge. Do not reference both variants of one family unless the application deliberately isolates their namespaces.
+
+> [!CAUTION]
+> PLC and field-device writes can move machinery, alter process conditions, or defeat assumptions made by an operator. Commission against simulators and non-production controllers, validate every address and type, retain independent safety interlocks, use network segmentation and least privilege, and treat a successful protocol response as communication success rather than proof of a safe machine state.
+
+## Included drivers and transports
+
+| Driver family | Protocols and transports | Typical equipment | Main capabilities | Detailed guide |
+| --- | --- | --- | --- | --- |
+| Allen-Bradley | CIP / EtherNet/IP through libplctag | ControlLogix, CompactLogix, Micro800 where supported, PLC-5, SLC 500, MicroLogix | Typed tag registration, word-bit access, grouped scans, bulk read/write, health streams, logical tags, simulator, generated bindings | [ABPlcRx README](packagereadme/ABPlcRx/README.md) |
+| Mitsubishi | MC Protocol / SLMP; TCP, UDP, and serial; 1E/3E/4E and 1C/3C/4C frames; binary and ASCII | MELSEC A, QnA, Q, L, iQ-R, iQ-F, FX5 and compatible endpoints | Device, random, block, monitor, memory, diagnostics, remote-control and loopback operations; tag databases; polling and write pipelines; simulator transports | [MitsubishiRx README](packagereadme/MitsubishiRx/README.md) |
+| Modbus | Modbus TCP, UDP, RTU, and ASCII | PLCs, drives, meters, remote I/O, gateways, process instruments | Client/master operations, slave/server data stores, coils and discrete inputs, input and holding registers, file records, diagnostics, logical tags, observable operations, simulation | [ModbusRx README](packagereadme/ModbusRx/README.md) |
+| Omron | FINS over TCP/UDP, Host Link FINS serial, Toolbus serial | Omron PLCs exposing FINS or supported serial endpoints | Typed memory-area tags, polling, reads/writes, clock and cycle-time operations, BCD helpers, logical tags, serial frame codecs, simulation, generated bindings | [OmronPlcRx README](packagereadme/OmronPlcRx/README.md) |
+| Siemens S7 | S7 communication over ISO-on-TCP | S7-200, S7-300, S7-400, S7-1200, S7-1500 | DB/input/output/marker/timer/counter addressing, polling, typed reads and queued writes, multi-variable batches, runtime and generated bindings, cache/performance/production helpers, logical tags | [S7PlcRx README](packagereadme/S7PlcRx/README.md) |
+| Serial and sockets | Serial ports, TCP streams, UDP datagrams | Serial instruments, barcode readers, scales, gateways, protocol adapters, network devices | Reactive bytes/text/lines/batches, manual async reads, framing helpers, discovery, connection/error streams, TCP and UDP clients, deterministic in-memory links | [SerialPortRx README](packagereadme/SerialPortRx/README.md) |
+| Beckhoff TwinCAT | ADS for TwinCAT 2 and TwinCAT 3 | Beckhoff PLC runtimes and ADS routes | Configuration-driven notifications, correlated reads/writes, typed observables, structured values, logical tags, dynamic and generated bindings, Windows service monitoring, in-memory ADS simulation | [TwinCATRx README](packagereadme/TwinCATRx/README.md) |
+
+### Shared logical-tag core
+
+`CP.IoT.Core` provides the protocol-neutral composition layer used by the drivers:
+
+- strongly typed `LogicalTagKey<T>` identifiers;
+- logical tag definitions, groups, catalogues, validation, and CSV persistence;
+- single and batch read/write contracts;
+- observable and `IAsyncEnumerable<T>` change streams;
+- contiguous batch planning where a protocol can combine adjacent addresses;
+- SQLite-backed stores and build-transitive integration.
+
+This keeps application code focused on logical names while protocol adapters own wire addresses, batching, transport errors, and conversion. It also lets an application compose more than one protocol family without forcing their concrete clients into an inheritance hierarchy.
+
+## Choose a package variant
+
+Use the unsuffixed package by default:
+
+```bash
+dotnet add package S7PlcRx
+```
+
+Choose the matching `.Reactive` package when the application already uses the System.Reactive-compatible `ReactiveUI.Primitives.Reactive` family:
+
+```bash
+dotnet add package S7PlcRx.Reactive
+```
+
+The `.Reactive` libraries are shared-source builds with corresponding `.Reactive` namespaces. Their protocol concepts match the base packages, but scheduler, unit, observable factory, and extension types can differ. Follow the package-family README for exact namespaces and signatures.
+
+Standalone generator NuGet artifacts are produced for Allen-Bradley, Mitsubishi, Modbus, Omron, S7, and TwinCAT. The Allen-Bradley, Mitsubishi, Omron, and TwinCAT runtime packages also embed their matching analyzer, so most applications receive generated bindings with the runtime package alone. Modbus and S7 applications install their `.Generators` package when generated bindings are required. SerialPortRx keeps its generator embedded in the runtime packages and does not produce a separate generator package.
+
+| Family | Standalone generator package | Runtime-package delivery |
+| --- | --- | --- |
+| Allen-Bradley | `ABPlcRx.Generators` | Also embedded in `ABPlcRx` and `ABPlcRx.Reactive` |
+| Mitsubishi | `MitsubishiRx.Generators` | Embedded in both runtime packages; generated clients currently target and require the base `MitsubishiRx` runtime |
+| Modbus | `ModbusRx.Generators` | Install separately when generated register maps are required |
+| Omron | `OmronPlcRx.Generators` | Also embedded in `OmronPlcRx` and `OmronPlcRx.Reactive` |
+| Siemens S7 | `S7PlcRx.Generators` | Install separately when generated property bindings are required |
+| Serial and sockets | None | Generator is embedded in `SerialPortRx` and `SerialPortRx.Reactive` |
+| Beckhoff TwinCAT | `TwinCATRx.Generators` | Also embedded in `CP.TwinCATRx` and `CP.TwinCATRx.Reactive` |
+
+## Common usage model
+
+Although wire protocols differ, driver applications generally follow the same composition:
+
+1. Select the base or `.Reactive` package family.
+2. Configure a transport, PLC model, endpoint, route, rack/slot, unit/node identifier, timeouts, and polling deliberately.
+3. Register typed physical tags or create a protocol request.
+4. Map important physical addresses to logical tag keys when application code should not know wire addresses.
+5. Subscribe to value, connection, write-result, and error streams before starting operational traffic.
+6. Use protocol-native batch operations for adjacent or grouped values.
+7. Validate writes, cancellation, retry, and reconnect behavior with the supplied simulator or in-memory seam.
+8. Dispose clients and subscriptions together where the public lifecycle supports it.
+
+The complete API inventories, configuration rules, and worked C# examples live in the seven linked package guides above.
+
+## Reactive and async streams
+
+The default packages expose BCL `IObservable<T>` values through `ReactiveUI.Primitives` and, where supported, `IObservableAsync<T>` for async-native processing. This supports:
+
+- value-on-change observation without polling in application code;
+- connection, health, error, and write-result telemetry;
+- sampling and buffering for UI, logging, and historian workloads;
+- cancellation-aware async consumption;
+- composition across drivers while keeping protocol clients separate.
+
+Keep subscriptions alive for the required session and dispose them with the owning driver. A high-rate PLC or socket stream should be sampled, buffered, or otherwise bounded before it reaches a UI, database, or remote telemetry sink.
+
+## AI-agent skills
+
+Every protocol-family NuGet package includes a concise skill at `skills/<skill-name>/SKILL.md`. The skills tell an AI agent which namespace and package variant to use, which safety and lifecycle rules are mandatory, how to choose the protocol workflow, and where to find the full packaged README.
+
+| Family | Packaged skill |
+| --- | --- |
+| Allen-Bradley | [`ab-plc-rx`](skills/ab-plc-rx/SKILL.md) |
+| Mitsubishi | [`mitsubishi-rx`](skills/mitsubishi-rx/SKILL.md) |
+| Modbus | [`modbus-rx`](skills/modbus-rx/SKILL.md) |
+| Omron | [`omron-plc-rx`](skills/omron-plc-rx/SKILL.md) |
+| Siemens S7 | [`s7-plc-rx`](skills/s7-plc-rx/SKILL.md) |
+| Serial and sockets | [`serial-port-rx`](skills/serial-port-rx/SKILL.md) |
+| Beckhoff TwinCAT | [`twincat-rx`](skills/twincat-rx/SKILL.md) |
+
+## Build and test
+
+The repository uses the .NET SDK pinned by `global.json`, NUKE for the build entry point, TUnit assertions, and Microsoft Testing Platform.
+
+```bash
+./build.cmd Compile --configuration Release
+dotnet test --solution src/IoT-DriverCore.slnx --configuration Release --no-build --max-parallel-test-modules 1
+```
+
+Hardware-facing tests require explicitly configured controllers or virtual serial ports. Use the simulator and in-memory suites for routine development; keep live PLC tests opt-in and read-only unless a test plan explicitly authorizes controlled writes.
+
+## Repository layout
+
+| Path | Purpose |
+| --- | --- |
+| `src/` | Runtime libraries, analyzers, tests, simulators, examples, and the solution |
+| `packagereadme/` | NuGet-facing README for each protocol family |
+| `skills/` | AI-agent skills included in the corresponding NuGet packages |
+| `images/` | Package icons and repository hero artwork |
+| `build/` | NUKE build application |
+| `.github/workflows/` | Build, test, package, sign, and publish workflows |
+
+## License
+
+IoT-DriverCore is licensed under the [MIT License](LICENSE).

--- a/images/iot-drivercore-hero.png
+++ b/images/iot-drivercore-hero.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:320f0ae81616ba0a2d1630f6c585de9ce49eb895f3aeb52277aa8684b3c97fc3
+size 2610382

--- a/packagereadme/ABPlcRx/README.md
+++ b/packagereadme/ABPlcRx/README.md
@@ -1,242 +1,3836 @@
-﻿![License](https://img.shields.io/github/license/ChrisPulman/ABPlcRx.svg) [![Build](https://github.com/ChrisPulman/ABPlcRx/actions/workflows/BuildOnly.yml/badge.svg)](https://github.com/ChrisPulman/ABPlcRx/actions/workflows/BuildOnly.yml) ![Nuget](https://img.shields.io/nuget/dt/ABPlcRx?color=pink&style=plastic) [![NuGet](https://img.shields.io/nuget/v/ABPlcRx.svg?style=plastic)](https://www.nuget.org/packages/ABPlcRx)
-
-![Alt](https://repobeats.axiom.co/api/embed/24d527be4f32c7d50e5e907b50687874772158ee.svg "Repobeats analytics image")
-
-<p align="left">
-  <a href="https://github.com/ChrisPulman/ABPlcRx">
-    <img alt="ABPlcRx" src="Images/logo.png" width="200"/>
-  </a>
-</p>
-
 # ABPlcRx
 
-A reactive Allen‑Bradley PLC client built on top of [libplctag](https://github.com/libplctag/libplctag). It provides a simple, high‑performance, reactive API for reading/writing tags from Rockwell/Allen‑Bradley controllers.
+## Overview
 
-Warning – Disclaimer
-PLCs control equipment. Mistakes can cause loss of property, production, or life. Use extreme caution. No warranty of suitability is provided.
+`ABPlcRx` is a reactive Allen-Bradley PLC client over libplctag. It registers physical PLC tags under application-owned logical names, scans them, and exposes value changes through `IObservable<T>` and `IObservableAsync<T>`.
 
-Supported PLC families (via libplctag)
-- ControlLogix/CompactLogix (LGX) over CIP EtherNet/IP
-- Micro800 family where supported by libplctag
-- PLC‑5, SLC 500, MicroLogix (Ethernet/ENI/DH+ bridging where supported)
-- Additional families supported by libplctag may be usable
+## Safety
 
-Core features
-- Create tags and group them for bulk operations
-- Reactive APIs (IObservable) for on‑change updates
-- Async reactive APIs (IObservableAsync) through ReactiveUI.Primitives.Async on .NET 8+
-- Read/write primitives: 8/16/32/64‑bit signed/unsigned, 32/64‑bit float
-- Bit addressing helpers for coil/word bits
-- String and structure support (libplctag style)
-- Bulk read/write across groups
-- Health monitoring (Ping/ObservePing)
-- Source generator attributes for typed PLC stream models
-- TUnit tests running on Microsoft Testing Platform
+PLC writes can move equipment. Validate tags against a non-production controller first, apply least-privilege network access, make writes deliberate, and ensure independent interlocks and emergency-stop logic remain effective. A successful library call is not proof that a machine state is safe.
 
-Getting started
-Installation
-- Install the NuGet package:
-  - Package Manager: Install-Package ABPlcRx
-  - .NET CLI: dotnet add package ABPlcRx
-- The ABPlcRx package includes its source generator analyzer; no separate generator package is required for normal NuGet consumption.
-- ABPlcRx depends on libplctag; the NuGet dependency brings required bindings.
+## Package matrix
 
-Basic concepts
-- Variable: your app’s key for a tag (free‑form string)
-- TagName: the PLC’s address/name for the tag (e.g., B3:3, N7:0, MyTag)
-- TagGroup: logical group to batch operations (e.g., “Default”, “Motion”)
-- Types and bits: to read/write a bit, create a tag as short (Int16) and use bit index 0‑15
+| Package | Default namespace | Targets | Purpose |
+|---|---|---|---|
+| `ABPlcRx` | `IoT.DriverCore.ABPlcRx` | net472, net48, net481, net8.0–net11.0 | libplctag-backed reactive AB client and source generator |
+| `ABPlcRx.Reactive` | `IoT.DriverCore.ABPlcRx.Reactive` | matching package targets | System.Reactive-compatible surface where supplied |
+| `ABPlcRx.Generators` | `IoT.DriverCore.ABPlcRx.SourceGenerators` | netstandard2.0 analyzer | Standalone analyzer package for generated PLC models; the runtime packages also embed their matching analyzer |
 
-Quick start
-```csharp
-using ABPlcRx;
-using System;
-using ReactiveUI.Primitives.Disposables;
+`ABPlcRx` references `ReactiveUI.Primitives`, `ReactiveUI.Primitives.Async`, and `libplctag.NativeImport`. Its source-generator analyzer is packed with the package.
 
-var disposables = new MultipleDisposable();
+## Install
 
-// SLC/PLC5/MicroLogix example (500ms scan)
-var slc = new ABPlcRx(PlcType.SLC, "192.168.1.50", TimeSpan.FromMilliseconds(500));
-disposables.Add(slc);
-
-// Create a word tag and use bit addressing (B3:3/0)
-slc.AddUpdateTagItem<short>("LightOn", "B3:3", "Default");
-
-// Observe changes (bool via bit 0)
-disposables.Add(
-    slc.Observe<bool>("LightOn", bit: 0)
-       .Subscribe(v => Console.WriteLine($"LightOn = {v}"))
-);
-
-// Toggle the bit and write
-var current = !slc.Value<bool>("LightOn", bit: 0);
-slc.Value("LightOn", current, bit: 0); // AutoWriteValue=true writes immediately
-Console.WriteLine($"Wrote {current} -> B3:3/0");
+```bash
+dotnet add package ABPlcRx
 ```
 
-ControlLogix/CompactLogix (LGX) example
+Use `IoT.DriverCore.ABPlcRx`; add `ReactiveUI.Primitives.Extensions` only when you want its subscription helpers.
+
+## Quick start
+
+The generic APIs deliberately take a type witness. This makes the PLC representation explicit and is valid C# for current packages.
+
 ```csharp
-// For LGX you must provide a path (default "1,0" = backplane, slot 0)
-var lgx = new ABPlcRx(PlcType.LGX, "192.168.1.60", TimeSpan.FromMilliseconds(200),
-                      timeOut: TimeSpan.FromSeconds(2), path: "1,0");
+using IoT.DriverCore.ABPlcRx;
 
-// Controller tag named MyDINT
-lgx.AddUpdateTagItem<int>("Counter", "MyDINT", "Default");
+using var plc = new ABPlcRx(PlcType.LGX, "192.168.1.60", TimeSpan.FromMilliseconds(200));
+plc.AddUpdateTagItem("Counter", "MyDINT", "Default", 0);
 
-// Observe numeric values
-lgx.Observe<int>("Counter").Subscribe(v => Console.WriteLine($"Counter={v}"));
+using var changes = plc.Observe("Counter", 0, -1)
+    .Subscribe(value => Console.WriteLine($"Counter = {value}"));
 
-// Increment and write
-lgx.Value("Counter", lgx.Value<int>("Counter") + 1);
-
-// Standard Logix BOOL tag named MachineReady
-lgx.AddUpdateTagItem<bool>("Ready", "MachineReady", "Default");
-lgx.Observe<bool>("Ready").Subscribe(v => Console.WriteLine($"Ready={v}"));
-
-var ready = !lgx.Value<bool>("Ready");
-lgx.Value("Ready", ready);
+plc.Value("Counter", 42, -1); // AutoWriteValue is true by default.
+var result = plc.Read("Counter");
+if (result is not null && PlcTagStatus.IsError(result.StatusCode))
+    Console.Error.WriteLine(PlcTagStatus.DecodeError(result.StatusCode));
 ```
 
-Reactive API highlights
-- Observe<T>(variable, bit = -1): stream values on change, supports late‑added tags
-- ObserveAsyncObservable<T>(variable, bit = -1): async-native stream using ReactiveUI.Primitives.Async on .NET 8+
-- ObserveMany(params string[] variables): latest values as a dictionary
-- ObserveManyAsyncObservable(params string[] variables): async-native latest value dictionaries
-- ObserveGroup(groupName): emits tag objects in a group when they change
-- ObserveGroupAsyncObservable(groupName): async-native group stream
-- ObserveSampled<T>(variable, sampleInterval, bit, scheduler): sampled stream for rate limiting
-- ObserveSampledAsyncObservable<T>(variable, sampleInterval, bit, scheduler): async-native sampled stream
-- ObserveErrors(): only tag operations that returned an error
-- ObserveErrorsAsyncObservable(): async-native error stream
-- CreateWriter<T>(variable, bit): returns an IObserver<T> that writes on OnNext
+For an SLC/PLC-5 word bit, register the word as `short` and give a bit index from 0 through 15:
 
-Async observables
 ```csharp
-using ReactiveUI.Primitives.Async;
-
-var counter = lgx.ObserveAsyncObservable<int>("Counter");
-
-// IObservableAsync<T> can use ReactiveUI.Primitives.Async operators.
-var activeCounter =
-    counter
-        .Where(value => value > 0)
-        .Select(value => $"Counter={value}");
+using var plc = new ABPlcRx(PlcType.SLC, "192.168.1.50", TimeSpan.FromMilliseconds(500));
+plc.AddUpdateTagItem("LightWord", "B3:3", "Outputs", (short)0);
+plc.Value("LightWord", true, 0);
+bool? lightOn = plc.GetValue("LightWord", false, 0);
 ```
 
-Source generated stream models
-```csharp
-using ABPlcRx.SourceGeneration;
+## Configuration
 
-[PlcModel]
-[PlcTag(typeof(int), "Counter", "MyDINT")]
-[PlcTag(typeof(bool), "LightOn", "B3:3", Bit = 0)]
-public partial class MachineTags
+Construct with `(PlcType, ip, scanInterval)` or `(PlcType, ip, scanInterval, timeout, path)`. `PlcType` is `LGX`, `SLC`, or `PLC5`; Logix routing uses `path` such as `"1,0"` when required by the controller topology.
+
+Set `ScanEnabled` to enable or disable scans for registered groups. Set `AutoWriteValue = false` to stage values with `Value` and commit with `Write(variable)` or `Write()`. Use logical variables consistently; they are the keys used by read, write, and observation methods.
+
+## Detailed features
+
+### Batching, health, and async reads
+
+```csharp
+var reads = await plc.ReadManyAsync(["Counter"], CancellationToken.None);
+var writes = await plc.WriteManyAsync(
+    new Dictionary<string, object?> { ["Counter"] = 43 }, CancellationToken.None);
+
+using var health = plc.ObservePing(TimeSpan.FromSeconds(2), false, null)
+    .Subscribe(connected => Console.WriteLine($"PLC reachable: {connected}"));
+
+var typed = await plc.ReadValueAsync("Counter", 0, -1, CancellationToken.None);
+```
+
+`ObserveMany` publishes a latest-value dictionary; `ObserveGroup` publishes changed `IPlcTag` instances in one group; `ObserveSampled` bounds a consumer's update rate. Each has an `IObservableAsync` counterpart named `...AsyncObservable`.
+
+### Deterministic simulation
+
+Use `ABPlcSimulator` for tests and integration harnesses without hardware. It shares the production facade and records native-style operations.
+
+```csharp
+using var simulator = new ABPlcSimulator(PlcType.LGX);
+simulator.AddUpdateTagItem("Counter", "MyDINT", "Default", 0);
+simulator.SetTagValue("MyDINT", 7);
+simulator.Read("Counter");
+Console.WriteLine(simulator.GetValue("Counter", 0, -1));
+```
+
+### Generated stream models
+
+The packaged analyzer recognizes the AB PLC model/tag attributes. Keep the model partial and use the generated binding method; inspect generated output when changing attribute names or types. The analyzer is a compile-time convenience, not a substitute for validating physical tag names.
+
+## Exhaustive feature guide and worked workflows
+
+The following sections supersede examples written for the pre-migration namespace. All examples use the current `IoT.DriverCore.ABPlcRx` surface and deliberately include ownership, cancellation, and result handling.
+
+### Registering tags, addressing bits, and choosing a value type
+
+`AddUpdateTagItem<T>` has three overload families. `(tagName, typeWitness)` makes the logical variable equal to the controller tag and uses the `Default` group. `(variable, tagName, typeWitness)` separates the application name from the physical address. `(variable, tagName, group, typeWitness)` also assigns a group for observation and bulk I/O. `typeWitness` is a value solely used to select `T`; use `0`, `false`, `0f`, or `string.Empty` rather than relying on inference.
+
+For native Logix `BOOL`, register `bool` and pass bit `-1`. For a bit in an SLC/PLC-5 integral word, register the *word* as `short`, `ushort`, `int`, `uint`, `long`, or `ulong`, then use an in-range bit index. A bit index with `bool` is invalid because the physical tag is already one Boolean. Read/write conversion errors and native operation failures appear in `PlcTagResult` / `TagOperationResult<T>` and on `ObserveErrors`.
+
+```csharp
+using IoT.DriverCore.ABPlcRx;
+
+using var plc = new ABPlcRx(PlcType.LGX, "192.168.1.60", TimeSpan.FromMilliseconds(250),
+    TimeSpan.FromSeconds(2), "1,0");
+
+plc.AddUpdateTagItem("RunCommand", "Program:Line.RunCmd", "Commands", false);
+plc.AddUpdateTagItem("SpeedSetpoint", "Program:Line.Speed", "Commands", 0f);
+plc.AddUpdateTagItem("AlarmWord", "N7:10", "Alarms", (short)0);
+
+// Native BOOL: bit -1. Integral SLC word: read/write bit 4.
+bool? run = plc.GetValue("RunCommand", false, -1);
+bool? alarm4 = plc.GetValue("AlarmWord", false, 4);
+if (alarm4 is true)
+    plc.Value("AlarmWord", false, 4);
+```
+
+### Cached values, synchronous I/O, and write staging
+
+`GetValue<T>` returns the most recently cached value; it does not force a transaction. `Value<T>(variable, value, bit)` changes the cached value. With `AutoWriteValue = true` (the default), it then writes immediately; otherwise it stages the change for `Write(variable)` or `Write()`. `Read(variable)` and `Write(variable)` return a nullable result when the variable does not exist. `Read()` and `Write()` return one result per registered tag. Check `StatusCode` with `PlcTagStatus.IsError` and `DecodeError`; do not infer success from a non-null result.
+
+```csharp
+plc.AutoWriteValue = false;
+plc.Value("SpeedSetpoint", 750f, -1); // cache/stage only
+
+PlcTagResult? committed = plc.Write("SpeedSetpoint");
+if (committed is null || PlcTagStatus.IsError(committed.StatusCode))
+    throw new InvalidOperationException(committed is null
+        ? "SpeedSetpoint is not registered."
+        : PlcTagStatus.DecodeError(committed.StatusCode));
+
+PlcTagResult? refreshed = plc.Read("SpeedSetpoint");
+Console.WriteLine($"PLC speed = {plc.GetValue("SpeedSetpoint", 0f, -1)}");
+```
+
+### Cancelable, typed and batched I/O
+
+Use `ReadValueAsync<T>` and `WriteValueAsync<T>` when a command must have a completion boundary. They return `TagOperationResult<T>` rather than throwing expected PLC status failures; inspect its success/status/value members before acting. `ReadManyAsync` accepts selected logical variables and returns a result for each. `WriteManyAsync` accepts logical-name/value pairs and writes them with the same cancellation boundary. Cancellation stops awaiting the operation; always dispose the facade once its subscriptions and commands are finished.
+
+```csharp
+using var shutdown = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+var ct = shutdown.Token;
+
+var read = await plc.ReadValueAsync("SpeedSetpoint", 0f, -1, ct);
+if (!read.Succeeded)
+    Console.Error.WriteLine($"Read failed: {read.Error}");
+else if (read.Value is float speed && speed < 1200)
 {
+    var write = await plc.WriteValueAsync("SpeedSetpoint", speed + 25, -1, ct);
+    if (!write.Succeeded) Console.Error.WriteLine(write.Error);
 }
 
-var tags = new MachineTags();
-using var binding = tags.AttachPlcStreams(slc);
-
-tags.CounterObservable.Subscribe(value => Console.WriteLine($"Counter={value}"));
-tags.LightOnObservable.Subscribe(value => Console.WriteLine($"LightOn={value}"));
-
-// On .NET 8+ the generator also emits IObservableAsync<T> streams.
-var asyncLightOn = tags.LightOnObservableAsync;
+var results = await plc.WriteManyAsync(new Dictionary<string, object?>
+{
+    ["RunCommand"] = true,
+    ["SpeedSetpoint"] = 800f,
+}, ct);
+foreach (var result in results.Where(r => PlcTagStatus.IsError(r.StatusCode)))
+    Console.Error.WriteLine(PlcTagStatus.DecodeError(result.StatusCode));
 ```
 
-The generator creates a property for each class-level `PlcTag` attribute, registers tags in `AttachPlcStreams`, keeps the generated property updated from the observable subscription, and exposes both `PropertyNameObservable` and `PropertyNameObservableAsync` on .NET 8+. Boolean tags without a `Bit` value are registered as native `bool` tags. Boolean bit tags with `Bit` set are registered as `short` tags and exposed as `bool` values.
+### Reactive, async-reactive, group, many, and sampled observation
 
-Examples
-Observe multiple variables
+`Observe<T>` emits the registered variable's current/change values while its subscription lives. `ObserveAll` emits each changed `IPlcTag`; `ObserveGroup` limits that to a registration group. `ObserveMany` emits a latest-value dictionary for the requested names. Their `...AsyncObservable` counterparts expose `IObservableAsync<T>` for `ReactiveUI.Primitives.Async` pipelines. `ObserveSampled<T>` and `ObserveSampledAsyncObservable<T>` keep the latest value at the supplied cadence, which is appropriate for UI/telemetry sinks but not safety interlocks. All sequences are cold from the caller's perspective: retain and dispose every returned subscription.
+
 ```csharp
-// Emits { "LightOn": true, "Counter": 42 }
-slc.ObserveMany("LightOn", "Counter")
-   .Subscribe(dict => Console.WriteLine(string.Join(", ", dict.Select(kv => $"{kv.Key}={kv.Value}"))));
+using ReactiveUI.Primitives.Disposables;
+
+using var subscriptions = new CompositeDisposable();
+subscriptions.Add(plc.Observe("RunCommand", false, -1).Subscribe(
+    value => Console.WriteLine($"Run={value}"),
+    error => Console.Error.WriteLine(error)));
+subscriptions.Add(plc.ObserveGroup("Alarms").Subscribe(tag =>
+    Console.WriteLine($"{tag.Variable}: {tag.Value}")));
+subscriptions.Add(plc.ObserveMany("RunCommand", "SpeedSetpoint").Subscribe(values =>
+    Console.WriteLine($"Snapshot: {values["RunCommand"]}, {values["SpeedSetpoint"]}")));
+subscriptions.Add(plc.ObserveSampled("SpeedSetpoint", TimeSpan.FromSeconds(1), 0f, -1, null)
+    .Subscribe(speed => PublishTelemetry(speed)));
+subscriptions.Add(plc.ObserveErrors().Subscribe(result =>
+    Console.Error.WriteLine(PlcTagStatus.DecodeError(result.StatusCode))));
+
+static void PublishTelemetry(float? speed) => Console.WriteLine($"telemetry={speed}");
 ```
 
-Group operations and bulk I/O
+`CreateWriter<T>(variable, typeWitness, bit)` is an `IObserver<T>` adapter: each `OnNext` calls the same value/write path, therefore write failures should also be observed through `ObserveErrors`. It is useful at the boundary of a validated command stream, but never connect an unbounded sensor stream directly to a PLC write.
+
 ```csharp
-// Group creation is implicit via AddUpdateTagItem
-slc.AddUpdateTagItem<short>("Alarm", "B3:10", "Safety");
-slc.AddUpdateTagItem<short>("Guard", "B3:11", "Safety");
-
-// Bulk read/write across all groups
-var results = slc.Read();
-var wrote = slc.Write();
+IObserver<bool> commandWriter = plc.CreateWriter("RunCommand", false, -1);
+using var commandErrors = plc.ObserveErrors().Subscribe(e =>
+    Console.Error.WriteLine($"Command failed: {PlcTagStatus.DecodeError(e.StatusCode)}"));
+commandWriter.OnNext(true);
 ```
 
-Health monitoring
+### Consuming `IObservableAsync<T>` streams
+
+Every `Observe*AsyncObservable` member is an `IObservableAsync<T>`, not an `IAsyncEnumerable<T>`. Subscribe with an `IObserverAsync<T>` and dispose the returned `IAsyncDisposable`; the cancellation token is checked when the subscription is created and is also supplied to value/error callbacks. The following observer is deliberately small but complete, and can be reused for values, errors, groups, snapshots, and ping state.
+
 ```csharp
-// One‑off ping
-var ok = slc.Ping();
+using IoT.DriverCore.ABPlcRx;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Async;
 
-// Observe ping results every 2 seconds
-slc.ObservePing(TimeSpan.FromSeconds(2))
-   .Subscribe(alive => Console.WriteLine($"PLC reachable: {alive}"));
+using var cancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+var observer = new ConsoleAsyncObserver<float?>();
+await using var subscription = await plc
+    .ObserveSampledAsyncObservable("SpeedSetpoint", TimeSpan.FromSeconds(1), 0f, -1, null)
+    .SubscribeAsync(observer, cancellation.Token);
+
+// Keep the subscription alive for the required application lifetime. On shutdown,
+// cancel the owner and let await using dispose the subscription.
+
+sealed class ConsoleAsyncObserver<T> : IObserverAsync<T>
+{
+    public ValueTask OnNextAsync(T value, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Console.WriteLine(value);
+        return default;
+    }
+
+    public ValueTask OnErrorResumeAsync(Exception error, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Console.Error.WriteLine(error);
+        return default;
+    }
+
+    public ValueTask OnCompletedAsync(Result result)
+    {
+        Console.WriteLine($"Completed: {result}");
+        return default;
+    }
+
+    public ValueTask DisposeAsync() => default;
+}
 ```
 
-Advanced: writing with an observer
+Use the same ownership pattern for all async-native members. For example, a group subscription has `IPlcTag` values, and a snapshot subscription has `IReadOnlyDictionary<string, object?>` values:
+
 ```csharp
-var writer = slc.CreateWriter<bool>("LightOn", bit: 0);
-writer.OnNext(true);  // writes and commits
+var groupObserver = new ConsoleAsyncObserver<IPlcTag>();
+var snapshotObserver = new ConsoleAsyncObserver<IReadOnlyDictionary<string, object?>>();
+await using var groupSubscription = await plc
+    .ObserveGroupAsyncObservable("Alarms")
+    .SubscribeAsync(groupObserver, CancellationToken.None);
+await using var snapshotSubscription = await plc
+    .ObserveManyAsyncObservable("RunCommand", "SpeedSetpoint")
+    .SubscribeAsync(snapshotObserver, CancellationToken.None);
 ```
 
-Configuration and options
-- ScanEnabled: enable/disable background scanning by group
-- AutoWriteValue: when true (default), setting Value(tag) writes immediately
-- Timeout: communications timeout (ms) via constructor timeOut
-- Groups: use the tagGroup parameter to logically separate tags
+Do not use `await foreach` directly on these members. `ABLogicalTagClient.ObserveAsync` and `ObserveManyAsync` are the distinct APIs that intentionally expose `IAsyncEnumerable<LogicalTagValue>`.
 
-API surface (high level)
-- ABPlcRx (implements IABPlcRx)
-  - AddUpdateTagItem<T>(variable, tagName, tagGroup = "Default")
-  - Observe<T>(variable, bit = -1)
-  - ObserveAsyncObservable<T>(variable, bit = -1) on .NET 8+
-  - ObserveMany(params string[] variables)
-  - ObserveManyAsyncObservable(params string[] variables) on .NET 8+
-  - ObserveGroup(groupName)
-  - ObserveGroupAsyncObservable(groupName) on .NET 8+
-  - ObserveSampled<T>(variable, sampleInterval, bit = -1, scheduler = null)
-  - ObserveSampledAsyncObservable<T>(variable, sampleInterval, bit = -1, scheduler = null) on .NET 8+
-  - ObserveErrors()
-  - ObserveErrorsAsyncObservable() on .NET 8+
-  - CreateWriter<T>(variable, bit = -1)
-  - Value<T>(variable, bit = -1) / Value<T>(variable, value, bit = -1)
-  - Read()/Read(variable) and Write()/Write(variable)
-  - Ping(bool echo = false), PingAsync(...), ObservePing(interval,...)
-  - ObservePingAsyncObservable(interval,...) on .NET 8+
+### Logical-tag catalog, access policy, CSV, and SQLite persistence
 
-Testing
-- Tests are in `src/ABPlcRx.Tests`.
-- The suite uses TUnit with Microsoft Testing Platform; `global.json` sets `"test": { "runner": "Microsoft.Testing.Platform" }`.
-- Run all tests with:
-```bash
-dotnet test src/ABPlcRx.sln
+`ABLogicalTagClient` composes an `IABPlcRx`; it does not own or dispose that controller. It maps a stable application tag name to an AB address and a supported data type (`bool`, integral types, `float`, `double`, or `string`), then validates the tag's `LogicalTagAccessMode` before I/O. A Boolean logical tag can describe a bit in an integral physical word by placing the zero-based bit index in `LogicalTagOptions.Metadata` under the key `"Bit"`.
+
+```csharp
+using IoT.DriverCore.ABPlcRx;
+using IoT.DriverCore.Core;
+
+using var simulator = new ABPlcSimulator(PlcType.LGX);
+using var tags = simulator.CreateLogicalTagClient();
+
+tags.CreateTag(new LogicalTag(
+    "PumpSpeed",
+    "Program:Pump.Speed",
+    "REAL",
+    new LogicalTagOptions
+    {
+        GroupName = "Pumps",
+        Description = "Pump speed feedback",
+        AccessMode = LogicalTagAccessMode.Read,
+        ScanInterval = TimeSpan.FromMilliseconds(500),
+    }));
+tags.CreateTag(new LogicalTag(
+    "PumpRunning",
+    "N7:10",
+    "bool",
+    new LogicalTagOptions
+    {
+        GroupName = "Pumps",
+        Metadata = new Dictionary<string, string> { ["Bit"] = "3" },
+    }));
+
+simulator.SetTagValue("Program:Pump.Speed", 123.5f);
+simulator.SetTagValue("N7:10", (short)8);
+
+var speed = await tags.ReadAsync("PumpSpeed", CancellationToken.None);
+var running = await tags.ReadAsync("PumpRunning", CancellationToken.None);
+if (speed.Succeeded && running.Succeeded)
+    Console.WriteLine($"speed={speed.Value!.Value}, running={running.Value!.Value}");
 ```
 
-Data types and bit access
-- Logix/CompactLogix/Micro800 standard `BOOL` tags can be created directly with `AddUpdateTagItem<bool>("Ready", "MachineReady")` and read or written with `Value<bool>("Ready")`.
-- To treat a single bit in an SLC/PLC word as a boolean, create the tag as `short` and use the `bit` parameter (0‑15).
-- For numeric tags use C# primitive types: sbyte/byte/short/ushort/int/uint/long/ulong/float/double.
-- Strings and structure types are supported where the PLC and libplctag support them.
+The logical client produces application-oriented `TagOperationResult<LogicalTagValue>` outcomes. It rejects absent tags, denied access, unsupported type declarations, duplicate bulk names, and a non-Boolean value supplied to a bit projection. Check `Succeeded` before using `Value`; bulk results retain the input order.
 
-Error handling
-- Each read/write yields a PlcTagResult with StatusCode (see PlcTagStatus).
-- If `FailOperationRaiseException` is set true on the underlying controller, failed operations will throw `PlcTagException`.
+```csharp
+var writes = await tags.WriteManyAsync(
+[
+    new LogicalTagValue("PumpRunning", false, TimeProvider.System.GetUtcNow()),
+],
+CancellationToken.None);
 
-Performance notes
-- Tags are grouped internally; bulk `Read()`/`Write()` iterate groups for fewer round trips.
-- Tag lookups are cached; prefer consistent `variable` keys.
-- Use `ObserveSampled` to reduce update rates to UI or logs.
+foreach (var write in writes)
+{
+    if (!write.Succeeded)
+        Console.Error.WriteLine(write.Error);
+}
 
-Troubleshooting
-- LGX controllers require a valid `path` (e.g., "1,0" for backplane/slot0).
-- Ensure your PLC networking, firewall, and CIP routes are reachable from your app host.
-- Use `Ping()`/`ObservePing()` to monitor reachability.
+using var logicalObservation = tags.Observe("PumpRunning").Subscribe(value =>
+    Console.WriteLine($"{value.TagName}={value.Value}; quality={value.Quality}"));
 
-License
-MIT. See LICENSE.
+using var streamCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+await using var enumerator = tags
+    .ObserveManyAsync(["PumpSpeed", "PumpRunning"], streamCancellation.Token)
+    .GetAsyncEnumerator();
+simulator.Read("PumpSpeed");
+simulator.Read("PumpRunning");
+if (await enumerator.MoveNextAsync())
+    Console.WriteLine($"Changed: {enumerator.Current.TagName}");
+```
 
----
+For persistent definitions, construct `LogicalTagSqliteStore`, initialise it through the client, then use the client CRUD methods. `UpsertTagAsync`, `EditTagAsync`, and `DeleteTagAsync` synchronise the running catalog; `UpsertGroupAsync` and `DeleteGroupAsync` persist group metadata. `LoadTagsAsync` replaces live registrations with the definitions in the store, so coordinate it with active I/O.
 
-**ABPlcRx** - Empowering Industrial Automation with Reactive Technology ⚡🏭
+```csharp
+using IoT.DriverCore.Core;
+
+var database = Path.Combine(AppContext.BaseDirectory, "ab-logical-tags.db");
+var store = new LogicalTagSqliteStore($"Data Source={database}");
+using var persistentTags = new ABLogicalTagClient(simulator, new LogicalTagCatalog(), store);
+
+await persistentTags.InitializeStoreAsync(CancellationToken.None);
+await persistentTags.UpsertGroupAsync(
+    new LogicalTagGroup("Pumps", "Pump controls"), CancellationToken.None);
+await persistentTags.UpsertTagAsync(
+    new LogicalTag("PumpCommand", "Program:Pump.Command", "bool",
+        new LogicalTagOptions { GroupName = "Pumps" }),
+    CancellationToken.None);
+
+LogicalTag? stored = await persistentTags.GetTagAsync("PumpCommand", CancellationToken.None);
+bool changed = await persistentTags.EditTagAsync(
+    stored!.WithAddress("Program:Pump.CommandNew"), CancellationToken.None);
+bool deleted = await persistentTags.DeleteTagAsync("PumpCommand", CancellationToken.None);
+Console.WriteLine($"edited={changed}, deleted={deleted}");
+```
+
+CSV import/export affects the in-memory catalog. Import validates definitions and registers them; export writes the current catalog. Use a `TextReader`/`TextWriter` you own and keep its lifetime outside the asynchronous call.
+
+```csharp
+using var input = new StringReader(
+    "Name,Address,DataType,GroupName,Description,Metadata,AccessMode,ScanIntervalMilliseconds\n" +
+    "TankLevel,Program:Tank.Level,REAL,Tanks,Tank level,,ReadWrite,500\n");
+IReadOnlyList<LogicalTag> imported = await tags.ImportCsvAsync(input, CancellationToken.None);
+
+using var output = new StringWriter();
+await tags.ExportCsvAsync(output, CancellationToken.None);
+Console.WriteLine(output.ToString());
+```
+
+### Simulator fault scripts, disconnection, and recovery
+
+`ABPlcSimulator` uses the production facade over deterministic in-memory native storage. `QueueFault` affects future matching native operations, optionally only for one physical tag; `ClearFaults` removes unconsumed scripted results. `Disconnect` makes subsequent I/O report the supplied non-success status until `Reconnect`, without losing memory or registered tags. `ConnectionChanged`, `OperationLog`, `OperationMetrics`, `TagStatuses`, and `ActiveHandleCount` make behavior observable in a test or local integration harness.
+
+```csharp
+using IoT.DriverCore.ABPlcRx;
+
+using var simulator = new ABPlcSimulator(PlcType.LGX);
+simulator.AddUpdateTagItem("Counter", "Program:Counter", "Test", 0);
+simulator.SetTagValue("Program:Counter", 7);
+
+using var connectivity = simulator.ConnectionChanged.Subscribe(online =>
+    Console.WriteLine(online ? "connected" : "disconnected"));
+
+simulator.QueueFault(
+    ABPlcSimulatorOperation.Read,
+    PlcTagStatus.ErrRead,
+    repeatCount: 1,
+    tagName: "Program:Counter");
+PlcTagResult? scriptedFailure = simulator.Read("Counter");
+Console.WriteLine(PlcTagStatus.DecodeError(scriptedFailure!.StatusCode));
+
+simulator.Disconnect();
+PlcTagResult? disconnected = simulator.Read("Counter");
+if (PlcTagStatus.IsError(disconnected!.StatusCode))
+    Console.WriteLine("I/O is deliberately unavailable while disconnected.");
+
+simulator.Reconnect();
+PlcTagResult? recovered = simulator.Read("Counter");
+Console.WriteLine($"Recovered: {!PlcTagStatus.IsError(recovered!.StatusCode)}");
+
+Console.WriteLine($"reads={simulator.OperationMetrics.ReadOperations}; " +
+                  $"failures={simulator.OperationMetrics.FailedOperations}");
+simulator.ClearFaults();
+simulator.ClearOperationLog();
+```
+
+Seed scalars with `SetTagValue<T>` or, for a structured fixture, raw bytes with the simulator-only `SetTagBytes`; inspect them with the corresponding getters. `CreateLogicalTagClient` is particularly useful for running the catalog examples above against the same deterministic memory. The simulator throws `ObjectDisposedException` for operations after disposal, so dispose logical clients/subscriptions first, then the simulator.
+
+```csharp
+using var simulator = new ABPlcSimulator(PlcType.LGX);
+simulator.SetTagBytes("Program:Recipe", new byte[] { 0x34, 0x12, 0x00, 0x00 });
+byte[] fixture = simulator.GetTagBytes("Program:Recipe");
+if (!fixture.AsSpan().SequenceEqual(new byte[] { 0x34, 0x12, 0x00, 0x00 }))
+    throw new InvalidOperationException("Simulator fixture was not retained.");
+```
+
+### Low-level `IPlcTag`, typed tags, result reduction, and value helpers
+
+Use `IABPlcRx` for ordinary code. The lower-level surface is for a tested adapter that needs a tag's native-style handle, raw value layout, or explicit `Lock`/`Unlock` boundary. `ObserveAll` is the public route to an `IPlcTag`; do not retain a tag after its containing controller is disposed. `IPlcTag.ValueManager` is a `PlcTagWrapper` with typed getters/setters, bit conversion, and fixed-format string support. It does not automatically write after a `Set*` call: call `IPlcTag.Write()` and check its result.
+
+```csharp
+IPlcTag? latest = null;
+using var all = plc.ObserveAll.Subscribe(tag => latest = tag);
+_ = plc.Read("AlarmWord");
+
+if (latest is not null)
+{
+    int lockStatus = latest.Lock();
+    try
+    {
+        if (!PlcTagStatus.IsError(lockStatus))
+        {
+            short word = latest.ValueManager.GetInt16(0);
+            latest.ValueManager.SetInt16(TagMixins.SetBit(word, 4, true), 0);
+            PlcTagResult write = latest.Write();
+            if (PlcTagStatus.IsError(write.StatusCode))
+                Console.Error.WriteLine(PlcTagStatus.DecodeError(write.StatusCode));
+        }
+    }
+    finally
+    {
+        if (!PlcTagStatus.IsError(lockStatus))
+            _ = latest.Unlock();
+    }
+}
+```
+
+`IPlcTag<T>` adds a typed `Value`; `Changed` emits `PlcTagResult` for that individual tag. `GetStatus`, `GetSize`, and `Abort` return libplctag-compatible status/data. `PlcTagResult.Reduce` combines a non-empty set into its earliest timestamp, summed execution time, and worst status; it is useful for reporting a known batch, not for making a multi-write transactional. Tags are created and released by the controller facade rather than by application code.
+
+```csharp
+var resultSet = plc.Read().ToArray();
+if (resultSet.Length != 0)
+{
+    PlcTagResult summary = PlcTagResult.Reduce(resultSet);
+    Console.WriteLine($"status={summary.StatusCode}; elapsed={summary.ExecutionTime}ms");
+}
+
+// A typed tag can be obtained from the public all-tag stream after registration/read.
+plc.AddUpdateTagItem("AlarmWord", "Program:AlarmWord", (short)0);
+IPlcTag<short>? alarmWord = null;
+using var tagChanges = plc.ObserveAll.Subscribe(tag =>
+{
+    if (tag.Variable == "AlarmWord" && tag is IPlcTag<short> typed)
+        alarmWord = typed;
+});
+_ = plc.Read("AlarmWord");
+if (alarmWord is not null)
+{
+    using var changed = alarmWord.Changed.Subscribe(result =>
+        Console.WriteLine($"AlarmWord status={result.StatusCode}"));
+    TagMixins.SetBit(alarmWord, bit: 4, value: true); // writes the typed tag
+}
+
+// These pure helpers are suitable for validation and diagnostics before I/O.
+var bits = TagHelper.NumberToBits(0b_0001_0010);
+int roundTrip = TagHelper.BitsToNumber(bits);
+Console.WriteLine($"bit 4 = {TagMixins.GetBit((short)roundTrip, 4)}");
+
+if (latest?.Value is double)
+{
+    // The tag's cached value must be a numeric value within this raw range.
+    double engineeringUnits = TagHelper.ScaleLinear(latest, 0, 32_767, 0, 100);
+    double squareRootUnits = TagMixins.ScaleSquareRoot(latest, 0, 32_767, 0, 100);
+    Console.WriteLine($"linear={engineeringUnits:F1}, sqrt={squareRootUnits:F1}");
+}
+```
+
+For engineering units, `TagHelper.ScaleLinear` / `ScaleSquareRoot` and the corresponding `TagMixins` extensions operate on an `IPlcTag` whose `Value` is numerically convertible to `double`. Confirm raw limits and scaling values on a non-production controller before treating a scaled result as a command or safety input.
+
+### Health monitoring and lifecycle
+
+`Ping(echo)` returns whether the controller is reachable. `PingAsync(echo, token)` is the cancelable variant. `ObservePing(interval, echo, scheduler)` emits deduplicated state changes; its async counterpart is `ObservePingAsyncObservable`. `ScanEnabled` gates background scanning, so turn it off only for controlled maintenance. `Dispose` disposes the native controller and does not dispose subscriptions that you own; dispose those first. `IsDisposed` is a diagnostic state only.
+
+```csharp
+using var online = plc.ObservePing(TimeSpan.FromSeconds(2), false, null)
+    .Subscribe(isOnline => Console.WriteLine(isOnline ? "PLC online" : "PLC offline"));
+
+if (!await plc.PingAsync(false, CancellationToken.None))
+    Console.Error.WriteLine("Do not issue production commands while the PLC is unreachable.");
+```
+
+### Combined workflow 1: guarded command with health, sampled feedback, and explicit completion
+
+This composition waits for the health gate, limits feedback publication, writes only with an awaited command, and releases all subscriptions before the client.
+
+```csharp
+using var lifetime = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+var ct = lifetime.Token;
+using var health = plc.ObservePing(TimeSpan.FromSeconds(1), false, null)
+    .Subscribe(online => Console.WriteLine($"online={online}"));
+using var feedback = plc.ObserveSampled("SpeedSetpoint", TimeSpan.FromMilliseconds(500), 0f, -1, null)
+    .Subscribe(value => Console.WriteLine($"feedback={value}"));
+
+if (await plc.PingAsync(false, ct))
+{
+    var result = await plc.WriteValueAsync("RunCommand", true, -1, ct);
+    if (!result.Succeeded) throw new InvalidOperationException(result.Error);
+}
+```
+
+### Combined workflow 2: staged multi-tag recipe with group visibility and rollback decision
+
+Staging gives the application an opportunity to validate all command values before any commit. It is not transactional at the PLC: record successful results and implement a device-specific compensation/stop policy for partial failure.
+
+```csharp
+plc.AutoWriteValue = false;
+using var commandAudit = plc.ObserveGroup("Commands").Subscribe(tag =>
+    Console.WriteLine($"Changed {tag.Variable} to {tag.Value}"));
+
+plc.Value("SpeedSetpoint", 650f, -1);
+plc.Value("RunCommand", true, -1);
+var recipeResults = plc.Write().ToArray();
+if (recipeResults.Any(r => PlcTagStatus.IsError(r.StatusCode)))
+{
+    plc.Value("RunCommand", false, -1);
+    plc.Write("RunCommand");
+    foreach (var failure in recipeResults.Where(r => PlcTagStatus.IsError(r.StatusCode)))
+        Console.Error.WriteLine(PlcTagStatus.DecodeError(failure.StatusCode));
+}
+```
+
+### Generated model workflow
+
+The analyzer is included in the runtime package and also available as `ABPlcRx.Generators`. Apply `PlcModelAttribute` and one or more `PlcTagAttribute`s to a partial class. Each attribute describes the generated property name, controller tag/address, optional group, optional bit, and CLR type. `AttachPlcStreams(IABPlcRx)` registers and subscribes; `DetachPlcStreams()` releases generated subscriptions. The generator produces a current-value property, `<Property>Observable`, and the async observable member where supported by the target. Use an integral registration for a Boolean `Bit` attribute.
+
+```csharp
+using IoT.DriverCore.ABPlcRx;
+using IoT.DriverCore.ABPlcRx.SourceGeneration;
+
+[PlcModel]
+[PlcTag(typeof(float), "Speed", "Program:Line.Speed", Group = "Motion")]
+[PlcTag(typeof(bool), "Alarm", "N7:10", Group = "Alarms", Bit = 4)]
+public partial class LineTags;
+
+var model = new LineTags();
+using var generatedBinding = model.AttachPlcStreams(plc);
+using var speed = model.SpeedObservable.Subscribe(Console.WriteLine);
+using var alarm = model.AlarmObservable.Subscribe(value =>
+{
+    if (value) Console.Error.WriteLine("Alarm bit is set");
+});
+// At shutdown: dispose subscriptions/binding, then dispose plc.
+```
+
+The reactive package has the same contracts under `IoT.DriverCore.ABPlcRx.Reactive`; choose that package only when the application uses its System.Reactive-compatible dependency stack. Never reference both runtime surfaces in the same project.
+
+## Complete public API reference
+
+The primary contract is `IABPlcRx`, implemented by `ABPlcRx` and `ABPlcSimulator`:
+
+- Lifecycle/state: `Dispose`, `IsDisposed`, `ScanEnabled`, `AutoWriteValue`, `ObserveAll`, `ObserveAllAsyncObservable`.
+- Registration: `AddUpdateTagItem<T>(tagName, typeWitness)`, `(variable, tagName, typeWitness)`, and `(variable, tagName, tagGroup, typeWitness)`; `RemoveTagItem`.
+- Values and streams: `GetValue<T>`, `Value<T>`, `Observe<T>`, `ObserveAsyncObservable<T>`, `ObserveMany`, `ObserveManyAsyncObservable`, `ObserveGroup`, `ObserveGroupAsyncObservable`, `ObserveSampled<T>`, `ObserveSampledAsyncObservable<T>`, and `CreateWriter<T>`.
+- I/O: `Read`, `Read(variable)`, `Write`, `Write(variable)`, `ReadManyAsync`, `WriteManyAsync`, `ReadValueAsync<T>`, and `WriteValueAsync<T>`.
+- Diagnostics: `ObserveErrors`, `ObserveErrorsAsyncObservable`, `Ping`, `PingAsync`, `ObservePing`, and `ObservePingAsyncObservable`.
+- Core types: `PlcType`, `IPlcTag`, `IPlcTag<T>`, `PlcTagResult`, `PlcTagException`, `PlcTagStatus`, `PlcTagWrapper`, `TagHelper`, and `TagMixins`. `PlcTagStatus.IsError` and `DecodeError` translate libplctag statuses.
+- Simulation: `ABPlcSimulator`, `ABPlcSimulatorOperation`, `ABPlcSimulatorOperationMetrics`, and `ABPlcSimulatorLogEntry`; simulator-only members include connection control, raw/scalar tag seeding, fault queueing, operation log/metrics, and `CreateLogicalTagClient`.
+- Logical tags: `ABLogicalTagClient` supports catalog registration, read/write one or many, observable and async enumeration, CSV import/export, and persistent tag/group CRUD.
+- Generation and bridges: `PlcModelAttribute`, `PlcTagAttribute`, and the `PlcModelGenerator` analyzer define generated model bindings; `ObservableAsyncBridgeExtensions` supplies the public observable-to-async-observable bridge used by generated and handwritten code.
+
+### Member-by-member contract
+
+| Member family | Inputs and return | Failure, state, and ownership |
+| --- | --- | --- |
+| Constructors | `PlcType`, host, scan interval; optionally timeout and LGX path. | Construction does not make a successful safety/connection guarantee. Dispose the created facade. |
+| Registration | `AddUpdateTagItem<T>` overloads and `RemoveTagItem`. | Duplicate variable replaces/updates the registration; unknown remove returns `false`. A variable/type mismatch is a caller error. |
+| Value access | `GetValue<T>` reads cache; `Value<T>` stages or writes; `Read`/`Write` return `PlcTagResult`. | Cache may be stale until read/scan. Check every returned status; `AutoWriteValue` decides whether `Value` performs I/O. |
+| Async I/O | `ReadValueAsync<T>`, `WriteValueAsync<T>`, `ReadManyAsync`, `WriteManyAsync`. | Pass a token for deadline/cancellation; inspect `TagOperationResult<T>` or each `PlcTagResult`, then dispose the client. |
+| Streams | `Observe`, `ObserveAll`, `ObserveMany`, `ObserveGroup`, `ObserveSampled`, writer factory, plus async-observable mirrors. | Each subscription is independently owned. Dispose it; stream errors/results do not make a PLC command safe. |
+| Diagnostics | `ObserveErrors`, `Ping`, `PingAsync`, `ObservePing`, plus async mirrors. | Health is reachability only. Decode native statuses and retain operational logs/audit records. |
+| Logical/simulation helpers | `ABLogicalTagClient`, `ABPlcSimulator`, operation records/metrics, `TagHelper`, `TagMixins`, tags/results/status. | Use simulators for deterministic tests; logical tags provide catalog/batch convenience but not PLC transactions. |
+
+### Supporting public member index
+
+These helpers are public because they support diagnostics, catalog administration, simulator test setup, and low-level libplctag mappings. They are normally composed through `IABPlcRx`, `ABLogicalTagClient`, or `ABPlcSimulator`; direct low-level use should remain behind a tested adapter.
+
+| Feature | Members and use |
+| --- | --- |
+| Logical-tag catalog and persistence | `CreateTag`, `RegisterTag`, `RemoveTag`, `ReadAsync`, `ReadManyAsync`, `WriteAsync`, `WriteManyAsync`, `ObserveAsync`, `ObserveManyAsync`, `InitializeStoreAsync`, `LoadTagsAsync`, `GetTagAsync`, `ListTagsAsync`, `EditTagAsync`, `DeleteTagAsync`, `UpsertTagAsync`, `GetGroupAsync`, `ListGroupsAsync`, `UpsertGroupAsync`, `DeleteGroupAsync`, `ImportCsvAsync`, `ExportCsvAsync`. All async members take a cancellation token; inspect `TagOperationResult<T>` before using its payload. |
+| Simulator connection/fault/audit | `Disconnect`, `Reconnect`, `QueueFault`, `ClearFaults`, `ClearOperationLog`, `CreateLogicalTagClient`, and `Operations`/metrics properties. Use a queued failure to test status/error paths, then clear/reset before the next scenario. |
+| Public tag and wrapper access | `IPlcTag.Abort`, `Lock`, `Unlock`, `GetStatus`, `GetSize`, `Read`, and `Write`, plus `PlcTagWrapper` `Get*`/`Set*` scalar/string members and `GetType`/`SetType` for object layouts. Tags are supplied by `ObserveAll`; `GetType`/`SetType` belong to `PlcTagWrapper`, not `IPlcTag`. Raw `GetTagBytes`/`SetTagBytes` are simulator-only fixture helpers. |
+| Bit/scaling utilities | `GetBit`, `SetBit`, `GetBits`, `SetBits`, `GetBitsArray`, `GetBitsString`, `NumberToBits`, `BitsToNumber`, `ScaleLinear`, `ScaleSquareRoot`, `Reduce`, and `ToString`. These are pure conversion/diagnostic helpers; validate range, signedness, endianness, and engineering-unit assumptions with known values before command use. |
+
+## Operational guidance
+
+Dispose subscriptions and clients. Prefer a scan interval that is realistic for controller and network capacity. Batch selected reads/writes instead of issuing many independent round trips. Treat `PlcTagResult.StatusCode` as the operation outcome; subscribe to `ObserveErrors` for stream-level visibility. Use sampled streams for UI and telemetry sinks.
+
+## Troubleshooting
+
+- **Cannot connect to Logix:** confirm the EtherNet/IP path and controller slot; use the five-argument constructor when routing is required.
+- **Bit value is wrong:** use an integral tag, not a native `bool`, for word-bit addressing and keep the index in range.
+- **A staged value does not reach the PLC:** check `AutoWriteValue`; call `Write(variable)` or `Write()` when it is false.
+- **No updates:** ensure the tag is registered, scanning is enabled, and the subscription remains alive.
+- **Native error:** inspect `StatusCode` with `PlcTagStatus.DecodeError`; verify gateway, firewall, and controller access before retrying.
+
+## AI skill
+
+For source-grounded implementation guidance, use the packaged [`ab-plc-rx` skill](../../skills/ab-plc-rx/SKILL.md). It directs an agent to retain explicit type witnesses, validate PLC safety, and consult this README for the detailed contract.
+
+MIT licensed. See the repository `LICENSE`.
+
+<!-- BEGIN GENERATED PUBLIC API -->
+
+## Exhaustive public API reference
+
+This catalogue is generated from the packaged runtime assemblies and their XML documentation. It includes exported public types and their declared public members; inherited members and non-public implementation details are intentionally omitted.
+
+### `ABPlcRx`
+
+Exported public types: 19; declared public members: 315.
+
+#### `T:IoT.DriverCore.ABPlcRx.ABLogicalTagClient`
+
+```csharp
+public class IoT.DriverCore.ABPlcRx.ABLogicalTagClient
+```
+Adapts existing Allen-Bradley setup members to the common logical-tag setup contracts.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.#ctor(IoT.DriverCore.ABPlcRx.IABPlcRx)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.ABLogicalTagClient(IoT.DriverCore.ABPlcRx.IABPlcRx controller)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ABPlcRx.ABLogicalTagClient` class.
+
+- Parameter `controller`: The composed Allen-Bradley controller.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.#ctor(IoT.DriverCore.ABPlcRx.IABPlcRx,IoT.DriverCore.Core.ILogicalTagCatalog)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.ABLogicalTagClient(IoT.DriverCore.ABPlcRx.IABPlcRx controller, IoT.DriverCore.Core.ILogicalTagCatalog catalog)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ABPlcRx.ABLogicalTagClient` class.
+
+- Parameter `controller`: The composed Allen-Bradley controller.
+- Parameter `catalog`: The logical-tag catalog.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.#ctor(IoT.DriverCore.ABPlcRx.IABPlcRx,IoT.DriverCore.Core.ILogicalTagCatalog,IoT.DriverCore.Core.LogicalTagSqliteStore)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.ABLogicalTagClient(IoT.DriverCore.ABPlcRx.IABPlcRx controller, IoT.DriverCore.Core.ILogicalTagCatalog catalog, IoT.DriverCore.Core.LogicalTagSqliteStore store)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ABPlcRx.ABLogicalTagClient` class.
+
+- Parameter `controller`: The composed Allen-Bradley controller.
+- Parameter `catalog`: The logical-tag catalog.
+- Parameter `store`: The SQLite tag store.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.#ctor(IoT.DriverCore.ABPlcRx.IABPlcRx,IoT.DriverCore.Core.ILogicalTagCatalog,IoT.DriverCore.Core.LogicalTagSqliteStore,System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.ABLogicalTagClient(IoT.DriverCore.ABPlcRx.IABPlcRx controller, IoT.DriverCore.Core.ILogicalTagCatalog catalog, IoT.DriverCore.Core.LogicalTagSqliteStore store, System.TimeProvider timeProvider)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ABPlcRx.ABLogicalTagClient` class.
+
+- Parameter `controller`: The composed Allen-Bradley controller.
+- Parameter `catalog`: The logical-tag catalog.
+- Parameter `store`: The SQLite tag store.
+- Parameter `timeProvider`: The time provider used to stamp logical tag values.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.#ctor(IoT.DriverCore.ABPlcRx.IABPlcRx,IoT.DriverCore.Core.ILogicalTagCatalog,System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.ABLogicalTagClient(IoT.DriverCore.ABPlcRx.IABPlcRx controller, IoT.DriverCore.Core.ILogicalTagCatalog catalog, System.TimeProvider timeProvider)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ABPlcRx.ABLogicalTagClient` class.
+
+- Parameter `controller`: The composed Allen-Bradley controller.
+- Parameter `catalog`: The logical-tag catalog.
+- Parameter `timeProvider`: The time provider used to stamp logical tag values.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.#ctor(IoT.DriverCore.ABPlcRx.IABPlcRx,System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.ABLogicalTagClient(IoT.DriverCore.ABPlcRx.IABPlcRx controller, System.TimeProvider timeProvider)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ABPlcRx.ABLogicalTagClient` class.
+
+- Parameter `controller`: The composed Allen-Bradley controller.
+- Parameter `timeProvider`: The time provider used to stamp logical tag values.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.CreateTag(IoT.DriverCore.Core.LogicalTag)`
+
+```csharp
+public IoT.DriverCore.Core.LogicalTag CreateTag(IoT.DriverCore.Core.LogicalTag tag)
+```
+Creates and registers an existing logical tag definition.
+
+- Parameter `tag`: The logical tag definition.
+- Returns: The registered definition.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.CreateTag(System.String,System.String,System.String)`
+
+```csharp
+public IoT.DriverCore.Core.LogicalTag CreateTag(string name, string address, string dataType)
+```
+Creates and registers a logical tag.
+
+- Parameter `name`: The logical name.
+- Parameter `address`: The Allen-Bradley address.
+- Parameter `dataType`: The CLR or PLC data type name.
+- Returns: The registered definition.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.DeleteGroupAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> DeleteGroupAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `name`: The `name` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<bool>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.DeleteTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> DeleteTagAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Deletes a SQLite tag and removes it from the live catalog when found.
+
+- Parameter `tagName`: The logical tag name.
+- Parameter `cancellationToken`: A token to cancel the operation.
+- Returns: True when the persisted tag existed.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.Dispose`
+
+```csharp
+public void Dispose()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.EditTagAsync(IoT.DriverCore.Core.LogicalTag,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> EditTagAsync(IoT.DriverCore.Core.LogicalTag tag, System.Threading.CancellationToken cancellationToken)
+```
+Edits a SQLite tag and synchronizes the live catalog when found.
+
+- Parameter `tag`: The replacement definition.
+- Parameter `cancellationToken`: A token to cancel the operation.
+- Returns: True when the persisted tag existed.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.ExportCsvAsync(System.IO.TextWriter,System.Char,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task ExportCsvAsync(System.IO.TextWriter writer, char delimiter, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `writer`: The `writer` value.
+- Parameter `delimiter`: The `delimiter` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.ExportCsvAsync(System.IO.TextWriter,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task ExportCsvAsync(System.IO.TextWriter writer, System.Threading.CancellationToken cancellationToken)
+```
+Exports the current catalog through `T:IoT.DriverCore.Core.LogicalTagCsv` .
+
+- Parameter `writer`: The CSV writer.
+- Parameter `cancellationToken`: A token to cancel the operation.
+- Returns: A task that completes after export.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.GetGroupAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.LogicalTagGroup> GetGroupAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `name`: The `name` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.Core.LogicalTagGroup>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.GetTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.LogicalTag> GetTagAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Gets a tag from the configured SQLite store.
+
+- Parameter `tagName`: The logical tag name.
+- Parameter `cancellationToken`: A token to cancel the operation.
+- Returns: The stored tag, or null.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.ImportCsvAsync(System.IO.TextReader,System.Char,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> ImportCsvAsync(System.IO.TextReader reader, char delimiter, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `reader`: The `reader` value.
+- Parameter `delimiter`: The `delimiter` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.ImportCsvAsync(System.IO.TextReader,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> ImportCsvAsync(System.IO.TextReader reader, System.Threading.CancellationToken cancellationToken)
+```
+Imports CSV definitions through `T:IoT.DriverCore.Core.LogicalTagCsv` and registers them.
+
+- Parameter `reader`: The CSV reader.
+- Parameter `cancellationToken`: A token to cancel the operation.
+- Returns: The imported definitions.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.InitializeStoreAsync(IoT.DriverCore.Core.LogicalTagSqliteStore,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task InitializeStoreAsync(IoT.DriverCore.Core.LogicalTagSqliteStore store, System.Threading.CancellationToken cancellationToken)
+```
+Initializes and retains a SQLite store for CRUD operations.
+
+- Parameter `store`: The SQLite store.
+- Parameter `cancellationToken`: A token to cancel the operation.
+- Returns: A task that completes after schema initialization.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.InitializeStoreAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task InitializeStoreAsync(System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.ListGroupsAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTagGroup>> ListGroupsAsync(System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTagGroup>>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.ListTagsAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> ListTagsAsync(System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.LoadTagsAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> LoadTagsAsync(System.Threading.CancellationToken cancellationToken)
+```
+Loads the configured SQLite catalog and dynamically registers every definition.
+
+- Parameter `cancellationToken`: A token to cancel the operation.
+- Returns: The loaded definitions.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.Observe(System.String)`
+
+```csharp
+public System.IObservable<IoT.DriverCore.Core.LogicalTagValue> Observe(string tagName)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Returns: A `System.IObservable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.ObserveAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue> ObserveAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.ObserveMany(System.Collections.Generic.IReadOnlyCollection`1{System.String})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.Core.LogicalTagValue> ObserveMany(System.Collections.Generic.IReadOnlyCollection<string> tagNames)
+```
+Executes the `ObserveMany` operation.
+
+- Parameter `tagNames`: The `tagNames` value.
+- Returns: A `System.IObservable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.ObserveManyAsync(System.Collections.Generic.IReadOnlyCollection`1{System.String},System.Threading.CancellationToken)`
+
+```csharp
+public System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue> ObserveManyAsync(System.Collections.Generic.IReadOnlyCollection<string> tagNames, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ObserveManyAsync` operation.
+
+- Parameter `tagNames`: The `tagNames` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.ReadAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>> ReadAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.ReadManyAsync(System.Collections.Generic.IReadOnlyCollection`1{System.String},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>> ReadManyAsync(System.Collections.Generic.IReadOnlyCollection<string> tagNames, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ReadManyAsync` operation.
+
+- Parameter `tagNames`: The `tagNames` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.RegisterTag(IoT.DriverCore.Core.LogicalTag)`
+
+```csharp
+public void RegisterTag(IoT.DriverCore.Core.LogicalTag tag)
+```
+Registers or replaces a logical tag in the controller and catalog.
+
+- Parameter `tag`: The logical tag definition.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.RemoveTag(System.String)`
+
+```csharp
+public bool RemoveTag(string tagName)
+```
+Removes a logical tag from the controller and catalog.
+
+- Parameter `tagName`: The logical tag name.
+- Returns: True when either layer contained the tag.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.UpsertGroupAsync(IoT.DriverCore.Core.LogicalTagGroup,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task UpsertGroupAsync(IoT.DriverCore.Core.LogicalTagGroup group, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `group`: The `group` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.UpsertTagAsync(IoT.DriverCore.Core.LogicalTag,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task UpsertTagAsync(IoT.DriverCore.Core.LogicalTag tag, System.Threading.CancellationToken cancellationToken)
+```
+Upserts a SQLite tag and synchronizes the live catalog.
+
+- Parameter `tag`: The tag definition.
+- Parameter `cancellationToken`: A token to cancel the operation.
+- Returns: A task that completes after synchronization.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.WriteAsync(IoT.DriverCore.Core.LogicalTagValue,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>> WriteAsync(IoT.DriverCore.Core.LogicalTagValue value, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `value`: The `value` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.WriteManyAsync(System.Collections.Generic.IReadOnlyCollection`1{IoT.DriverCore.Core.LogicalTagValue},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>> WriteManyAsync(System.Collections.Generic.IReadOnlyCollection<IoT.DriverCore.Core.LogicalTagValue> values, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `WriteManyAsync` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>>` result.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABLogicalTagClient.Catalog`
+
+```csharp
+public IoT.DriverCore.Core.ILogicalTagCatalog Catalog { get; }
+```
+Gets the logical-tag catalog used by this adapter.
+
+- Value: The `Catalog` value.
+
+#### `T:IoT.DriverCore.ABPlcRx.ABPlcRx`
+
+```csharp
+public class IoT.DriverCore.ABPlcRx.ABPlcRx
+```
+Reactive Allen Bradley PLC facade.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.#ctor(IoT.DriverCore.ABPlcRx.PlcType,System.String,System.TimeSpan)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.ABPlcRx(IoT.DriverCore.ABPlcRx.PlcType plcType, string ip, System.TimeSpan scanInterval)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ABPlcRx.ABPlcRx` class.
+
+- Parameter `plcType`: Type of the PLC.
+- Parameter `ip`: The ip.
+- Parameter `scanInterval`: The scan interval.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.#ctor(IoT.DriverCore.ABPlcRx.PlcType,System.String,System.TimeSpan,System.TimeSpan,System.String)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.ABPlcRx(IoT.DriverCore.ABPlcRx.PlcType plcType, string ip, System.TimeSpan scanInterval, System.TimeSpan timeOut, string path)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ABPlcRx.ABPlcRx` class.
+
+- Parameter `plcType`: Type of the PLC.
+- Parameter `ip`: The ip.
+- Parameter `scanInterval`: The scan interval.
+- Parameter `timeOut`: The time out.
+- Parameter `path`: The path.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.AddUpdateTagItem``1(System.String,System.String,System.String,``0)`
+
+```csharp
+public void AddUpdateTagItem<T>(string variable, string tagName, string tagGroup, T typeWitness)
+```
+Adds the update tag item.
+
+- Parameter `variable`: The variable, this can be any non null name you wish to use.
+- Parameter `tagName`: Name of the tag.
+- Parameter `tagGroup`: The tag group.
+- Parameter `typeWitness`: Optional type witness for callers that infer from a value.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.AddUpdateTagItem``1(System.String,System.String,``0)`
+
+```csharp
+public void AddUpdateTagItem<T>(string variable, string tagName, T typeWitness)
+```
+Adds the update tag item.
+
+- Parameter `variable`: The variable, this can be any non null name you wish to use.
+- Parameter `tagName`: Name of the tag.
+- Parameter `typeWitness`: Optional type witness for callers that infer from a value.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.AddUpdateTagItem``1(System.String,``0)`
+
+```csharp
+public void AddUpdateTagItem<T>(string tagName, T typeWitness)
+```
+Adds the update tag item.
+
+- Parameter `tagName`: Name of the tag.
+- Parameter `typeWitness`: Optional type witness for callers that infer from a value.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.CreateWriter``1(System.String,``0,System.Int32)`
+
+```csharp
+public System.IObserver<T> CreateWriter<T>(string variable, T typeWitness, int bit)
+```
+Creates an observer that writes values to a PLC variable when OnNext is called.
+
+- Parameter `variable`: The variable to write to.
+- Parameter `typeWitness`: Type witness for the writer value type.
+- Parameter `bit`: The bit [ONLY use for bool tags].
+- Returns: An observer that will write and commit values to the PLC.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.Dispose`
+
+```csharp
+public void Dispose()
+```
+Releases the PLC facade's managed and unmanaged resources.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.GetValue``1(System.String,``0,System.Int32)`
+
+```csharp
+public T GetValue<T>(string variable, T typeWitness, int bit)
+```
+Values the specified variable.
+
+- Parameter `variable`: The variable.
+- Parameter `typeWitness`: Type witness for the requested PLC value type.
+- Parameter `bit`: The bit [ONLY use for bool tags].
+- Returns: A value of T.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.ObserveAsyncObservable``1(System.String,``0,System.Int32)`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<T> ObserveAsyncObservable<T>(string variable, T typeWitness, int bit)
+```
+Observes the specified variable as an async-native observable.
+
+- Parameter `variable`: The variable.
+- Parameter `typeWitness`: Type witness for the requested PLC value type.
+- Parameter `bit`: The bit.
+- Returns: An async observable of T.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.ObserveErrors`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ABPlcRx.PlcTagResult> ObserveErrors()
+```
+Streams only error results across all tags.
+
+- Returns: Observable sequence of error results.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.ObserveErrorsAsyncObservable`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ABPlcRx.PlcTagResult> ObserveErrorsAsyncObservable()
+```
+Streams only error results across all tags as an async-native observable.
+
+- Returns: Async observable sequence of error results.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.ObserveGroup(System.String)`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ABPlcRx.IPlcTag> ObserveGroup(string groupName)
+```
+Observe a PLC tag group, emitting the tag whose value changed.
+
+- Parameter `groupName`: The group name to observe.
+- Returns: Observable sequence of tags in the group that have changed.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.ObserveGroupAsyncObservable(System.String)`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ABPlcRx.IPlcTag> ObserveGroupAsyncObservable(string groupName)
+```
+Observe a PLC tag group as an async-native observable.
+
+- Parameter `groupName`: The group name to observe.
+- Returns: Async observable sequence of tags in the group that have changed.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.ObserveMany(System.String[])`
+
+```csharp
+public System.IObservable<System.Collections.Generic.IReadOnlyDictionary<string, object>> ObserveMany(string[] variables)
+```
+Observe values for many variables and emit a latest-value dictionary.
+
+- Parameter `variables`: One or more variable names to observe.
+- Returns: Observable sequence of dictionary containing the latest values for each variable.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.ObserveManyAsyncObservable(System.String[])`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<System.Collections.Generic.IReadOnlyDictionary<string, object>> ObserveManyAsyncObservable(string[] variables)
+```
+Observes many variables as an async-native latest-value dictionary.
+
+- Parameter `variables`: One or more variable names to observe.
+- Returns: Async observable sequence of dictionary containing the latest values for each variable.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.ObservePing(System.TimeSpan,System.Boolean,ReactiveUI.Primitives.Concurrency.ISequencer)`
+
+```csharp
+public System.IObservable<bool> ObservePing(System.TimeSpan interval, bool echo, ReactiveUI.Primitives.Concurrency.ISequencer scheduler)
+```
+Observe ping results on a schedule.
+
+- Parameter `interval`: The interval between pings.
+- Parameter `echo`: True echo result to standard output.
+- Parameter `scheduler`: Optional scheduler for the ping cadence.
+- Returns: Observable sequence of ping result states, deduplicated.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.ObservePingAsyncObservable(System.TimeSpan,System.Boolean,ReactiveUI.Primitives.Concurrency.ISequencer)`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<bool> ObservePingAsyncObservable(System.TimeSpan interval, bool echo, ReactiveUI.Primitives.Concurrency.ISequencer scheduler)
+```
+Observe ping results on a schedule as an async-native observable.
+
+- Parameter `interval`: The interval between pings.
+- Parameter `echo`: True echo result to standard output.
+- Parameter `scheduler`: Optional scheduler for the ping cadence.
+- Returns: Async observable sequence of ping result states, deduplicated.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.ObserveSampledAsyncObservable``1(System.String,System.TimeSpan,``0,System.Int32,ReactiveUI.Primitives.Concurrency.ISequencer)`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<T> ObserveSampledAsyncObservable<T>(string variable, System.TimeSpan sampleInterval, T typeWitness, int bit, ReactiveUI.Primitives.Concurrency.ISequencer scheduler)
+```
+Observe a variable with sampling as an async-native observable.
+
+- Parameter `variable`: The variable to observe.
+- Parameter `sampleInterval`: The sampling interval.
+- Parameter `typeWitness`: Type witness for the requested PLC value type.
+- Parameter `bit`: The bit [ONLY use for bool tags].
+- Parameter `scheduler`: Optional scheduler for sampling.
+- Returns: Async observable sequence of sampled values.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.ObserveSampled``1(System.String,System.TimeSpan,``0,System.Int32,ReactiveUI.Primitives.Concurrency.ISequencer)`
+
+```csharp
+public System.IObservable<T> ObserveSampled<T>(string variable, System.TimeSpan sampleInterval, T typeWitness, int bit, ReactiveUI.Primitives.Concurrency.ISequencer scheduler)
+```
+Observe a variable with sampling, reducing event rate while preserving latest value.
+
+- Parameter `variable`: The variable to observe.
+- Parameter `sampleInterval`: The sampling interval.
+- Parameter `typeWitness`: Type witness for the requested PLC value type.
+- Parameter `bit`: The bit [ONLY use for bool tags].
+- Parameter `scheduler`: Optional scheduler for sampling.
+- Returns: Observable sequence of sampled values.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.Observe``1(System.String,``0,System.Int32)`
+
+```csharp
+public System.IObservable<T> Observe<T>(string variable, T typeWitness, int bit)
+```
+Observes the specified variable.
+
+- Parameter `variable`: The variable.
+- Parameter `typeWitness`: Type witness for the requested PLC value type.
+- Parameter `bit`: The bit.
+- Returns: An Observable of T.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.Ping(System.Boolean)`
+
+```csharp
+public bool Ping(bool echo)
+```
+Ping the PLC.
+
+- Parameter `echo`: True echo result to standard output.
+- Returns: True when ping succeeds; otherwise false.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.PingAsync(System.Boolean,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> PingAsync(bool echo, System.Threading.CancellationToken cancellationToken)
+```
+Ping the PLC asynchronously.
+
+- Parameter `echo`: True echo result to standard output.
+- Parameter `cancellationToken`: A token to cancel the ping operation.
+- Returns: A task producing true when ping succeeds; otherwise false.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.Read`
+
+```csharp
+public System.Collections.Generic.IEnumerable<IoT.DriverCore.ABPlcRx.PlcTagResult> Read()
+```
+Reads all the Tags in this instance.
+
+- Returns: A PlcTagResult.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.Read(System.String)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.PlcTagResult Read(string variable)
+```
+Reads the specified variable.
+
+- Parameter `variable`: The variable.
+- Returns: A PlcTagResult.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.ReadManyAsync(System.Collections.Generic.IReadOnlyCollection`1{System.String},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.ABPlcRx.PlcTagResult>> ReadManyAsync(System.Collections.Generic.IReadOnlyCollection<string> variables, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ReadManyAsync` operation.
+
+- Parameter `variables`: The `variables` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.ABPlcRx.PlcTagResult>>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.ReadValueAsync``1(System.String,``0,System.Int32,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<T>> ReadValueAsync<T>(string variable, T typeWitness, int bit, System.Threading.CancellationToken cancellationToken)
+```
+Reads and converts one logical variable asynchronously.
+
+- Parameter `variable`: The logical variable name.
+- Parameter `typeWitness`: Type witness for the requested PLC value type.
+- Parameter `bit`: The optional integral bit index.
+- Parameter `cancellationToken`: A token to cancel the operation.
+- Returns: The typed operation result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.RemoveTagItem(System.String)`
+
+```csharp
+public bool RemoveTagItem(string variable)
+```
+Removes a registered tag by logical variable name.
+
+- Parameter `variable`: The logical variable name.
+- Returns: True when a tag was removed.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.Value``1(System.String,``0,System.Int32)`
+
+```csharp
+public void Value<T>(string variable, T value, int bit)
+```
+Values the specified variable.
+
+- Parameter `variable`: The variable.
+- Parameter `value`: The value.
+- Parameter `bit`: The bit [ONLY use for bool tags].
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.Write`
+
+```csharp
+public System.Collections.Generic.IEnumerable<IoT.DriverCore.ABPlcRx.PlcTagResult> Write()
+```
+Writes all the tags in this instance.
+
+- Returns: A PlcTagResult.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.Write(System.String)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.PlcTagResult Write(string variable)
+```
+Writes the specified variable.
+
+- Parameter `variable`: The variable.
+- Returns: A PlcTagResult.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.WriteManyAsync(System.Collections.Generic.IReadOnlyDictionary`2{System.String,System.Object},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.ABPlcRx.PlcTagResult>> WriteManyAsync(System.Collections.Generic.IReadOnlyDictionary<string, object> values, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `WriteManyAsync` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.ABPlcRx.PlcTagResult>>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcRx.WriteValueAsync``1(System.String,``0,System.Int32,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<T>> WriteValueAsync<T>(string variable, T value, int bit, System.Threading.CancellationToken cancellationToken)
+```
+Writes one logical variable asynchronously.
+
+- Parameter `variable`: The logical variable name.
+- Parameter `value`: The value to write.
+- Parameter `bit`: The optional integral bit index.
+- Parameter `cancellationToken`: A token to cancel the operation.
+- Returns: The typed operation result.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcRx.AutoWriteValue`
+
+```csharp
+public bool AutoWriteValue { get; set; }
+```
+Gets or sets a value indicating whether [automatic write value].
+
+- Value: true if [automatic write value]; otherwise, false .
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcRx.IsDisposed`
+
+```csharp
+public bool IsDisposed { get; }
+```
+Gets a value indicating whether gets a value that indicates whether the object is disposed.
+
+- Value: The `IsDisposed` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcRx.ObserveAll`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ABPlcRx.IPlcTag> ObserveAll { get; }
+```
+Gets the data read.
+
+- Value: The data read.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcRx.ObserveAllAsyncObservable`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ABPlcRx.IPlcTag> ObserveAllAsyncObservable { get; }
+```
+Gets the data read as an async-native observable.
+
+- Value: The async data read stream.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcRx.ScanEnabled`
+
+```csharp
+public bool ScanEnabled { get; set; }
+```
+Gets or sets a value indicating whether [scan enabled].
+
+- Value: true if [scan enabled]; otherwise, false .
+
+#### `T:IoT.DriverCore.ABPlcRx.ABPlcSimulator`
+
+```csharp
+public class IoT.DriverCore.ABPlcRx.ABPlcSimulator
+```
+Deterministic, in-memory Allen-Bradley controller simulator.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.#ctor`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.ABPlcSimulator()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ABPlcRx.ABPlcSimulator` class.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.#ctor(IoT.DriverCore.ABPlcRx.PlcType)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.ABPlcSimulator(IoT.DriverCore.ABPlcRx.PlcType plcType)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ABPlcRx.ABPlcSimulator` class.
+
+- Parameter `plcType`: The processor family to emulate.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.#ctor(IoT.DriverCore.ABPlcRx.PlcType,System.TimeSpan,System.TimeSpan,System.String,System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.ABPlcSimulator(IoT.DriverCore.ABPlcRx.PlcType plcType, System.TimeSpan scanInterval, System.TimeSpan timeout, string path, System.TimeProvider timeProvider)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ABPlcRx.ABPlcSimulator` class.
+
+- Parameter `plcType`: The processor family to emulate.
+- Parameter `scanInterval`: The tag scan interval.
+- Parameter `timeout`: The operation timeout.
+- Parameter `path`: The optional route path.
+- Parameter `timeProvider`: The time provider used for results and operation logs.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.AddUpdateTagItem``1(System.String,System.String,System.String,``0)`
+
+```csharp
+public void AddUpdateTagItem<T>(string variable, string tagName, string tagGroup, T typeWitness)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `variable`: The `variable` value.
+- Parameter `tagName`: The `tagName` value.
+- Parameter `tagGroup`: The `tagGroup` value.
+- Parameter `typeWitness`: The `typeWitness` value.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.AddUpdateTagItem``1(System.String,System.String,``0)`
+
+```csharp
+public void AddUpdateTagItem<T>(string variable, string tagName, T typeWitness)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `variable`: The `variable` value.
+- Parameter `tagName`: The `tagName` value.
+- Parameter `typeWitness`: The `typeWitness` value.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.AddUpdateTagItem``1(System.String,``0)`
+
+```csharp
+public void AddUpdateTagItem<T>(string tagName, T typeWitness)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Parameter `typeWitness`: The `typeWitness` value.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.ClearFaults`
+
+```csharp
+public void ClearFaults()
+```
+Clears all unconsumed scripted operation results.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.ClearOperationLog`
+
+```csharp
+public void ClearOperationLog()
+```
+Clears the operation log and restarts its sequence at one.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.CreateLogicalTagClient`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.ABLogicalTagClient CreateLogicalTagClient()
+```
+Creates a logical-tag client over this simulator.
+
+- Returns: A logical-tag client that does not require physical hardware.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.CreateWriter``1(System.String,``0,System.Int32)`
+
+```csharp
+public System.IObserver<T> CreateWriter<T>(string variable, T typeWitness, int bit)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `variable`: The `variable` value.
+- Parameter `typeWitness`: The `typeWitness` value.
+- Parameter `bit`: The `bit` value.
+- Returns: A `System.IObserver<T>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.Disconnect`
+
+```csharp
+public void Disconnect()
+```
+Disconnects simulated communications with `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrBadConnection` .
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.Disconnect(System.Int32)`
+
+```csharp
+public void Disconnect(int statusCode)
+```
+Disconnects simulated communications.
+
+- Parameter `statusCode`: The status returned by IO while disconnected.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.Dispose`
+
+```csharp
+public void Dispose()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.GetTagBytes(System.String)`
+
+```csharp
+public byte[] GetTagBytes(string tagName)
+```
+Gets a copy of raw device memory for a physical PLC tag.
+
+- Parameter `tagName`: The physical PLC tag name.
+- Returns: A copy of the raw tag bytes.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.GetTagValue``1(System.String,``0)`
+
+```csharp
+public T GetTagValue<T>(string tagName, T typeWitness)
+```
+Reads a supported scalar value directly from device memory.
+
+- Parameter `tagName`: The physical PLC tag name.
+- Parameter `typeWitness`: A type witness for the scalar value.
+- Returns: The decoded value.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.GetValue``1(System.String,``0,System.Int32)`
+
+```csharp
+public T GetValue<T>(string variable, T typeWitness, int bit)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `variable`: The `variable` value.
+- Parameter `typeWitness`: The `typeWitness` value.
+- Parameter `bit`: The `bit` value.
+- Returns: A `T` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.ObserveAsyncObservable``1(System.String,``0,System.Int32)`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<T> ObserveAsyncObservable<T>(string variable, T typeWitness, int bit)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `variable`: The `variable` value.
+- Parameter `typeWitness`: The `typeWitness` value.
+- Parameter `bit`: The `bit` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<T>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.ObserveErrors`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ABPlcRx.PlcTagResult> ObserveErrors()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `System.IObservable<IoT.DriverCore.ABPlcRx.PlcTagResult>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.ObserveErrorsAsyncObservable`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ABPlcRx.PlcTagResult> ObserveErrorsAsyncObservable()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ABPlcRx.PlcTagResult>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.ObserveGroup(System.String)`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ABPlcRx.IPlcTag> ObserveGroup(string groupName)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `groupName`: The `groupName` value.
+- Returns: A `System.IObservable<IoT.DriverCore.ABPlcRx.IPlcTag>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.ObserveGroupAsyncObservable(System.String)`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ABPlcRx.IPlcTag> ObserveGroupAsyncObservable(string groupName)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `groupName`: The `groupName` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ABPlcRx.IPlcTag>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.ObserveMany(System.String[])`
+
+```csharp
+public System.IObservable<System.Collections.Generic.IReadOnlyDictionary<string, object>> ObserveMany(string[] variables)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `variables`: The `variables` value.
+- Returns: A `System.IObservable<System.Collections.Generic.IReadOnlyDictionary<string, object>>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.ObserveManyAsyncObservable(System.String[])`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<System.Collections.Generic.IReadOnlyDictionary<string, object>> ObserveManyAsyncObservable(string[] variables)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `variables`: The `variables` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<System.Collections.Generic.IReadOnlyDictionary<string, object>>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.ObservePing(System.TimeSpan,System.Boolean,ReactiveUI.Primitives.Concurrency.ISequencer)`
+
+```csharp
+public System.IObservable<bool> ObservePing(System.TimeSpan interval, bool echo, ReactiveUI.Primitives.Concurrency.ISequencer scheduler)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `interval`: The `interval` value.
+- Parameter `echo`: The `echo` value.
+- Parameter `scheduler`: The `scheduler` value.
+- Returns: A `System.IObservable<bool>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.ObservePingAsyncObservable(System.TimeSpan,System.Boolean,ReactiveUI.Primitives.Concurrency.ISequencer)`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<bool> ObservePingAsyncObservable(System.TimeSpan interval, bool echo, ReactiveUI.Primitives.Concurrency.ISequencer scheduler)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `interval`: The `interval` value.
+- Parameter `echo`: The `echo` value.
+- Parameter `scheduler`: The `scheduler` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<bool>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.ObserveSampledAsyncObservable``1(System.String,System.TimeSpan,``0,System.Int32,ReactiveUI.Primitives.Concurrency.ISequencer)`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<T> ObserveSampledAsyncObservable<T>(string variable, System.TimeSpan sampleInterval, T typeWitness, int bit, ReactiveUI.Primitives.Concurrency.ISequencer scheduler)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `variable`: The `variable` value.
+- Parameter `sampleInterval`: The `sampleInterval` value.
+- Parameter `typeWitness`: The `typeWitness` value.
+- Parameter `bit`: The `bit` value.
+- Parameter `scheduler`: The `scheduler` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<T>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.ObserveSampled``1(System.String,System.TimeSpan,``0,System.Int32,ReactiveUI.Primitives.Concurrency.ISequencer)`
+
+```csharp
+public System.IObservable<T> ObserveSampled<T>(string variable, System.TimeSpan sampleInterval, T typeWitness, int bit, ReactiveUI.Primitives.Concurrency.ISequencer scheduler)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `variable`: The `variable` value.
+- Parameter `sampleInterval`: The `sampleInterval` value.
+- Parameter `typeWitness`: The `typeWitness` value.
+- Parameter `bit`: The `bit` value.
+- Parameter `scheduler`: The `scheduler` value.
+- Returns: A `System.IObservable<T>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.Observe``1(System.String,``0,System.Int32)`
+
+```csharp
+public System.IObservable<T> Observe<T>(string variable, T typeWitness, int bit)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `variable`: The `variable` value.
+- Parameter `typeWitness`: The `typeWitness` value.
+- Parameter `bit`: The `bit` value.
+- Returns: A `System.IObservable<T>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.Ping(System.Boolean)`
+
+```csharp
+public bool Ping(bool echo)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `echo`: The `echo` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.PingAsync(System.Boolean,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> PingAsync(bool echo, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `echo`: The `echo` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<bool>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.QueueFault(IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation,System.Int32)`
+
+```csharp
+public void QueueFault(IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation operation, int statusCode)
+```
+Queues a libplctag-compatible result for a future matching operation.
+
+- Parameter `operation`: The operation to fault.
+- Parameter `statusCode`: The status to return.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.QueueFault(IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation,System.Int32,System.Int32)`
+
+```csharp
+public void QueueFault(IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation operation, int statusCode, int repeatCount)
+```
+Queues a repeated libplctag-compatible result for future matching operations.
+
+- Parameter `operation`: The operation to fault.
+- Parameter `statusCode`: The status to return.
+- Parameter `repeatCount`: The number of matching operations affected.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.QueueFault(IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation,System.Int32,System.Int32,System.String)`
+
+```csharp
+public void QueueFault(IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation operation, int statusCode, int repeatCount, string tagName)
+```
+Queues a libplctag-compatible result for a future matching operation.
+
+- Parameter `operation`: The operation to fault.
+- Parameter `statusCode`: The status to return.
+- Parameter `repeatCount`: The number of matching operations affected.
+- Parameter `tagName`: Optional physical tag-name filter.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.Read`
+
+```csharp
+public System.Collections.Generic.IEnumerable<IoT.DriverCore.ABPlcRx.PlcTagResult> Read()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `System.Collections.Generic.IEnumerable<IoT.DriverCore.ABPlcRx.PlcTagResult>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.Read(System.String)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.PlcTagResult Read(string variable)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `variable`: The `variable` value.
+- Returns: A `IoT.DriverCore.ABPlcRx.PlcTagResult` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.ReadManyAsync(System.Collections.Generic.IReadOnlyCollection`1{System.String},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.ABPlcRx.PlcTagResult>> ReadManyAsync(System.Collections.Generic.IReadOnlyCollection<string> variables, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ReadManyAsync` operation.
+
+- Parameter `variables`: The `variables` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.ABPlcRx.PlcTagResult>>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.ReadValueAsync``1(System.String,``0,System.Int32,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<T>> ReadValueAsync<T>(string variable, T typeWitness, int bit, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `variable`: The `variable` value.
+- Parameter `typeWitness`: The `typeWitness` value.
+- Parameter `bit`: The `bit` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<T>>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.Reconnect`
+
+```csharp
+public void Reconnect()
+```
+Reconnects simulated communications without losing device memory or registrations.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.RemoveTagItem(System.String)`
+
+```csharp
+public bool RemoveTagItem(string variable)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `variable`: The `variable` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.SetTagBytes(System.String,System.Collections.Generic.IReadOnlyCollection`1{System.Byte})`
+
+```csharp
+public void SetTagBytes(string tagName, System.Collections.Generic.IReadOnlyCollection<byte> value)
+```
+Executes the `SetTagBytes` operation.
+
+- Parameter `tagName`: The `tagName` value.
+- Parameter `value`: The `value` value.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.SetTagValue``1(System.String,``0)`
+
+```csharp
+public void SetTagValue<T>(string tagName, T value)
+```
+Seeds or updates a supported scalar value in device memory.
+
+- Parameter `tagName`: The physical PLC tag name.
+- Parameter `value`: The value to encode.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.Value``1(System.String,``0,System.Int32)`
+
+```csharp
+public void Value<T>(string variable, T value, int bit)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `variable`: The `variable` value.
+- Parameter `value`: The `value` value.
+- Parameter `bit`: The `bit` value.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.Write`
+
+```csharp
+public System.Collections.Generic.IEnumerable<IoT.DriverCore.ABPlcRx.PlcTagResult> Write()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `System.Collections.Generic.IEnumerable<IoT.DriverCore.ABPlcRx.PlcTagResult>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.Write(System.String)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.PlcTagResult Write(string variable)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `variable`: The `variable` value.
+- Returns: A `IoT.DriverCore.ABPlcRx.PlcTagResult` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.WriteManyAsync(System.Collections.Generic.IReadOnlyDictionary`2{System.String,System.Object},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.ABPlcRx.PlcTagResult>> WriteManyAsync(System.Collections.Generic.IReadOnlyDictionary<string, object> values, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `WriteManyAsync` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.ABPlcRx.PlcTagResult>>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulator.WriteValueAsync``1(System.String,``0,System.Int32,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<T>> WriteValueAsync<T>(string variable, T value, int bit, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `variable`: The `variable` value.
+- Parameter `value`: The `value` value.
+- Parameter `bit`: The `bit` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<T>>` result.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulator.ActiveHandleCount`
+
+```csharp
+public int ActiveHandleCount { get; }
+```
+Gets the number of live tag handles.
+
+- Value: The `ActiveHandleCount` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulator.AutoWriteValue`
+
+```csharp
+public bool AutoWriteValue { get; set; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `AutoWriteValue` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulator.ConnectionChanged`
+
+```csharp
+public System.IObservable<bool> ConnectionChanged { get; }
+```
+Gets connection-state changes. The current state is emitted on subscription.
+
+- Value: The `ConnectionChanged` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulator.IsConnected`
+
+```csharp
+public bool IsConnected { get; }
+```
+Gets a value indicating whether simulated communications are connected.
+
+- Value: The `IsConnected` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulator.IsDisposed`
+
+```csharp
+public bool IsDisposed { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `IsDisposed` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulator.ObserveAll`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ABPlcRx.IPlcTag> ObserveAll { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `ObserveAll` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulator.ObserveAllAsyncObservable`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ABPlcRx.IPlcTag> ObserveAllAsyncObservable { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `ObserveAllAsyncObservable` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulator.OperationLog`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<IoT.DriverCore.ABPlcRx.ABPlcSimulatorLogEntry> OperationLog { get; }
+```
+Gets a stable snapshot of recorded simulator operations.
+
+- Value: The `OperationLog` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulator.OperationMetrics`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperationMetrics OperationMetrics { get; }
+```
+Gets exact native-operation counts without relying on wall-clock timings.
+
+- Value: The `OperationMetrics` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulator.ScanEnabled`
+
+```csharp
+public bool ScanEnabled { get; set; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `ScanEnabled` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulator.TagStatuses`
+
+```csharp
+public System.Collections.Generic.IReadOnlyDictionary<string, int> TagStatuses { get; }
+```
+Gets the latest operation status for every physical PLC tag.
+
+- Value: The `TagStatuses` value.
+
+#### `T:IoT.DriverCore.ABPlcRx.ABPlcSimulatorLogEntry`
+
+```csharp
+public class IoT.DriverCore.ABPlcRx.ABPlcSimulatorLogEntry
+```
+One deterministic simulator operation record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ABPlcRx.ABPlcSimulatorLogEntry.ToString`
+
+```csharp
+public string ToString()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `string` result.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulatorLogEntry.Handle`
+
+```csharp
+public int Handle { get; }
+```
+Gets the native-style handle.
+
+- Value: The `Handle` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulatorLogEntry.Operation`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation Operation { get; }
+```
+Gets the operation.
+
+- Value: The `Operation` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulatorLogEntry.Sequence`
+
+```csharp
+public long Sequence { get; }
+```
+Gets the monotonic operation sequence.
+
+- Value: The `Sequence` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulatorLogEntry.StatusCode`
+
+```csharp
+public int StatusCode { get; }
+```
+Gets the resulting libplctag-compatible status.
+
+- Value: The `StatusCode` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulatorLogEntry.TagName`
+
+```csharp
+public string TagName { get; }
+```
+Gets the physical PLC tag name, when known.
+
+- Value: The `TagName` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulatorLogEntry.Timestamp`
+
+```csharp
+public System.DateTimeOffset Timestamp { get; }
+```
+Gets the operation timestamp.
+
+- Value: The `Timestamp` value.
+
+#### `T:IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation`
+
+```csharp
+public enum IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation
+```
+Operations that can be recorded or faulted by `T:IoT.DriverCore.ABPlcRx.ABPlcSimulator` .
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation.Abort`
+
+```csharp
+public static const IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation Abort
+```
+Abort outstanding tag IO.
+
+###### `F:IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation.Create`
+
+```csharp
+public static const IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation Create
+```
+Create a tag handle.
+
+###### `F:IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation.Destroy`
+
+```csharp
+public static const IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation Destroy
+```
+Destroy a tag handle.
+
+###### `F:IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation.GetStatus`
+
+```csharp
+public static const IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation GetStatus
+```
+Query tag status.
+
+###### `F:IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation.Lock`
+
+```csharp
+public static const IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation Lock
+```
+Lock a tag handle.
+
+###### `F:IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation.Read`
+
+```csharp
+public static const IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation Read
+```
+Read device memory into a tag handle.
+
+###### `F:IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation.Unlock`
+
+```csharp
+public static const IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation Unlock
+```
+Unlock a tag handle.
+
+###### `F:IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation.Write`
+
+```csharp
+public static const IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperation Write
+```
+Write a tag handle into device memory.
+
+#### `T:IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperationMetrics`
+
+```csharp
+public class IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperationMetrics
+```
+Immutable, deterministic native-operation counts captured by an `T:IoT.DriverCore.ABPlcRx.ABPlcSimulator` .
+
+##### Declared public members
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperationMetrics.CreateOperations`
+
+```csharp
+public long CreateOperations { get; }
+```
+Gets the number of create operations.
+
+- Value: The `CreateOperations` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperationMetrics.DestroyOperations`
+
+```csharp
+public long DestroyOperations { get; }
+```
+Gets the number of destroy operations.
+
+- Value: The `DestroyOperations` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperationMetrics.FailedOperations`
+
+```csharp
+public long FailedOperations { get; }
+```
+Gets the number of non-success native operations.
+
+- Value: The `FailedOperations` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperationMetrics.ReadOperations`
+
+```csharp
+public long ReadOperations { get; }
+```
+Gets the number of native reads.
+
+- Value: The `ReadOperations` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperationMetrics.TotalOperations`
+
+```csharp
+public long TotalOperations { get; }
+```
+Gets the number of native operations recorded.
+
+- Value: The `TotalOperations` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.ABPlcSimulatorOperationMetrics.WriteOperations`
+
+```csharp
+public long WriteOperations { get; }
+```
+Gets the number of native writes.
+
+- Value: The `WriteOperations` value.
+
+#### `T:IoT.DriverCore.ABPlcRx.IABPlcRx`
+
+```csharp
+public interface IoT.DriverCore.ABPlcRx.IABPlcRx
+```
+Reactive Allen Bradley PLC facade contract.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.AddUpdateTagItem``1(System.String,System.String,System.String,``0)`
+
+```csharp
+public void AddUpdateTagItem<T>(string variable, string tagName, string tagGroup, T typeWitness)
+```
+Adds the update tag item.
+
+- Parameter `variable`: The variable, this can be any non null name you wish to use.
+- Parameter `tagName`: Name of the plc tag.
+- Parameter `tagGroup`: The tag group.
+- Parameter `typeWitness`: Optional type witness for callers that infer from a value.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.AddUpdateTagItem``1(System.String,System.String,``0)`
+
+```csharp
+public void AddUpdateTagItem<T>(string variable, string tagName, T typeWitness)
+```
+Adds the update tag item.
+
+- Parameter `variable`: The variable, this can be any non null name you wish to use.
+- Parameter `tagName`: Name of the plc tag.
+- Parameter `typeWitness`: Optional type witness for callers that infer from a value.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.AddUpdateTagItem``1(System.String,``0)`
+
+```csharp
+public void AddUpdateTagItem<T>(string tagName, T typeWitness)
+```
+Adds the update tag item.
+
+- Parameter `tagName`: Name of the PLC tag.
+- Parameter `typeWitness`: Optional type witness for callers that infer from a value.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.CreateWriter``1(System.String,``0,System.Int32)`
+
+```csharp
+public System.IObserver<T> CreateWriter<T>(string variable, T typeWitness, int bit)
+```
+Creates an observer that writes values to a PLC variable when OnNext is called.
+
+- Parameter `variable`: The variable to write to.
+- Parameter `typeWitness`: Type witness for the writer value type.
+- Parameter `bit`: The bit [ONLY use for bool tags].
+- Returns: An observer that will write and commit values to the PLC.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.GetValue``1(System.String,``0,System.Int32)`
+
+```csharp
+public T GetValue<T>(string variable, T typeWitness, int bit)
+```
+Values the specified variable.
+
+- Parameter `variable`: The variable.
+- Parameter `typeWitness`: Type witness for the requested PLC value type.
+- Parameter `bit`: The bit.
+- Returns: A value of T.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.ObserveAsyncObservable``1(System.String,``0,System.Int32)`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<T> ObserveAsyncObservable<T>(string variable, T typeWitness, int bit)
+```
+Observes the specified variable using an async-native observable.
+
+- Parameter `variable`: The variable.
+- Parameter `typeWitness`: Type witness for the requested PLC value type.
+- Parameter `bit`: The bit.
+- Returns: An async observable sequence of values of type T.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.ObserveErrors`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ABPlcRx.PlcTagResult> ObserveErrors()
+```
+Streams only error results across all tags.
+
+- Returns: Observable sequence of error results.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.ObserveErrorsAsyncObservable`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ABPlcRx.PlcTagResult> ObserveErrorsAsyncObservable()
+```
+Streams only error results across all tags using an async-native observable.
+
+- Returns: Async observable sequence of error results.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.ObserveGroup(System.String)`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ABPlcRx.IPlcTag> ObserveGroup(string groupName)
+```
+Observe a PLC tag group, emitting the tag whose value changed.
+
+- Parameter `groupName`: The group name to observe.
+- Returns: Observable sequence of tags in the group that have changed.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.ObserveGroupAsyncObservable(System.String)`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ABPlcRx.IPlcTag> ObserveGroupAsyncObservable(string groupName)
+```
+Observe a PLC tag group using an async-native observable.
+
+- Parameter `groupName`: The group name to observe.
+- Returns: Async observable sequence of tags in the group that have changed.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.ObserveMany(System.String[])`
+
+```csharp
+public System.IObservable<System.Collections.Generic.IReadOnlyDictionary<string, object>> ObserveMany(string[] variables)
+```
+Observe values for many variables and emit a latest-value dictionary.
+
+- Parameter `variables`: One or more variable names to observe.
+- Returns: Observable sequence of dictionary containing the latest values for each variable.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.ObserveManyAsyncObservable(System.String[])`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<System.Collections.Generic.IReadOnlyDictionary<string, object>> ObserveManyAsyncObservable(string[] variables)
+```
+Observe values for many variables using an async-native observable.
+
+- Parameter `variables`: One or more variable names to observe.
+- Returns: Async observable sequence of dictionary containing the latest values for each variable.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.ObservePing(System.TimeSpan,System.Boolean,ReactiveUI.Primitives.Concurrency.ISequencer)`
+
+```csharp
+public System.IObservable<bool> ObservePing(System.TimeSpan interval, bool echo, ReactiveUI.Primitives.Concurrency.ISequencer scheduler)
+```
+Observe ping results on a schedule.
+
+- Parameter `interval`: The interval between pings.
+- Parameter `echo`: True echo result to standard output.
+- Parameter `scheduler`: Optional scheduler for the ping cadence.
+- Returns: Observable sequence of ping result states, deduplicated.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.ObservePingAsyncObservable(System.TimeSpan,System.Boolean,ReactiveUI.Primitives.Concurrency.ISequencer)`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<bool> ObservePingAsyncObservable(System.TimeSpan interval, bool echo, ReactiveUI.Primitives.Concurrency.ISequencer scheduler)
+```
+Observe ping results on a schedule using an async-native observable.
+
+- Parameter `interval`: The interval between pings.
+- Parameter `echo`: True echo result to standard output.
+- Parameter `scheduler`: Optional scheduler for the ping cadence.
+- Returns: Async observable sequence of ping result states, deduplicated.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.ObserveSampledAsyncObservable``1(System.String,System.TimeSpan,``0,System.Int32,ReactiveUI.Primitives.Concurrency.ISequencer)`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<T> ObserveSampledAsyncObservable<T>(string variable, System.TimeSpan sampleInterval, T typeWitness, int bit, ReactiveUI.Primitives.Concurrency.ISequencer scheduler)
+```
+Observe a variable with sampling using an async-native observable.
+
+- Parameter `variable`: The variable to observe.
+- Parameter `sampleInterval`: The sampling interval.
+- Parameter `typeWitness`: Type witness for the requested PLC value type.
+- Parameter `bit`: The bit [ONLY use for bool tags].
+- Parameter `scheduler`: Optional scheduler for sampling.
+- Returns: Async observable sequence of sampled values.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.ObserveSampled``1(System.String,System.TimeSpan,``0,System.Int32,ReactiveUI.Primitives.Concurrency.ISequencer)`
+
+```csharp
+public System.IObservable<T> ObserveSampled<T>(string variable, System.TimeSpan sampleInterval, T typeWitness, int bit, ReactiveUI.Primitives.Concurrency.ISequencer scheduler)
+```
+Observe a variable with sampling, reducing event rate while preserving latest value.
+
+- Parameter `variable`: The variable to observe.
+- Parameter `sampleInterval`: The sampling interval.
+- Parameter `typeWitness`: Type witness for the requested PLC value type.
+- Parameter `bit`: The bit [ONLY use for bool tags].
+- Parameter `scheduler`: Optional scheduler for sampling.
+- Returns: Observable sequence of sampled values.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.Observe``1(System.String,``0,System.Int32)`
+
+```csharp
+public System.IObservable<T> Observe<T>(string variable, T typeWitness, int bit)
+```
+Observes the specified variable.
+
+- Parameter `variable`: The variable.
+- Parameter `typeWitness`: Type witness for the requested PLC value type.
+- Parameter `bit`: The bit.
+- Returns: An observable sequence of values of type T.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.Ping(System.Boolean)`
+
+```csharp
+public bool Ping(bool echo)
+```
+Ping the PLC.
+
+- Parameter `echo`: True echo result to standard output.
+- Returns: True when ping succeeds; otherwise, false.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.PingAsync(System.Boolean,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> PingAsync(bool echo, System.Threading.CancellationToken cancellationToken)
+```
+Ping the PLC asynchronously.
+
+- Parameter `echo`: True echo result to standard output.
+- Parameter `cancellationToken`: A token to cancel the ping operation.
+- Returns: A task producing true when ping succeeds; otherwise, false.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.Read`
+
+```csharp
+public System.Collections.Generic.IEnumerable<IoT.DriverCore.ABPlcRx.PlcTagResult> Read()
+```
+Reads all tags in this instance.
+
+- Returns: A sequence of PlcTagResult.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.Read(System.String)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.PlcTagResult Read(string variable)
+```
+Reads the specified variable.
+
+- Parameter `variable`: The variable.
+- Returns: A PlcTagResult.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.ReadManyAsync(System.Collections.Generic.IReadOnlyCollection`1{System.String},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.ABPlcRx.PlcTagResult>> ReadManyAsync(System.Collections.Generic.IReadOnlyCollection<string> variables, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ReadManyAsync` operation.
+
+- Parameter `variables`: The `variables` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.ABPlcRx.PlcTagResult>>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.ReadValueAsync``1(System.String,``0,System.Int32,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<T>> ReadValueAsync<T>(string variable, T typeWitness, int bit, System.Threading.CancellationToken cancellationToken)
+```
+Reads and converts one logical variable asynchronously.
+
+- Parameter `variable`: The logical variable name.
+- Parameter `typeWitness`: Type witness for the requested PLC value type.
+- Parameter `bit`: The optional integral bit index.
+- Parameter `cancellationToken`: A token to cancel the operation.
+- Returns: The typed operation result.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.RemoveTagItem(System.String)`
+
+```csharp
+public bool RemoveTagItem(string variable)
+```
+Removes a registered tag by logical variable name.
+
+- Parameter `variable`: The logical variable name.
+- Returns: True when a tag was removed.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.Value``1(System.String,``0,System.Int32)`
+
+```csharp
+public void Value<T>(string variable, T value, int bit)
+```
+Values the specified variable.
+
+- Parameter `variable`: The variable.
+- Parameter `value`: The value.
+- Parameter `bit`: The bit.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.Write`
+
+```csharp
+public System.Collections.Generic.IEnumerable<IoT.DriverCore.ABPlcRx.PlcTagResult> Write()
+```
+Writes all tags in this instance.
+
+- Returns: A sequence of PlcTagResult.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.Write(System.String)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.PlcTagResult Write(string variable)
+```
+Writes the specified variable.
+
+- Parameter `variable`: The variable.
+- Returns: A PlcTagResult.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.WriteManyAsync(System.Collections.Generic.IReadOnlyDictionary`2{System.String,System.Object},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.ABPlcRx.PlcTagResult>> WriteManyAsync(System.Collections.Generic.IReadOnlyDictionary<string, object> values, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `WriteManyAsync` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.ABPlcRx.PlcTagResult>>` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.IABPlcRx.WriteValueAsync``1(System.String,``0,System.Int32,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<T>> WriteValueAsync<T>(string variable, T value, int bit, System.Threading.CancellationToken cancellationToken)
+```
+Writes one logical variable asynchronously.
+
+- Parameter `variable`: The logical variable name.
+- Parameter `value`: The value to write.
+- Parameter `bit`: The optional integral bit index.
+- Parameter `cancellationToken`: A token to cancel the operation.
+- Returns: The typed operation result.
+
+###### `P:IoT.DriverCore.ABPlcRx.IABPlcRx.AutoWriteValue`
+
+```csharp
+public bool AutoWriteValue { get; set; }
+```
+Gets or sets a value indicating whether [automatic write value].
+
+- Value: true if [automatic write value]; otherwise, false .
+
+###### `P:IoT.DriverCore.ABPlcRx.IABPlcRx.IsDisposed`
+
+```csharp
+public bool IsDisposed { get; }
+```
+Gets a value indicating whether the object is disposed.
+
+- Value: The `IsDisposed` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.IABPlcRx.ObserveAll`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ABPlcRx.IPlcTag> ObserveAll { get; }
+```
+Gets the observe all.
+
+- Value: The observe all.
+
+###### `P:IoT.DriverCore.ABPlcRx.IABPlcRx.ObserveAllAsyncObservable`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ABPlcRx.IPlcTag> ObserveAllAsyncObservable { get; }
+```
+Gets the asynchronous observe all stream.
+
+- Value: The asynchronous observe all stream.
+
+###### `P:IoT.DriverCore.ABPlcRx.IABPlcRx.ScanEnabled`
+
+```csharp
+public bool ScanEnabled { get; set; }
+```
+Gets or sets a value indicating whether [scan enabled].
+
+- Value: true if [scan enabled]; otherwise, false .
+
+#### `T:IoT.DriverCore.ABPlcRx.IPlcTag`
+
+```csharp
+public interface IoT.DriverCore.ABPlcRx.IPlcTag
+```
+Interface Tag.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ABPlcRx.IPlcTag.Abort`
+
+```csharp
+public int Abort()
+```
+Abort any outstanding IO to the PLC. `T:IoT.DriverCore.ABPlcRx.PlcTagStatus` .
+
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.IPlcTag.GetSize`
+
+```csharp
+public int GetSize()
+```
+Get size tag.
+
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.IPlcTag.GetStatus`
+
+```csharp
+public int GetStatus()
+```
+Get status operation. `T:IoT.DriverCore.ABPlcRx.PlcTagStatus` .
+
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.IPlcTag.Lock`
+
+```csharp
+public int Lock()
+```
+Lock for multitrading. `T:IoT.DriverCore.ABPlcRx.PlcTagStatus` .
+
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.IPlcTag.Read`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.PlcTagResult Read()
+```
+Performs read of Tag.
+
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.IPlcTag.Unlock`
+
+```csharp
+public int Unlock()
+```
+Unlock for multitrading `T:IoT.DriverCore.ABPlcRx.PlcTagStatus` .
+
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.IPlcTag.Write`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.PlcTagResult Write()
+```
+Perform write of Tag.
+
+- Returns: A Value.
+
+###### `P:IoT.DriverCore.ABPlcRx.IPlcTag.Changed`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ABPlcRx.PlcTagResult> Changed { get; }
+```
+Gets the changed.
+
+- Value: The changed.
+
+###### `P:IoT.DriverCore.ABPlcRx.IPlcTag.Handle`
+
+```csharp
+public int Handle { get; }
+```
+Gets handle creation Tag.
+
+- Value: The `Handle` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.IPlcTag.IsRead`
+
+```csharp
+public bool IsRead { get; }
+```
+Gets a value indicating whether indicates whether or not a value must be read from the PLC.
+
+- Value: The `IsRead` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.IPlcTag.IsWrite`
+
+```csharp
+public bool IsWrite { get; }
+```
+Gets a value indicating whether indicates whether or not a value must be write to the PLC.
+
+- Value: The `IsWrite` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.IPlcTag.Length`
+
+```csharp
+public int Length { get; }
+```
+Gets elements length: 1- single, n-array.
+
+- Value: The `Length` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.IPlcTag.ReadOnly`
+
+```csharp
+public bool ReadOnly { get; set; }
+```
+Gets or sets whether the tag is read-only.
+
+- Value: The `ReadOnly` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.IPlcTag.Size`
+
+```csharp
+public int Size { get; }
+```
+Gets the size of an element in bytes. The tag is assumed to be composed of elements of the same size. For structure tags, use the total size of the structure.
+
+- Value: The `Size` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.IPlcTag.TagName`
+
+```csharp
+public string TagName { get; }
+```
+Gets the textual name of the tag to access. The name is anything allowed by the protocol. E.g. myDataStruct.rotationTimer.ACC, myDINTArray[42] etc.
+
+- Value: The `TagName` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.IPlcTag.TypeValue`
+
+```csharp
+public System.Type TypeValue { get; }
+```
+Gets type value.
+
+- Value: The `TypeValue` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.IPlcTag.Value`
+
+```csharp
+public object Value { get; set; }
+```
+Gets or sets value tag.
+
+- Value: The `Value` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.IPlcTag.ValueManager`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.PlcTagWrapper ValueManager { get; }
+```
+Gets value manager.
+
+- Value: The `ValueManager` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.IPlcTag.Variable`
+
+```csharp
+public string Variable { get; }
+```
+Gets the key.
+
+- Value: The key.
+
+#### `T:IoT.DriverCore.ABPlcRx.IPlcTag`1`
+
+```csharp
+public interface IoT.DriverCore.ABPlcRx.IPlcTag`1
+```
+Interface Tag.
+
+##### Declared public members
+
+###### `P:IoT.DriverCore.ABPlcRx.IPlcTag`1.Value`
+
+```csharp
+public TType Value { get; set; }
+```
+Gets or sets the value.
+
+- Value: The value.
+
+#### `T:IoT.DriverCore.ABPlcRx.ObservableAsyncBridgeExtensions`
+
+```csharp
+public class IoT.DriverCore.ABPlcRx.ObservableAsyncBridgeExtensions
+```
+Bridges synchronous observable streams to ReactiveUI.Primitives async observables.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ABPlcRx.ObservableAsyncBridgeExtensions.ToAsyncObservable``1(System.IObservable`1{``0})`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<T> ToAsyncObservable<T>(System.IObservable<T> source)
+```
+Executes the `ToAsyncObservable` operation.
+
+- Parameter `source`: The `source` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<T>` result.
+
+#### `T:IoT.DriverCore.ABPlcRx.PlcTagException`
+
+```csharp
+public class IoT.DriverCore.ABPlcRx.PlcTagException
+```
+Plc Tag Exception.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagException.#ctor`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.PlcTagException()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ABPlcRx.PlcTagException` class.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagException.#ctor(IoT.DriverCore.ABPlcRx.PlcTagResult)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.PlcTagException(IoT.DriverCore.ABPlcRx.PlcTagResult result)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ABPlcRx.PlcTagException` class.
+
+- Parameter `result`: The PLC tag result that caused the exception.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagException.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.PlcTagException(string message)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ABPlcRx.PlcTagException` class.
+
+- Parameter `message`: The exception message.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagException.#ctor(System.String,System.Exception)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.PlcTagException(string message, System.Exception innerException)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ABPlcRx.PlcTagException` class.
+
+- Parameter `message`: The exception message.
+- Parameter `innerException`: The inner exception.
+
+###### `P:IoT.DriverCore.ABPlcRx.PlcTagException.Result`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.PlcTagResult Result { get; }
+```
+Gets result operation.
+
+- Value: ResultOperation.
+
+#### `T:IoT.DriverCore.ABPlcRx.PlcTagResult`
+
+```csharp
+public class IoT.DriverCore.ABPlcRx.PlcTagResult
+```
+Result returned by PLC tag operations.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagResult.Reduce(System.Collections.Generic.IEnumerable`1{IoT.DriverCore.ABPlcRx.PlcTagResult})`
+
+```csharp
+public static IoT.DriverCore.ABPlcRx.PlcTagResult Reduce(System.Collections.Generic.IEnumerable<IoT.DriverCore.ABPlcRx.PlcTagResult> results)
+```
+Executes the `Reduce` operation.
+
+- Parameter `results`: The `results` value.
+- Returns: A `IoT.DriverCore.ABPlcRx.PlcTagResult` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagResult.Reduce(System.Collections.Generic.IEnumerable`1{IoT.DriverCore.ABPlcRx.PlcTagResult},System.TimeProvider)`
+
+```csharp
+public static IoT.DriverCore.ABPlcRx.PlcTagResult Reduce(System.Collections.Generic.IEnumerable<IoT.DriverCore.ABPlcRx.PlcTagResult> results, System.TimeProvider timeProvider)
+```
+Executes the `Reduce` operation.
+
+- Parameter `results`: The `results` value.
+- Parameter `timeProvider`: The `timeProvider` value.
+- Returns: A `IoT.DriverCore.ABPlcRx.PlcTagResult` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagResult.ToString`
+
+```csharp
+public string ToString()
+```
+Information result.
+
+- Returns: A Value.
+
+###### `P:IoT.DriverCore.ABPlcRx.PlcTagResult.ExecutionTime`
+
+```csharp
+public long ExecutionTime { get; }
+```
+Gets millisecond execution operatorion.
+
+- Value: The execution time.
+
+###### `P:IoT.DriverCore.ABPlcRx.PlcTagResult.StatusCode`
+
+```csharp
+public int StatusCode { get; }
+```
+Gets the `T:IoT.DriverCore.ABPlcRx.PlcTagStatus` code; STATUS_OK indicates success.
+
+- Value: The status code.
+
+###### `P:IoT.DriverCore.ABPlcRx.PlcTagResult.Tag`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.IPlcTag Tag { get; }
+```
+Gets tag.
+
+- Value: The tag.
+
+###### `P:IoT.DriverCore.ABPlcRx.PlcTagResult.Timestamp`
+
+```csharp
+public System.DateTimeOffset Timestamp { get; }
+```
+Gets timestamp last operation.
+
+- Value: The timestamp.
+
+#### `T:IoT.DriverCore.ABPlcRx.PlcTagStatus`
+
+```csharp
+public class IoT.DriverCore.ABPlcRx.PlcTagStatus
+```
+Status code operation.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrBadConfig`
+
+```csharp
+public static int ErrBadConfig
+```
+The operation failed due to incorrect remote-system configuration.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrBadConnection`
+
+```csharp
+public static int ErrBadConnection
+```
+The connection failed, for example because the remote PLC was power cycled.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrBadData`
+
+```csharp
+public static int ErrBadData
+```
+The data received from the remote PLC was undecipherable or otherwise not able to be processed. Can also be returned from a remote system that cannot process the data sent to it.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrBadDevice`
+
+```csharp
+public static int ErrBadDevice
+```
+Usually returned from a remote system when something addressed does not exist.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrBadGateway`
+
+```csharp
+public static int ErrBadGateway
+```
+Usually returned when the library is unable to connect to a remote system.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrBadParam`
+
+```csharp
+public static int ErrBadParam
+```
+A common error return when something is not correct with the tag creation attribute string.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrBadReply`
+
+```csharp
+public static int ErrBadReply
+```
+Usually returned when the remote system returned an unexpected response.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrBadStatus`
+
+```csharp
+public static int ErrBadStatus
+```
+Usually returned by a remote system when something is not in a good state.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrClose`
+
+```csharp
+public static int ErrClose
+```
+An error occurred trying to close some resource.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrCreate`
+
+```csharp
+public static int ErrCreate
+```
+An error occurred trying to create some internal resource.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrDuplicate`
+
+```csharp
+public static int ErrDuplicate
+```
+A remote-system error caused by a duplicate value, such as a connection ID.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrEncode`
+
+```csharp
+public static int ErrEncode
+```
+An error was returned when trying to encode some data such as a tag name.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrErrAbort`
+
+```csharp
+public static int ErrErrAbort
+```
+The operation was aborted.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrMutexDestroy`
+
+```csharp
+public static int ErrMutexDestroy
+```
+An internal library error that should be very unusual to see.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrMutexInit`
+
+```csharp
+public static int ErrMutexInit
+```
+An internal library error that should be very unusual to see.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrMutexLock`
+
+```csharp
+public static int ErrMutexLock
+```
+An internal library error that should be very unusual to see.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrMutexUnlock`
+
+```csharp
+public static int ErrMutexUnlock
+```
+An internal library error that should be very unusual to see.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrNoData`
+
+```csharp
+public static int ErrNoData
+```
+Returned when expected data is not present.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrNoMatch`
+
+```csharp
+public static int ErrNoMatch
+```
+Similar to NOT_FOUND.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrNoMem`
+
+```csharp
+public static int ErrNoMem
+```
+Returned by the library when memory allocation fails.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrNoResources`
+
+```csharp
+public static int ErrNoResources
+```
+Returned by the remote system when some resource allocation fails.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrNotAllowed`
+
+```csharp
+public static int ErrNotAllowed
+```
+Often returned from the remote system when an operation is not permitted.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrNotFound`
+
+```csharp
+public static int ErrNotFound
+```
+Often returned from the remote system when something is not found.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrNotImplemented`
+
+```csharp
+public static int ErrNotImplemented
+```
+Returned when a valid operation is not implemented.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrNullPtr`
+
+```csharp
+public static int ErrNullPtr
+```
+An internal error that can also indicate an invalid API handle.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrOpen`
+
+```csharp
+public static int ErrOpen
+```
+Returned when an error occurs opening a resource such as a socket.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrOutOfBounds`
+
+```csharp
+public static int ErrOutOfBounds
+```
+Usually returned when trying to write a value into a tag outside of the tag data bounds.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrRead`
+
+```csharp
+public static int ErrRead
+```
+Returned when an error occurs during a read operation, usually related to socket problems.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrRemoteErr`
+
+```csharp
+public static int ErrRemoteErr
+```
+An unspecified or untranslatable remote error causes this.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrThreadCreate`
+
+```csharp
+public static int ErrThreadCreate
+```
+An internal library error. If you see this, it is likely that everything is about to crash.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrThreadJoin`
+
+```csharp
+public static int ErrThreadJoin
+```
+Another internal library error that should be very unlikely to see.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrTimeout`
+
+```csharp
+public static int ErrTimeout
+```
+An operation took too long and timed out.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrTooLarge`
+
+```csharp
+public static int ErrTooLarge
+```
+More data was returned than was expected.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrTooSmall`
+
+```csharp
+public static int ErrTooSmall
+```
+Insufficient data was returned from the remote system.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrUnsupported`
+
+```csharp
+public static int ErrUnsupported
+```
+The operation is not supported on the remote system.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrWinsock`
+
+```csharp
+public static int ErrWinsock
+```
+A Winsock-specific error occurred (only on Windows).
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.ErrWrite`
+
+```csharp
+public static int ErrWrite
+```
+An error occurred trying to write, usually to a socket.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.StatusOK`
+
+```csharp
+public static int StatusOK
+```
+No error.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcTagStatus.StatusPending`
+
+```csharp
+public static int StatusPending
+```
+Operation in progress. Not an error.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagStatus.DecodeError(System.Int32)`
+
+```csharp
+public static string DecodeError(int code)
+```
+Decode error.
+
+- Parameter `code`: Error code.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagStatus.IsError(System.Int32)`
+
+```csharp
+public static bool IsError(int code)
+```
+Check code in error.
+
+- Parameter `code`: The code.
+- Returns: A Value.
+
+#### `T:IoT.DriverCore.ABPlcRx.PlcTagWrapper`
+
+```csharp
+public class IoT.DriverCore.ABPlcRx.PlcTagWrapper
+```
+Plc Tag Wrapper.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.GetBit(System.Int32)`
+
+```csharp
+public bool GetBit(int index)
+```
+Get bit from index.
+
+- Parameter `index`: The index.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.GetBits`
+
+```csharp
+public System.Collections.BitArray GetBits()
+```
+Get bit array from value.
+
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.GetBitsArray`
+
+```csharp
+public bool[] GetBitsArray()
+```
+Get bit array from value.
+
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.GetBitsString`
+
+```csharp
+public string GetBitsString()
+```
+Get bit string format.
+
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.GetBool(System.Int32)`
+
+```csharp
+public bool GetBool(int offset)
+```
+Get local value Bool.
+
+- Parameter `offset`: The offset.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.GetFloat32(System.Int32)`
+
+```csharp
+public float GetFloat32(int offset)
+```
+Get local value Float32.
+
+- Parameter `offset`: The offset.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.GetFloat64(System.Int32)`
+
+```csharp
+public double GetFloat64(int offset)
+```
+Get local value Float.
+
+- Parameter `offset`: The offset.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.GetInt16(System.Int32)`
+
+```csharp
+public short GetInt16(int offset)
+```
+Get local value Int16.
+
+- Parameter `offset`: The offset.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.GetInt32(System.Int32)`
+
+```csharp
+public int GetInt32(int offset)
+```
+Get local value Int32.
+
+- Parameter `offset`: The offset.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.GetInt64(System.Int32)`
+
+```csharp
+public long GetInt64(int offset)
+```
+Get local value Int64.
+
+- Parameter `offset`: The offset.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.GetInt8(System.Int32)`
+
+```csharp
+public sbyte GetInt8(int offset)
+```
+Get local value Int8.
+
+- Parameter `offset`: The offset.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.GetString(System.Int32)`
+
+```csharp
+public string GetString(int offset)
+```
+Get local value String.
+
+- Parameter `offset`: The offset.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.GetType(System.Object,System.Int32)`
+
+```csharp
+public object GetType(object obj, int offset)
+```
+Get local value form type.
+
+- Parameter `obj`: The object.
+- Parameter `offset`: The offset.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.GetUInt16(System.Int32)`
+
+```csharp
+public ushort GetUInt16(int offset)
+```
+Get local value UInt16.
+
+- Parameter `offset`: The offset.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.GetUInt32(System.Int32)`
+
+```csharp
+public uint GetUInt32(int offset)
+```
+Get local value UInt32.
+
+- Parameter `offset`: The offset.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.GetUInt64(System.Int32)`
+
+```csharp
+public ulong GetUInt64(int offset)
+```
+Get local value UInt64.
+
+- Parameter `offset`: The offset.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.GetUInt8(System.Int32)`
+
+```csharp
+public byte GetUInt8(int offset)
+```
+Get local value UInt8.
+
+- Parameter `offset`: The offset.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.SetBit(System.Int32,System.Boolean)`
+
+```csharp
+public void SetBit(int index, bool value)
+```
+Set bit from index and value.
+
+- Parameter `index`: The index.
+- Parameter `value`: if set to true [value].
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.SetBits(System.Collections.BitArray)`
+
+```csharp
+public void SetBits(System.Collections.BitArray bits)
+```
+Set bits from BitArray.
+
+- Parameter `bits`: The bits.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.SetBool(System.Boolean,System.Int32)`
+
+```csharp
+public void SetBool(bool value, int offset)
+```
+Set local value Bool.
+
+- Parameter `value`: if set to true [value].
+- Parameter `offset`: The offset.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.SetFloat32(System.Single,System.Int32)`
+
+```csharp
+public void SetFloat32(float value, int offset)
+```
+Set local value Float32.
+
+- Parameter `value`: The value.
+- Parameter `offset`: The offset.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.SetFloat64(System.Double,System.Int32)`
+
+```csharp
+public void SetFloat64(double value, int offset)
+```
+Set local value Float.
+
+- Parameter `value`: The value.
+- Parameter `offset`: The offset.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.SetInt16(System.Int16,System.Int32)`
+
+```csharp
+public void SetInt16(short value, int offset)
+```
+Set local value Int16.
+
+- Parameter `value`: The value.
+- Parameter `offset`: The offset.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.SetInt32(System.Int32,System.Int32)`
+
+```csharp
+public void SetInt32(int value, int offset)
+```
+Set local value Int32.
+
+- Parameter `value`: The value.
+- Parameter `offset`: The offset.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.SetInt64(System.Int64,System.Int32)`
+
+```csharp
+public void SetInt64(long value, int offset)
+```
+Set local value Int64.
+
+- Parameter `value`: The value.
+- Parameter `offset`: The offset.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.SetInt8(System.SByte,System.Int32)`
+
+```csharp
+public void SetInt8(sbyte value, int offset)
+```
+Set local value Int8.
+
+- Parameter `value`: The value.
+- Parameter `offset`: The offset.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.SetString(System.String,System.Int32)`
+
+```csharp
+public void SetString(string value, int offset)
+```
+Set local value String.
+
+- Parameter `value`: The value.
+- Parameter `offset`: The offset.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.SetType(System.Object,System.Int32)`
+
+```csharp
+public void SetType(object obj, int offset)
+```
+Set local valute from type.
+
+- Parameter `obj`: The object.
+- Parameter `offset`: The offset.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.SetUInt16(System.UInt16,System.Int32)`
+
+```csharp
+public void SetUInt16(ushort value, int offset)
+```
+Set local value UInt16.
+
+- Parameter `value`: The value.
+- Parameter `offset`: The offset.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.SetUInt32(System.UInt32,System.Int32)`
+
+```csharp
+public void SetUInt32(uint value, int offset)
+```
+Set local value UInt32.
+
+- Parameter `value`: The value.
+- Parameter `offset`: The offset.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.SetUInt64(System.UInt64,System.Int32)`
+
+```csharp
+public void SetUInt64(ulong value, int offset)
+```
+Set local value UInt64.
+
+- Parameter `value`: The value.
+- Parameter `offset`: The offset.
+
+###### `M:IoT.DriverCore.ABPlcRx.PlcTagWrapper.SetUInt8(System.Byte,System.Int32)`
+
+```csharp
+public void SetUInt8(byte value, int offset)
+```
+Set local value UInt8.
+
+- Parameter `value`: The value.
+- Parameter `offset`: The offset.
+
+#### `T:IoT.DriverCore.ABPlcRx.PlcType`
+
+```csharp
+public enum IoT.DriverCore.ABPlcRx.PlcType
+```
+Allen Bradley PLC processor family.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcType.LGX`
+
+```csharp
+public static const IoT.DriverCore.ABPlcRx.PlcType LGX
+```
+ControlLogix / CompactLogix Control Systems.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcType.PLC5`
+
+```csharp
+public static const IoT.DriverCore.ABPlcRx.PlcType PLC5
+```
+PLC-5 Controllers.
+
+###### `F:IoT.DriverCore.ABPlcRx.PlcType.SLC`
+
+```csharp
+public static const IoT.DriverCore.ABPlcRx.PlcType SLC
+```
+SLC / MicroLogix Controller.
+
+#### `T:IoT.DriverCore.ABPlcRx.SourceGeneration.PlcModelAttribute`
+
+```csharp
+public class IoT.DriverCore.ABPlcRx.SourceGeneration.PlcModelAttribute
+```
+Marks a partial type as a PLC reactive stream model.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ABPlcRx.SourceGeneration.PlcModelAttribute.#ctor`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.SourceGeneration.PlcModelAttribute()
+```
+Initializes a new instance of `IoT.DriverCore.ABPlcRx.SourceGeneration.PlcModelAttribute`.
+
+#### `T:IoT.DriverCore.ABPlcRx.SourceGeneration.PlcTagAttribute`
+
+```csharp
+public class IoT.DriverCore.ABPlcRx.SourceGeneration.PlcTagAttribute
+```
+Describes a PLC tag stream that should be generated for a partial model.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ABPlcRx.SourceGeneration.PlcTagAttribute.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.SourceGeneration.PlcTagAttribute(string tagName)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ABPlcRx.SourceGeneration.PlcTagAttribute` class.
+
+- Parameter `tagName`: The PLC tag name.
+
+###### `M:IoT.DriverCore.ABPlcRx.SourceGeneration.PlcTagAttribute.#ctor(System.Type,System.String,System.String)`
+
+```csharp
+public IoT.DriverCore.ABPlcRx.SourceGeneration.PlcTagAttribute(System.Type valueType, string propertyName, string tagName)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ABPlcRx.SourceGeneration.PlcTagAttribute` class.
+
+- Parameter `valueType`: The PLC value type.
+- Parameter `propertyName`: The generated property name.
+- Parameter `tagName`: The PLC tag name.
+
+###### `P:IoT.DriverCore.ABPlcRx.SourceGeneration.PlcTagAttribute.Bit`
+
+```csharp
+public int Bit { get; set; }
+```
+Gets or sets the bit index for boolean bit access.
+
+- Value: The `Bit` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.SourceGeneration.PlcTagAttribute.Group`
+
+```csharp
+public string Group { get; set; }
+```
+Gets or sets the tag group.
+
+- Value: The `Group` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.SourceGeneration.PlcTagAttribute.PropertyName`
+
+```csharp
+public string PropertyName { get; }
+```
+Gets the generated property name when the attribute is applied to a class.
+
+- Value: The `PropertyName` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.SourceGeneration.PlcTagAttribute.RegisterTag`
+
+```csharp
+public bool RegisterTag { get; set; }
+```
+Gets or sets a value indicating whether generated attach logic should register the tag.
+
+- Value: The `RegisterTag` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.SourceGeneration.PlcTagAttribute.TagName`
+
+```csharp
+public string TagName { get; }
+```
+Gets the PLC tag name.
+
+- Value: The `TagName` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.SourceGeneration.PlcTagAttribute.ValueType`
+
+```csharp
+public System.Type ValueType { get; }
+```
+Gets the generated property value type when the attribute is applied to a class.
+
+- Value: The `ValueType` value.
+
+###### `P:IoT.DriverCore.ABPlcRx.SourceGeneration.PlcTagAttribute.Variable`
+
+```csharp
+public string Variable { get; set; }
+```
+Gets or sets the application variable key. Defaults to the property name.
+
+- Value: The `Variable` value.
+
+#### `T:IoT.DriverCore.ABPlcRx.TagHelper`
+
+```csharp
+public class IoT.DriverCore.ABPlcRx.TagHelper
+```
+Helper Tag.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ABPlcRx.TagHelper.BitsToNumber(System.Collections.BitArray)`
+
+```csharp
+public static int BitsToNumber(System.Collections.BitArray bits)
+```
+Bite array to number.
+
+- Parameter `bits`: The bits.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.TagHelper.CreateObject``1(``0,System.Int32)`
+
+```csharp
+public static TType CreateObject<TType>(TType typeWitness, int length)
+```
+Create object from Type.
+
+- Parameter `typeWitness`: Type witness for the requested value.
+- Parameter `length`: The length.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.TagHelper.NumberToBits(System.Int32)`
+
+```csharp
+public static System.Collections.BitArray NumberToBits(int value)
+```
+Number to bit array.
+
+- Parameter `value`: The value.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.TagHelper.ScaleLinear(IoT.DriverCore.ABPlcRx.IPlcTag,System.Double,System.Double,System.Double,System.Double)`
+
+```csharp
+public static double ScaleLinear(IoT.DriverCore.ABPlcRx.IPlcTag tag, double minRaw, double maxRaw, double minScale, double maxScale)
+```
+Performs Linear scaling conversion.
+
+- Parameter `tag`: The tag.
+- Parameter `minRaw`: The minimum raw.
+- Parameter `maxRaw`: The maximum raw.
+- Parameter `minScale`: The minimum scale.
+- Parameter `maxScale`: The maximum scale.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.TagHelper.ScaleSquareRoot(IoT.DriverCore.ABPlcRx.IPlcTag,System.Double,System.Double,System.Double,System.Double)`
+
+```csharp
+public static double ScaleSquareRoot(IoT.DriverCore.ABPlcRx.IPlcTag tag, double minRaw, double maxRaw, double minScale, double maxScale)
+```
+Performs SquareRoot conversion.
+
+- Parameter `tag`: The tag.
+- Parameter `minRaw`: The minimum raw.
+- Parameter `maxRaw`: The maximum raw.
+- Parameter `minScale`: The minimum scale.
+- Parameter `maxScale`: The maximum scale.
+- Returns: A Value.
+
+#### `T:IoT.DriverCore.ABPlcRx.TagMixins`
+
+```csharp
+public class IoT.DriverCore.ABPlcRx.TagMixins
+```
+PLC tag bit helper extensions.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ABPlcRx.TagMixins.GetBit(IoT.DriverCore.ABPlcRx.IPlcTag`1{System.Int16},System.Int32)`
+
+```csharp
+public static bool GetBit(IoT.DriverCore.ABPlcRx.IPlcTag<short> source, int bit)
+```
+Executes the `GetBit` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `bit`: The `bit` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.ABPlcRx.TagMixins.GetBit(System.Int16,System.Int32)`
+
+```csharp
+public static bool GetBit(short source, int bit)
+```
+Gets the bit.
+
+- Parameter `source`: The signed 16-bit source value.
+- Parameter `bit`: The bit.
+- Returns: A bool from the source at bit x.
+
+###### `M:IoT.DriverCore.ABPlcRx.TagMixins.ScaleLinear(IoT.DriverCore.ABPlcRx.IPlcTag,System.Double,System.Double,System.Double,System.Double)`
+
+```csharp
+public static double ScaleLinear(IoT.DriverCore.ABPlcRx.IPlcTag tag, double minRaw, double maxRaw, double minScale, double maxScale)
+```
+Performs Linear scaling conversion.
+
+- Parameter `tag`: The PLC tag.
+- Parameter `minRaw`: The minimum raw.
+- Parameter `maxRaw`: The maximum raw.
+- Parameter `minScale`: The minimum scale.
+- Parameter `maxScale`: The maximum scale.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.TagMixins.ScaleSquareRoot(IoT.DriverCore.ABPlcRx.IPlcTag,System.Double,System.Double,System.Double,System.Double)`
+
+```csharp
+public static double ScaleSquareRoot(IoT.DriverCore.ABPlcRx.IPlcTag tag, double minRaw, double maxRaw, double minScale, double maxScale)
+```
+Performs SquareRoot conversion.
+
+- Parameter `tag`: The PLC tag.
+- Parameter `minRaw`: The minimum raw.
+- Parameter `maxRaw`: The maximum raw.
+- Parameter `minScale`: The minimum scale.
+- Parameter `maxScale`: The maximum scale.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.ABPlcRx.TagMixins.SetBit(IoT.DriverCore.ABPlcRx.IPlcTag`1{System.Int16},System.Int32,System.Boolean)`
+
+```csharp
+public static void SetBit(IoT.DriverCore.ABPlcRx.IPlcTag<short> source, int bit, bool value)
+```
+Executes the `SetBit` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `bit`: The `bit` value.
+- Parameter `value`: The `value` value.
+
+###### `M:IoT.DriverCore.ABPlcRx.TagMixins.SetBit(System.Int16,System.Int32,System.Boolean)`
+
+```csharp
+public static short SetBit(short source, int bit, bool value)
+```
+Sets the bit.
+
+- Parameter `source`: The signed 16-bit source value.
+- Parameter `bit`: The bit.
+- Parameter `value`: if set to true [value].
+- Returns: A short.
+
+<!-- END GENERATED PUBLIC API -->

--- a/packagereadme/MitsubishiRx/README.md
+++ b/packagereadme/MitsubishiRx/README.md
@@ -1,2968 +1,7590 @@
 # MitsubishiRx
 
-<div align="center">
-  <img src="Images/image-icon.png" style="width:25%;" />
-</div>
+## Overview
 
-Reactive Mitsubishi PLC client for **MC Protocol / SLMP** in C# with **ReactiveUI.Primitives**, **ReactiveUI.Primitives.Reactive**, **SerialPortRx**, and **SerialPortRx.Reactive** integration.
+`MitsubishiRx` is an async and observable Mitsubishi MC Protocol / SLMP client. It supports 1E, 3E and 4E Ethernet frames, 1C, 3C and 4C serial frames, TCP, UDP, and serial transports, direct device operations, tag databases, logical tags, polling, and test transports.
 
-This README is the **primary usage guide** for the library. It explains:
-- which PLC families, Ethernet frame types, and serial frame types are supported
-- how to configure TCP/UDP/serial transports, binary/ASCII encodings, serial message formats, and X/Y notation
-- how to use every public feature exposed by the client
-- how to build and import a **tag database** so application code can use **tag names instead of PLC addresses**
-- what CSV format is required to initialize the tag database
+## Safety
 
-## Documentation map
+PLC writes, remote run/stop/reset, password changes, and buffer-memory access can change a live process. Validate addresses and values against the PLC program, start with a simulator or isolated controller, restrict network access, and require an application-level interlock and audit trail before issuing control operations. A successful protocol response is not a safety guarantee.
 
-Use this README as the complete in-repository documentation source:
+## Package matrix
 
-| Need | Start here |
-|---|---|
-| Install and choose package basics | [Install](#install) |
-| Choose between `MitsubishiRx` and `MitsubishiRx.Reactive` | [Package variants](#package-variants) |
-| Select PLC family, frame, transport, data encoding, serial format, or X/Y notation | [Supported PLC families and how to choose settings](#supported-plc-families-and-how-to-choose-settings) |
-| Configure `MitsubishiClientOptions` and `MitsubishiSerialOptions` | [Core configuration](#core-configuration) |
-| Connect, disconnect, and monitor connection state | [Connection lifecycle](#connection-lifecycle) |
-| Use every high-level PLC operation with C# examples | [Feature guide: every public operation](#feature-guide-every-public-operation) |
-| Generate strongly typed tag and group clients | [Generated typed client surface](#generated-typed-client-surface) |
-| Configure symbolic tags, typed helpers, groups, schema files, validation, hot reload, diffs, and rollout policies | [Tag database: use tag names instead of PLC addresses](#tag-database-use-tag-names-instead-of-plc-addresses) |
-| Match APIs to PLC families and endpoint types | [PLC-family-specific usage guidance](#plc-family-specific-usage-guidance) |
-| Find concise feature-to-method mapping | [Feature-to-API quick map](#feature-to-api-quick-map) |
-| Look up signatures, return types, models, enums, constants, advanced extension points, and generated APIs | [Complete API reference](#complete-api-reference) |
-| Diagnose common setup and communication problems | [Troubleshooting notes](#troubleshooting-notes) |
+| Package | Namespace | Target frameworks | Use it when |
+| --- | --- | --- | --- |
+| `MitsubishiRx` | `IoT.DriverCore.MitsubishiRx` | net8.0, net9.0, net10.0, net11.0 | Using ReactiveUI.Primitives and SerialPortRx. |
+| `MitsubishiRx.Reactive` | `IoT.DriverCore.MitsubishiRx.Reactive` | net8.0, net9.0, net10.0, net11.0 | Using the ReactiveUI.Primitives reactive bridge and SerialPortRx.Reactive. |
+| `MitsubishiRx.Generators` | generated code targets `IoT.DriverCore.MitsubishiRx` | analyzer targets supplied by the compiler | Installing the analyzer alongside `MitsubishiRx`, or pinning its analyzer version deliberately. |
 
----
+The runtime packages compile shared source under different namespaces. Do not reference both in one application unless the distinction is intentional. Both runtime packages carry the analyzer, but the current generator emits clients for `IoT.DriverCore.MitsubishiRx` and requires the base `MitsubishiRx` runtime. Use the handwritten tag, polling, and write APIs in a `MitsubishiRx.Reactive`-only application.
 
 ## Install
 
 ```bash
 dotnet add package MitsubishiRx
-```
-
-Use the `MitsubishiRx.Reactive` package when the consuming application is already using the `ReactiveUI.Primitives.Reactive` package family and wants the same Mitsubishi PLC API surface compiled against the reactive bridge packages:
-
-```bash
+# or, for the reactive namespace
 dotnet add package MitsubishiRx.Reactive
+# Optional: the runtime packages already embed this analyzer.
+dotnet add package MitsubishiRx.Generators
 ```
 
-Do not reference both packages from the same project unless you intentionally want both namespaces. They expose the same client type names under different namespaces.
+## Quick start
 
----
-
-## Package variants
-
-`MitsubishiRx` and `MitsubishiRx.Reactive` are built from the same source code. The reactive package is a linked-source shim that defines `REACTIVE_SHIM`, changes the public namespace to `MitsubishiRx.Reactive`, and swaps the project-level using aliases to the `ReactiveUI.Primitives.Reactive` and `SerialPortRx.Reactive` package families.
-
-| Package | Namespace | Target frameworks | Reactive package family | Serial package | Best fit |
-|---|---|---|---|---|---|
-| `MitsubishiRx` | `MitsubishiRx` | `net8.0`, `net9.0`, `net10.0`, `net11.0` | `ReactiveUI.Primitives`, `ReactiveUI.Primitives.Async`, `ReactiveUI.Primitives.Extensions` | `SerialPortRx` | Default package for applications using the lean ReactiveUI.Primitives stack. |
-| `MitsubishiRx.Reactive` | `MitsubishiRx.Reactive` | `net8.0`, `net9.0`, `net10.0`, `net11.0` | `ReactiveUI.Primitives.Reactive`, `ReactiveUI.Primitives.Extensions.Reactive` | `SerialPortRx.Reactive` | Applications using the System.Reactive-backed ReactiveUI.Primitives reactive bridge packages. |
-
-The API concepts are intentionally the same across both packages:
-
-| Concept | `MitsubishiRx` type | `MitsubishiRx.Reactive` type |
-|---|---|---|
-| Client | `MitsubishiRx.MitsubishiRx` | `MitsubishiRx.Reactive.MitsubishiRx` |
-| Options | `MitsubishiRx.MitsubishiClientOptions` | `MitsubishiRx.Reactive.MitsubishiClientOptions` |
-| Tag database | `MitsubishiRx.MitsubishiTagDatabase` | `MitsubishiRx.Reactive.MitsubishiTagDatabase` |
-| Response envelope | `MitsubishiRx.Responce<T>` | `MitsubishiRx.Reactive.Responce<T>` |
-| Reactive value envelope | `MitsubishiRx.MitsubishiReactiveValue<T>` | `MitsubishiRx.Reactive.MitsubishiReactiveValue<T>` |
-| Write pipeline | `MitsubishiRx.MitsubishiReactiveWritePipeline<TPayload>` | `MitsubishiRx.Reactive.MitsubishiReactiveWritePipeline<TPayload>` |
-| Custom transport | `MitsubishiRx.IMitsubishiTransport` | `MitsubishiRx.Reactive.IMitsubishiTransport` |
-
-Every feature shown in this README works with both packages unless a section explicitly calls out the source generator. The generated typed client currently emits the base `MitsubishiRx` namespace, so use the runtime tag, group, polling, and write-pipeline APIs for `MitsubishiRx.Reactive` projects.
-
-### Same feature, different namespace
-
-Most code changes are limited to the namespace import and the fully qualified client name when you need one.
+The primary constructor takes options, an optional transport (useful for tests), and an optional scheduler. Calls return `Responce` / `Responce<T>`; check `IsSucceed` before using `Value`.
 
 ```csharp
-using MitsubishiRx;
+using IoT.DriverCore.MitsubishiRx;
 
 var options = new MitsubishiClientOptions(
-    Host: "192.168.0.10",
-    Port: 5000,
-    FrameType: MitsubishiFrameType.ThreeE,
-    DataCode: CommunicationDataCode.Binary,
-    TransportKind: MitsubishiTransportKind.Tcp);
-
-await using var client = new MitsubishiRx.MitsubishiRx(options);
-var words = await client.ReadWordsAsync("D100", 2);
-```
-
-Reactive package equivalent:
-
-```csharp
-using MitsubishiRx.Reactive;
-
-var options = new MitsubishiClientOptions(
-    Host: "192.168.0.10",
-    Port: 5000,
-    FrameType: MitsubishiFrameType.ThreeE,
-    DataCode: CommunicationDataCode.Binary,
-    TransportKind: MitsubishiTransportKind.Tcp);
-
-await using var client = new MitsubishiRx.Reactive.MitsubishiRx(options);
-var words = await client.ReadWordsAsync("D100", 2);
-```
-
-### Reactive package scheduler and trigger types
-
-Both packages expose `IObservable<T>` APIs. The project files use using aliases so the shared source stays the same, but the compiled scheduler and unit trigger types differ by package:
-
-| API concept | `MitsubishiRx` | `MitsubishiRx.Reactive` |
-|---|---|---|
-| Scheduler constructor parameter | `ReactiveUI.Primitives.Concurrency.ISequencer` | `System.Reactive.Concurrency.IScheduler` |
-| Default scheduler | `ReactiveUI.Primitives.Concurrency.Sequencer.Default` | `System.Reactive.Concurrency.Scheduler.Default` |
-| Trigger unit for `ObserveWordsLatest` / `ObserveTagGroupLatest` | `ReactiveUI.Primitives.RxVoid` | `System.Reactive.Unit` |
-| Observable factories used by implementation | `ReactiveUI.Primitives.Signals.Signal` | `System.Reactive.Linq.Observable` |
-| Disposable factory used by implementation | `ReactiveUI.Primitives.Disposables.Scope` | `System.Reactive.Disposables.Disposable` |
-
-Reactive package trigger example:
-
-```csharp
-using MitsubishiRx.Reactive;
-using System.Reactive.Linq;
-
-IObservable<System.Reactive.Unit> trigger =
-    Observable.Interval(TimeSpan.FromSeconds(5)).Select(_ => System.Reactive.Unit.Default);
-
-await using var client = new MitsubishiRx.Reactive.MitsubishiRx(options);
-
-using var latest = client.ObserveWordsLatest("D100", 2, trigger)
-    .Subscribe(result =>
-    {
-        if (result.IsSucceed)
-        {
-            Console.WriteLine(string.Join(", ", result.Value!));
-        }
-    });
-```
-
----
-
-## What this library provides
-
-MitsubishiRx was refactored from a low-level socket wrapper into a protocol-aware Mitsubishi PLC client that:
-
-- supports **1E**, **3E**, and **4E** Ethernet frame families
-- supports **1C**, **3C**, and **4C** serial frame families
-- supports **TCP**, **UDP**, and reactive **serial** transports
-- uses **SerialPortRx** or **SerialPortRx.Reactive** for reactive serial communications, depending on the selected package
-- supports **binary** and **ASCII** MC Protocol / SLMP packet encodings
-- supports direct device addressing and symbolic **tag-name-based** access
-- exposes high-level async APIs for reads, writes, remote control, monitor, block, random, loopback, memory, and diagnostics operations
-- exposes **ReactiveUI.Primitives**- or **ReactiveUI.Primitives.Reactive**-based polling and health streams for reactive applications
-- includes **TUnit** tests running on **Microsoft Testing Platform**
-
----
-
-## Supported PLC families and how to choose settings
-
-The library now covers Mitsubishi **Ethernet and serial MC protocol paths**. Ethernet support remains the broadest and deepest implementation.
-Serial support is now integrated through **SerialPortRx** and currently provides the first verified reactive serial path.
-
-### Supported family guidance
-
-| PLC family / endpoint type | Typical frame | Transport | Notes |
-|---|---|---|---|
-| **A / AnS** with legacy Ethernet interfaces | **1E** | TCP/UDP | Use when the target only exposes legacy A-compatible MC protocol behavior. |
-| **QnA-compatible Ethernet endpoints** | **3E** | TCP/UDP | Default modern choice for most Q/QnA-compatible MC protocol use. |
-| **Q / L / iQ-R / iQ-F / FX5** with modern SLMP/MC protocol endpoints | **3E** or **4E** | TCP/UDP | 3E is the normal first choice. 4E is used when serial correlation is required. |
-| **FX3 compatibility paths** | **1E** or **3E** depending on module/path | TCP/UDP | Use the path documented for the installed Ethernet interface or gateway. |
-| **FX3 / A-compatible serial computer-link style paths** | **1C** | Serial | Use for installed bases exposing serial MC / computer link compatible message structures. |
-| **QnA-compatible serial modules** | **3C** | Serial | ASCII serial MC protocol path. |
-| **QnA-compatible serial modules with extended access** | **4C** | Serial | ASCII or binary serial MC protocol path, depending on configured format. |
-
-### Transport selection
-
-| Transport | When to use |
-|---|---|
-| `MitsubishiTransportKind.Tcp` | Default choice for most PLC integrations. Use when you want connection-oriented request/response behavior. |
-| `MitsubishiTransportKind.Udp` | Use when the target is configured for UDP SLMP/MC protocol and you want datagram-style communication. |
-| `MitsubishiTransportKind.Serial` | Use for RS-232/RS-422/RS-485 MC protocol communication. The library uses **SerialPortRx** to provide the reactive serial transport implementation. |
-
-### Data encoding selection
-
-| Encoding | When to use |
-|---|---|
-| `CommunicationDataCode.Binary` | Default for most applications. Smaller frames and simpler payload handling. Required for `4C` serial format 5. |
-| `CommunicationDataCode.Ascii` | Use when the target requires ASCII MC protocol / SLMP or when matching existing ASCII integrations. Required for `1C` and `3C`. |
-
-### Serial message format selection
-
-Serial MC protocol communication also depends on the serial **message format** configured on the PLC/module side.
-
-| Serial message format | Meaning | Typical use |
-|---|---|---|
-| `MitsubishiSerialMessageFormat.Format1` | ASCII serial framing with ENQ/STX/ACK/NAK control characters | Legacy 1C/3C/4C serial ASCII integrations |
-| `MitsubishiSerialMessageFormat.Format4` | ASCII serial framing with CR/LF delimiters | Serial endpoints configured for CR/LF terminated MC protocol |
-| `MitsubishiSerialMessageFormat.Format5` | Binary serial framing using DLE/STX/ETX | `4C` binary serial communication |
-
-### X/Y addressing notation
-
-Mitsubishi `X` and `Y` device addressing is module/family dependent. The client makes that explicit.
-
-| Setting | Meaning |
-|---|---|
-| `XyAddressNotation.Octal` | Interpret `X10` as octal `8`. This is common for classic Mitsubishi behavior. |
-| `XyAddressNotation.Hexadecimal` | Interpret `X10` as hexadecimal `16`. Use when the Ethernet path/module is documented that way. |
-
----
-
-## Core configuration
-
-All communication starts from `MitsubishiClientOptions`.
-
-```csharp
-using MitsubishiRx;
-
-var options = new MitsubishiClientOptions(
-    Host: "192.168.0.10",
-    Port: 5000,
+    Host: "192.168.0.10", Port: 5000,
     FrameType: MitsubishiFrameType.ThreeE,
     DataCode: CommunicationDataCode.Binary,
     TransportKind: MitsubishiTransportKind.Tcp,
-    Route: MitsubishiRoute.Default,
-    MonitoringTimer: 0x0010,
-    Timeout: TimeSpan.FromSeconds(4),
-    CpuType: CpuType.None,
-    XyNotation: XyAddressNotation.Octal);
+    Timeout: TimeSpan.FromSeconds(3));
+
+await using var plc = new MitsubishiRx(options, transport: null, scheduler: null);
+var opened = await plc.OpenAsync(CancellationToken.None);
+if (!opened.IsSucceed) throw new InvalidOperationException(opened.Err);
+
+var read = await plc.ReadWordsAsync("D100", 2, CancellationToken.None);
+if (read.IsSucceed && read.Value is { } words)
+    Console.WriteLine($"D100={words[0]}");
+
+var written = await plc.WriteWordsAsync("D100", new ushort[] { 42 }, CancellationToken.None);
+if (!written.IsSucceed) Console.Error.WriteLine(written.Err);
 ```
 
-### Option reference
+## Configuration
 
-| Option | Meaning |
-|---|---|
-| `Host` | PLC IP address / DNS name for Ethernet, or serial port name such as `COM3` when using serial transport |
-| `Port` | Ethernet port exposed by the PLC/module. Use `0` for serial transport. |
-| `FrameType` | `OneE`, `ThreeE`, `FourE`, `OneC`, `ThreeC`, or `FourC` |
-| `DataCode` | `Binary` or `Ascii` |
-| `TransportKind` | `Tcp`, `Udp`, or `Serial` |
-| `Route` | SLMP route metadata for 3E/4E |
-| `MonitoringTimer` | PLC-side monitoring timer in 250 ms units |
-| `Timeout` | Client-side transport timeout |
-| `CpuType` | Optional family hint |
-| `XyNotation` | Octal or hexadecimal parsing for `X`/`Y` |
-| `LegacyPcNumber` | 1E PC number |
-| `SerialNumberProvider` | 4E serial number generator |
-| `Serial` | `MitsubishiSerialOptions` describing the serial port and serial MC protocol framing |
+`MitsubishiClientOptions` records the endpoint and framing. Use 3E/binary/TCP as the normal starting point; select the actual PLC/module configuration rather than inferring it from a CPU family.
 
-### Serial transport configuration
-
-When using serial MC protocol communication, populate the `Serial` option and set `TransportKind.Serial`.
+| Setting | Notes |
+| --- | --- |
+| `FrameType` | `OneE`, `ThreeE`, `FourE`, `OneC`, `ThreeC`, `FourC`. |
+| `DataCode` | `Binary` or `Ascii`; 1C/3C are ASCII serial paths and format 5 is binary 4C. |
+| `TransportKind` | `Tcp`, `Udp`, or `Serial`. |
+| `Route`, `MonitoringTimer`, `LegacyPcNumber`, `SerialNumberProvider` | Ethernet/SLMP route and frame metadata. `ResolvedRoute` defaults to `MitsubishiRoute.Default`. |
+| `Timeout`, `CpuType`, `XyNotation` | Client timeout, optional family hint, and X/Y octal/hexadecimal interpretation. |
+| `Serial` | Required when `TransportKind.Serial`; configure `MitsubishiSerialOptions` with port parameters, message format, routing, station and buffer settings. |
 
 ```csharp
-using MitsubishiRx;
 using System.IO.Ports;
+using IoT.DriverCore.MitsubishiRx;
 
-var serialOptions = new MitsubishiClientOptions(
-    Host: "COM3",
-    Port: 0,
-    FrameType: MitsubishiFrameType.FourC,
-    DataCode: CommunicationDataCode.Binary,
-    TransportKind: MitsubishiTransportKind.Serial,
-    Timeout: TimeSpan.FromSeconds(2),
-    CpuType: CpuType.Fx5,
+var serial = new MitsubishiClientOptions(
+    "COM3", 0, MitsubishiFrameType.FourC, CommunicationDataCode.Binary,
+    MitsubishiTransportKind.Serial,
     Serial: new MitsubishiSerialOptions(
-        PortName: "COM3",
-        BaudRate: 9600,
-        DataBits: 7,
-        Parity: Parity.Even,
-        StopBits: StopBits.One,
-        Handshake: Handshake.None,
-        MessageFormat: MitsubishiSerialMessageFormat.Format5,
-        StationNumber: 0x00,
-        NetworkNumber: 0x00,
-        PcNumber: 0xFF,
-        RequestDestinationModuleIoNumber: 0x03FF,
-        RequestDestinationModuleStationNumber: 0x00,
-        SelfStationNumber: 0x00,
-        MessageWait: 0x00));
-```
-
-### Serial option reference
-
-| Serial option | Meaning |
-|---|---|
-| `PortName` | Serial port name, such as `COM3` |
-| `BaudRate` | Configured baud rate |
-| `DataBits` | Configured data bits |
-| `Parity` | Configured serial parity |
-| `StopBits` | Configured stop bits |
-| `Handshake` | Configured hardware/software flow control |
-| `MessageFormat` | Serial MC message format: `Format1`, `Format4`, or `Format5` |
-| `StationNumber` | Target station number |
-| `NetworkNumber` | Target network number for `3C/4C` |
-| `PcNumber` | Target PC number |
-| `RequestDestinationModuleIoNumber` | Request destination module I/O number for `4C` routing |
-| `RequestDestinationModuleStationNumber` | Request destination module station number for `4C` routing |
-| `SelfStationNumber` | Self-station number for multidrop layouts |
-| `MessageWait` | Serial message wait in 10 ms units |
-| `ReadBufferSize` / `WriteBufferSize` | Serial driver buffer sizing |
-| `NewLine` | Newline sequence used by line-oriented serial modes |
-
-### Default route
-
-For direct own-station CPU access:
-
-```csharp
-var route = MitsubishiRoute.Default;
-```
-
-For routed access, supply explicit route values:
-
-```csharp
-var route = new MitsubishiRoute(
-    NetworkNumber: 0x00,
-    StationNumber: 0xFF,
-    ModuleIoNumber: 0x03FF,
-    MultidropStationNumber: 0x00);
-```
-
----
-
-## Creating the client
-
-```csharp
-using MitsubishiRx;
-
-await using var client = new MitsubishiRx.MitsubishiRx(options);
-```
-
-### Legacy constructor
-
-A compatibility constructor is also available:
-
-```csharp
-var client = new MitsubishiRx.MitsubishiRx(CpuType.QnA, "192.168.0.10", 5000, timeout: 1500);
-```
-
----
-
-## Connection lifecycle
-
-### Open / close
-
-```csharp
-var open = await client.OpenAsync();
-if (!open.IsSucceed)
-{
-    Console.WriteLine(open.Err);
-}
-
-var close = await client.CloseAsync();
-```
-
-Synchronous wrappers are also available:
-
-```csharp
-var openSync = client.Open();
-var closeSync = client.Close();
-```
-
-### Connection state stream
-
-```csharp
-using var states = client.ConnectionStates.Subscribe(state =>
-{
-    Console.WriteLine($"Connection state: {state}");
-});
-```
-
-Possible values:
-- `Disconnected`
-- `Connecting`
-- `Connected`
-- `Reconnecting`
-- `Faulted`
-
----
-
-## Feature guide: every public operation
-
-The sections below map directly to the client’s public API.
-
----
-
-## 1. Batch word reads and writes
-
-### Read words by PLC address
-
-```csharp
-var result = await client.ReadWordsAsync("D100", 2);
-if (result.IsSucceed)
-{
-    ushort d100 = result.Value![0];
-    ushort d101 = result.Value[1];
-}
-```
-
-### Read words over serial MC protocol
-
-```csharp
-using MitsubishiRx;
-using System.IO.Ports;
-
-var serialOptions = new MitsubishiClientOptions(
-    Host: "COM3",
-    Port: 0,
-    FrameType: MitsubishiFrameType.FourC,
-    DataCode: CommunicationDataCode.Binary,
-    TransportKind: MitsubishiTransportKind.Serial,
-    Timeout: TimeSpan.FromSeconds(2),
-    CpuType: CpuType.Fx5,
-    Serial: new MitsubishiSerialOptions(
-        PortName: "COM3",
-        BaudRate: 9600,
-        DataBits: 7,
-        Parity: Parity.Even,
-        StopBits: StopBits.One,
-        Handshake: Handshake.None,
+        PortName: "COM3", BaudRate: 9600, DataBits: 7,
+        Parity: Parity.Even, StopBits: StopBits.One, Handshake: Handshake.None,
         MessageFormat: MitsubishiSerialMessageFormat.Format5));
-
-await using var serialClient = new MitsubishiRx.MitsubishiRx(serialOptions);
-var serialRead = await serialClient.ReadWordsAsync("D100", 2);
 ```
 
-### Write words by PLC address
+## Detailed features
+
+### Response, errors, cancellation, and lifetime
+
+Every command has an asynchronous form and returns `Responce` (the established public spelling) or `Responce<T>`. A protocol rejection, transport exception, timeout, or conversion error is represented by `IsSucceed == false`, `Err`, `ErrList`, and, where applicable, `Exception`; it is not normally thrown from a command. Argument validation and use after disposal can still throw. Always pass a cancellation token, test the response before reading `Value`, and dispose the client after subscriptions have been disposed. `Open`/`Close` are synchronous convenience wrappers; prefer `OpenAsync`/`CloseAsync` on a server or UI thread.
 
 ```csharp
-var write = await client.WriteWordsAsync("D100", new ushort[] { 123, 456, 789 });
-```
-
-### When to use
-- data registers like `D`, `W`, `R`, `ZR`
-- word-based timer/counter values like `TN`, `CN`, `SD`
-- bulk register transfers
-
-### PLC family guidance
-- **1E**: use for legacy-compatible batch device operations over Ethernet
-- **3E/4E**: preferred path for modern Ethernet PLCs
-- **1C/3C/4C**: use when the installed connection is serial MC protocol rather than Ethernet
-
-### Serial support status
-
-Current serial implementation status:
-
-| Serial area | Status |
-|---|---|
-| Reactive serial transport via `SerialPortRx` | **Implemented** |
-| Serial frame modeling (`1C`, `3C`, `4C`) | **Implemented** |
-| Serial option/configuration surface | **Implemented** |
-| Batch word read over serial | **Implemented** |
-| Batch word write over serial | **Implemented** |
-| Batch bit read over serial | **Implemented** |
-| Batch bit write over serial | **Implemented** |
-| Random word read over serial | **Implemented for `1C`, `3C`, and `4C`** |
-| Random word write over serial | **Implemented for `1C`, `3C`, and `4C`** |
-| `1C` ASCII format 1/4 decode path | **Implemented** |
-| `3C` ASCII format 1/4 decode path | **Implemented** |
-| `4C` ASCII and binary format 5 decode path | **Implemented** |
-| Serial block read/write | **Implemented for `1C`, `3C`, and `4C`** |
-| Serial monitor registration/execution | **Implemented for `1C`, `3C`, and `4C`** |
-| Serial remote control commands | **Implemented for `1C`, `3C`, and `4C`** |
-| Serial type-name read | **Implemented for `1C`, tested `3C` ASCII, and `4C` format 5** |
-| Serial loopback | **Implemented for `1C`, tested `3C` ASCII, and `4C` format 5** |
-| Serial memory / extend-unit read-write | **Implemented for `1C`, tested `3C` ASCII, and `4C` format 5** |
-| Raw serial command execution | **Implemented for `1C`, tested `3C` ASCII, and `4C` format 5** |
-
----
-
-## 2. Batch bit reads and writes
-
-### Read bits by PLC address
-
-```csharp
-var bits = await client.ReadBitsAsync("M10", 8);
-if (bits.IsSucceed)
+static async Task<T> Require<T>(Task<Responce<T>> request)
 {
-    bool m10 = bits.Value![0];
-    bool m11 = bits.Value[1];
+    var result = await request.ConfigureAwait(false);
+    if (!result.IsSucceed)
+        throw new InvalidOperationException(result.Err, result.Exception);
+    return result.Value!;
 }
+
+using var stop = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+await using var plc = new MitsubishiRx(options, transport: null, scheduler: null);
+var opened = await plc.OpenAsync(stop.Token);
+if (!opened.IsSucceed) return;             // report opened.Err / opened.ErrList
+ushort[] words = await Require(plc.ReadWordsAsync("D100", 4, stop.Token));
+await plc.CloseAsync(CancellationToken.None);
 ```
 
-### Write bits by PLC address
+`ConnectionStates` publishes `Disconnected`, connecting/connected and fault states; `OperationLogs` contains the operation description, request/response bytes, success and exception. Subscribe before `OpenAsync` if startup telemetry matters, redact raw frames if they can contain sensitive payloads, and dispose the subscriptions before the client.
 
 ```csharp
-var writeBits = await client.WriteBitsAsync("M10", new[] { true, false, true, true });
-```
-
-### Common device examples
-- `M` internal relays
-- `X` inputs
-- `Y` outputs
-- `L`, `SM`, `TS`, `TC`, `CS`, `CC`
-
-### X/Y notation example
-
-```csharp
-var octalOptions = options with { XyNotation = XyAddressNotation.Octal };
-var hexOptions = options with { XyNotation = XyAddressNotation.Hexadecimal };
-```
-
----
-
-## 3. Random reads and writes
-
-Use random operations when you need non-contiguous word devices.
-
-### Random read words
-
-```csharp
-var randomRead = await client.RandomReadWordsAsync(new[]
+using var state = plc.ConnectionStates.Subscribe(s => Console.WriteLine($"PLC: {s}"));
+using var log = plc.OperationLogs.Subscribe(entry =>
 {
-    "D100",
-    "D250",
-    "W10",
-    "ZR200",
+    if (!entry.Success) Console.Error.WriteLine(entry.Description);
 });
 ```
 
-### Random write words
+### Addressing, device values, and batch operations
+
+`MitsubishiDeviceAddress.Parse(address, xyNotation)` is the parser used by the client. Device prefixes such as `D`, `M`, `X`, `Y`, `W`, `B`, `R`, `ZR`, and `TN` must match the PLC/program. `XyAddressNotation` chooses how X/Y suffixes are interpreted; retain the PLC's configured octal/hex convention. `ReadWordsAsync`/`WriteWordsAsync` read contiguous 16-bit device units, while `ReadBitsAsync`/`WriteBitsAsync` read contiguous bit units. The supplied count or list length is part of the protocol request, so never accidentally write a larger buffer than the designed tag region.
 
 ```csharp
-var randomWrite = await client.RandomWriteWordsAsync(new Dictionary<string, ushort>
+var address = MitsubishiDeviceAddress.Parse("D200", XyAddressNotation.Octal);
+var before = await plc.ReadWordsAsync("D200", points: 3, cancellationToken: CancellationToken.None);
+if (before.IsSucceed)
 {
-    ["D100"] = 100,
-    ["D250"] = 250,
-    ["W10"] = 0x1234,
-});
-```
-
-### Best fit
-- sparse register collection
-- HMI/status pages pulling scattered registers
-- writing a small set of independent values without multiple round-trips
-
----
-
-## 4. Monitor registration and monitor execution
-
-Monitoring is a two-stage operation.
-
-### Register monitor devices
-
-```csharp
-var register = await client.RegisterMonitorAsync(new[]
-{
-    "D100",
-    "D101",
-    "D102",
-});
-```
-
-### Execute monitor
-
-```csharp
-var monitor = await client.ExecuteMonitorAsync();
-if (monitor.IsSucceed)
-{
-    byte[] rawMonitorPayload = monitor.Value!;
-}
-```
-
-### Best fit
-- repeated observation of a fixed register list
-- lightweight monitoring loops coordinated by your application
-
----
-
-## 5. Multiple block read and write
-
-Use block operations when you want grouped contiguous word and/or bit blocks.
-
-### Read blocks
-
-```csharp
-var blockRequest = new MitsubishiBlockRequest(
-    WordBlocks:
-    [
-        new MitsubishiWordBlock(MitsubishiDeviceAddress.Parse("D100"), new ushort[10]),
-        new MitsubishiWordBlock(MitsubishiDeviceAddress.Parse("W20", XyAddressNotation.Octal), new ushort[4]),
-    ],
-    BitBlocks:
-    [
-        new MitsubishiBitBlock(MitsubishiDeviceAddress.Parse("M10"), new bool[16]),
-    ]);
-
-var blockRead = await client.ReadBlocksAsync(blockRequest);
-```
-
-### Write blocks
-
-```csharp
-var writeRequest = new MitsubishiBlockRequest(
-    WordBlocks:
-    [
-        new MitsubishiWordBlock(MitsubishiDeviceAddress.Parse("D100"), new ushort[] { 1, 2, 3, 4 }),
-    ],
-    BitBlocks:
-    [
-        new MitsubishiBitBlock(MitsubishiDeviceAddress.Parse("M10"), new[] { true, false, true, false }),
-    ]);
-
-var blockWrite = await client.WriteBlocksAsync(writeRequest);
-```
-
-### Best fit
-- grouped transfer plans
-- deterministic read/write structures
-- coalesced data exchange where address continuity matters
-
----
-
-## 6. PLC type-name read
-
-```csharp
-var typeName = await client.ReadTypeNameAsync();
-if (typeName.IsSucceed)
-{
-    Console.WriteLine(typeName.Value!.ModelName);
-    Console.WriteLine(typeName.Value.ModelCode);
-}
-```
-
-### Best fit
-- startup diagnostics
-- logging exact connected PLC/module type
-- validation that the integration is pointing at the expected target
-
----
-
-## 7. Remote control operations
-
-### Remote RUN
-
-```csharp
-await client.RemoteRunAsync(force: true, clearMode: false);
-```
-
-### Remote STOP / PAUSE / RESET / LATCH CLEAR
-
-```csharp
-await client.RemoteStopAsync();
-await client.RemotePauseAsync();
-await client.RemoteResetAsync();
-await client.RemoteLatchClearAsync();
-```
-
-### Notes
-- available behavior depends on PLC family, CPU mode, permissions, and Ethernet module configuration
-- use carefully in production systems
-
----
-
-## 8. Remote password unlock / lock
-
-```csharp
-await client.UnlockAsync("1234");
-await client.LockAsync("1234");
-```
-
-### Best fit
-- workflows where protected remote operations must be explicitly unlocked
-
----
-
-## 9. Clear error
-
-```csharp
-var clear = await client.ClearErrorAsync();
-```
-
-### Best fit
-- acknowledging module/PLC error conditions after diagnostic handling
-
----
-
-## 10. Loopback
-
-```csharp
-var loop = await client.LoopbackAsync(new byte[] { 0x12, 0x34, 0x56, 0x78 });
-if (loop.IsSucceed)
-{
-    var echoed = loop.Value!;
-}
-```
-
-### Best fit
-- link validation
-- protocol path smoke tests
-- troubleshooting Ethernet routes or gateway behavior
-
----
-
-## 11. Memory read / write and intelligent-module access
-
-These methods expose raw memory/buffer style commands.
-
-### Memory read
-
-```csharp
-var memory = await client.ReadMemoryAsync(MitsubishiCommands.MemoryRead, address: 0x2000, length: 4);
-```
-
-### Memory write
-
-```csharp
-var memoryWrite = await client.WriteMemoryAsync(MitsubishiCommands.MemoryWrite, address: 0x2000, values: new ushort[] { 1, 2, 3, 4 });
-```
-
-### Extend unit read/write
-
-```csharp
-var unitRead = await client.ReadMemoryAsync(MitsubishiCommands.ExtendUnitRead, address: 0x0100, length: 8);
-var unitWrite = await client.WriteMemoryAsync(MitsubishiCommands.ExtendUnitWrite, address: 0x0100, values: new ushort[] { 10, 20, 30 });
-```
-
-### Best fit
-- intelligent function module buffer memory access
-- lower-level system data exchange where documented by Mitsubishi manuals
-
----
-
-## 12. Raw command execution
-
-For advanced or unsupported workflows, execute a raw request.
-
-```csharp
-var raw = await client.ExecuteRawAsync(
-    new MitsubishiRawCommandRequest(
-        Command: MitsubishiCommands.DeviceRead,
-        Subcommand: 0x0000,
-        Body: Array.Empty<byte>(),
-        Description: "Custom raw op"));
-```
-
-### Best fit
-- experimental protocol work
-- custom command shapes
-- validating edge-case protocol scenarios
-
----
-
-## 13. Reactive polling and diagnostics
-
-Reactive features are built with **ReactiveUI.Primitives**.
-
-### Observe words
-
-```csharp
-using var subscription = client
-    .ObserveWords("D100", 2, TimeSpan.FromSeconds(1))
-    .Subscribe(result =>
-    {
-        if (result.IsSucceed)
-        {
-            Console.WriteLine(string.Join(", ", result.Value!));
-        }
-    });
-```
-
-### Observe bits
-
-```csharp
-using var bitSubscription = client
-    .ObserveBits("M10", 8, TimeSpan.FromMilliseconds(500))
-    .Subscribe(result =>
-    {
-        if (result.IsSucceed)
-        {
-            Console.WriteLine(string.Join(", ", result.Value!));
-        }
-    });
-```
-
-### Observe words with heartbeat
-
-```csharp
-using var heartbeatSub = client
-    .ObserveWordsHeartbeat(
-        "D100",
-        2,
-        pollInterval: TimeSpan.FromSeconds(1),
-        heartbeatAfter: TimeSpan.FromSeconds(2))
-    .Subscribe(sample =>
-    {
-        if (sample.IsHeartbeat)
-        {
-            Console.WriteLine("Heartbeat");
-            return;
-        }
-
-        Console.WriteLine(string.Join(", ", sample.Update.Value!));
-    });
-```
-
-### Observe words with stale detection
-
-```csharp
-using var staleSub = client
-    .ObserveWordsStale(
-        "D100",
-        2,
-        pollInterval: TimeSpan.FromSeconds(1),
-        staleAfter: TimeSpan.FromSeconds(5))
-    .Subscribe(state =>
-    {
-        Console.WriteLine($"Is stale: {state.IsStale}");
-    });
-```
-
-### Triggered latest-only reads
-
-```csharp
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Signals;
-
-var trigger = new Signal<RxVoid>();
-using var latestSub = client
-    .ObserveWordsLatest("D100", 2, trigger)
-    .Subscribe(result => Console.WriteLine(result.IsSucceed));
-
-trigger.OnNext(RxVoid.Default);
-```
-
-### Reactive tag-group polling
-
-Once tag groups are defined, you can observe grouped snapshots with the same reactive patterns used by the lower-level word/bit APIs.
-
-### Observe a tag group
-
-```csharp
-using var groupSub = client
-    .ObserveTagGroup("Line1Overview", TimeSpan.FromSeconds(1))
-    .Subscribe(result =>
-    {
-        if (!result.IsSucceed || result.Value is null)
-        {
-            return;
-        }
-
-        var snapshot = result.Value;
-        Console.WriteLine($"Temp={snapshot.GetRequired<short>("SignedTemp")}");
-        Console.WriteLine($"Count={snapshot.GetRequired<uint>("TotalCount")}");
-        Console.WriteLine($"Message={snapshot.GetRequired<string>("OperatorMessage")}");
-        Console.WriteLine($"Pump={snapshot.GetRequired<bool>("PumpRunning")}");
-    });
-```
-
-### Observe a tag group with heartbeat
-
-```csharp
-using var groupHeartbeat = client
-    .ObserveTagGroupHeartbeat(
-        "Line1Overview",
-        pollInterval: TimeSpan.FromSeconds(5),
-        heartbeatAfter: TimeSpan.FromSeconds(2))
-    .Subscribe(sample =>
-    {
-        if (sample.IsHeartbeat)
-        {
-            Console.WriteLine("Group heartbeat");
-            return;
-        }
-
-        var snapshot = sample.Update!.Value!;
-        Console.WriteLine(snapshot.GetRequired<uint>("TotalCount"));
-    });
-```
-
-### Observe a tag group with stale detection
-
-```csharp
-using var groupStale = client
-    .ObserveTagGroupStale(
-        "Line1Overview",
-        pollInterval: TimeSpan.FromSeconds(5),
-        staleAfter: TimeSpan.FromSeconds(2))
-    .Subscribe(state =>
-    {
-        Console.WriteLine($"Group stale={state.IsStale}");
-    });
-```
-
-### Triggered latest-only grouped reads
-
-```csharp
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Signals;
-
-var groupTrigger = new Signal<RxVoid>();
-using var latestGroup = client
-    .ObserveTagGroupLatest("Line1Overview", groupTrigger)
-    .Subscribe(result =>
-    {
-        if (result.IsSucceed && result.Value is not null)
-        {
-            Console.WriteLine(result.Value.GetRequired<uint>("TotalCount"));
-        }
-    });
-
-groupTrigger.OnNext(RxVoid.Default);
-```
-
-These grouped reactive APIs are useful for HMI/dashboard polling loops because they keep the application written against stable symbolic names instead of raw PLC addresses.
-
-### Reactive hot shared value streams
-
-```csharp
-using var reactiveWords = client
-    .ObserveReactiveWords("D100", 2, TimeSpan.FromSeconds(1))
-    .Subscribe(value =>
-    {
-        if (value.Quality == MitsubishiReactiveQuality.Good && value.Value is not null)
-        {
-            Console.WriteLine($"Words: {string.Join(", ", value.Value)} @ {value.TimestampUtc:u}");
-        }
-    });
-```
-
-```csharp
-using var reactiveTag = client
-    .ObserveReactiveTag<float>("MotorSpeed", TimeSpan.FromMilliseconds(250))
-    .Subscribe(value =>
-    {
-        if (value.Quality == MitsubishiReactiveQuality.Good)
-        {
-            Console.WriteLine($"MotorSpeed={value.Value}");
-        }
-    });
-```
-
-```csharp
-using var reactiveGroup = client
-    .ObserveReactiveTagGroup("Line1Overview", TimeSpan.FromSeconds(1))
-    .Subscribe(value =>
-    {
-        if (value.Quality == MitsubishiReactiveQuality.Good && value.Value is not null)
-        {
-            Console.WriteLine(value.Value.GetRequired<uint>("TotalCount"));
-        }
-    });
-```
-
-These planner-backed reactive APIs are shared/hot streams with replay of the latest value and teardown when the final subscriber unsubscribes.
-
-### Reactive write pipelines
-
-```csharp
-var setpointWrites = client.CreateReactiveTagWritePipeline<float>(
-    "Setpoint",
-    MitsubishiReactiveWriteMode.LatestWins,
-    coalescingWindow: TimeSpan.FromMilliseconds(100));
-
-using var writeResults = setpointWrites.Results.Subscribe(result =>
-    Console.WriteLine($"Write success={result.Success} target={result.Target} error={result.Error}"));
-
-setpointWrites.Post(12.5f);
-setpointWrites.Post(13.0f);
-```
-
-Supported modes:
-- `Queued`
-- `LatestWins`
-- `Coalescing`
-
-The same pipeline API is available from the reactive package by changing the namespace:
-
-```csharp
-using MitsubishiRx.Reactive;
-
-var setpointWrites = client.CreateReactiveTagWritePipeline<float>(
-    "Setpoint",
-    MitsubishiReactiveWriteMode.Coalescing,
-    coalescingWindow: TimeSpan.FromMilliseconds(250));
-
-using var writeResults = setpointWrites.Results.Subscribe(result =>
-    Console.WriteLine($"{result.Target}: {result.Success}"));
-
-setpointWrites.Post(42.0f);
-```
-
-### Generated typed client surface
-
-`MitsubishiRx.Generators` is the Roslyn incremental source generator bundled with the package. It turns a compile-time tag schema into a strongly typed facade over the normal runtime tag APIs.
-
-You do not normally reference `MitsubishiRx.Generators` directly. The `MitsubishiRx` package includes `MitsubishiRx.Generators.dll` under `analyzers/dotnet/cs`, so SDK-style consumer projects get the analyzer automatically:
-
-```bash
-dotnet add package MitsubishiRx
-```
-
-The `MitsubishiRx.Reactive` package also carries the analyzer asset, but the generator currently emits `namespace MitsubishiRx` and extends the base `global::MitsubishiRx.MitsubishiRx` client type. For `MitsubishiRx.Reactive` projects, use the runtime tag APIs (`ReadFloatByTagAsync`, `ReadTagGroupSnapshotAsync`, `ObserveReactiveTag<T>`, `CreateReactiveTagWritePipeline<T>`, and related members) until generator namespace support is added for the reactive shim.
-
-#### Generator feature summary
-
-| Feature | Generated API | Runtime API used |
-|---|---|---|
-| Schema marker | `MitsubishiTagClientSchemaAttribute` | Compile-time marker only |
-| Client entrypoint | `client.Generated()` | Wraps the existing `MitsubishiRx` instance |
-| Tag catalog | `client.Generated().Tags.<TagName>` | Per-tag generated client |
-| Group catalog | `client.Generated().Groups.<GroupName>` | Per-group generated client |
-| Typed tag reads | `ReadAsync(CancellationToken)` | Typed `Read...ByTagAsync` helpers |
-| Typed tag writes | `WriteAsync(value, CancellationToken)` | Typed `Write...ByTagAsync` helpers |
-| Typed tag observation | `Observe(pollInterval, minimumUpdateSpacing)` | `ObserveReactiveTag<T>` |
-| Typed group reads | `ReadAsync(CancellationToken)` | `ReadTagGroupSnapshotAsync` plus generated required mapping |
-| Optional group reads | `ReadOptionalAsync(CancellationToken)` | `ReadTagGroupSnapshotAsync` plus generated optional mapping |
-| Typed group writes | `WriteAsync(TSnapshot, CancellationToken)` | `WriteTagGroupSnapshotAsync` |
-| Typed group observation | `Observe(...)` / `ObserveOptional(...)` | `ObserveReactiveTagGroup` plus generated projection |
-| Snapshot helpers | `FromSnapshot`, `TryFromSnapshot`, `ToSnapshot`, `MapReactive`, `MapReactiveOptional` | Converts between runtime and generated snapshot shapes |
-| Compile-time validation | `MRTXGEN001` through `MRTXGEN011` | Reports invalid schemas as compiler errors |
-
-#### Schema attribute and JSON contract
-
-Add `[MitsubishiTagClientSchema(...)]` to a class or assembly. The constructor takes one compile-time string value. Class-level usage:
-
-```csharp
-using MitsubishiRx;
-
-[MitsubishiTagClientSchema(
-    """
-    {
-      "tags": [
-        { "name": "MotorSpeed", "address": "D100", "dataType": "Float" },
-        { "name": "Mode", "address": "D101", "dataType": "UInt16" }
-      ],
-      "groups": [
-        { "name": "Line1", "tagNames": ["MotorSpeed", "Mode"] }
-      ]
-    }
-    """)]
-internal sealed class PlcSchema;
-```
-
-Assembly-level usage:
-
-```csharp
-using MitsubishiRx;
-
-[assembly: MitsubishiTagClientSchema(
-    """
-    {
-      "tags": [
-        { "name": "MotorSpeed", "dataType": "Float" },
-        { "name": "Mode", "dataType": "UInt16" },
-        { "name": "PumpRunning", "dataType": "Bit" }
-      ],
-      "groups": [
-        { "name": "Line1", "tagNames": ["MotorSpeed", "Mode", "PumpRunning"] }
-      ]
-    }
-    """)]
-```
-
-Generator schema fields:
-
-| JSON field | Required | Meaning |
-|---|---:|---|
-| `tags` | No | Array of tag entries exposed under `client.Generated().Tags`. |
-| `tags[].name` | Yes | Runtime tag name and generated identifier source. It must match a tag in `client.TagDatabase` at runtime. |
-| `tags[].dataType` | No | Generated .NET type and runtime helper selection. Missing or `null` defaults to `UInt16` / `ushort`. |
-| `groups` | No | Array of group entries exposed under `client.Generated().Groups`. |
-| `groups[].name` | Yes | Runtime group name and generated identifier source. It must match a group in `client.TagDatabase` at runtime. |
-| `groups[].tagNames` | Yes | Ordered tag names used to build the generated snapshot record. |
-
-The generator ignores extra schema properties such as `address`, `description`, `scale`, `offset`, `units`, `length`, and `byteOrder`. Keep those in the runtime `MitsubishiTagDatabase`; generated clients call the normal tag APIs by name, and the runtime database supplies addresses, scaling, string length, byte order, and other PLC metadata.
-
-`MitsubishiTagClientSchemaAttribute` targets assemblies and classes, allows multiple attributes, and is not inherited. Current generation uses the first collected non-empty schema value, so prefer one authoritative schema attribute per consuming project.
-
-#### Supported generated data types
-
-Use the casing shown in this table. Schema validation is case-insensitive, but the current generated API mapping is matched with these canonical names.
-
-| Schema `dataType` | Generated .NET type | Read method | Write method |
-|---|---|---|---|
-| missing / `null` | `ushort` | `ReadUInt16ByTagAsync` | `WriteUInt16ByTagAsync` |
-| `Word` | `ushort` | `ReadUInt16ByTagAsync` | `WriteUInt16ByTagAsync` |
-| `UInt16` | `ushort` | `ReadUInt16ByTagAsync` | `WriteUInt16ByTagAsync` |
-| `Int16` | `short` | `ReadInt16ByTagAsync` | `WriteInt16ByTagAsync` |
-| `Int32` | `int` | `ReadInt32ByTagAsync` | `WriteInt32ByTagAsync` |
-| `DWord` | `uint` | `ReadDWordByTagAsync` | `WriteDWordByTagAsync` |
-| `UInt32` | `uint` | `ReadDWordByTagAsync` | `WriteDWordByTagAsync` |
-| `Float` | `float` | `ReadFloatByTagAsync` | `WriteFloatByTagAsync` |
-| `String` | `string` | `ReadStringByTagAsync` | `WriteStringByTagAsync` |
-| `Bit` | `bool` | `ReadGeneratedBitTagAsync` | `WriteGeneratedBitTagAsync` |
-
-#### Generated client entrypoint and catalogs
-
-```csharp
-GeneratedMitsubishiTagClient generated = client.Generated();
-
-var tags = generated.Tags;
-var groups = generated.Groups;
-```
-
-Generated property names are sanitized from schema names:
-
-| Schema name | Generated identifier |
-|---|---|
-| `MotorSpeed` | `MotorSpeed` |
-| `Motor Speed` | `MotorSpeed` |
-| `Line 1 Overview` | `Line1Overview` |
-| `9Mode` | `_9Mode` |
-
-If two names sanitize to the same identifier, the generator reports `MRTXGEN005`.
-
-#### Generated tag clients
-
-For each schema tag, the generator emits a property under `Tags` and a sealed tag client type:
-
-```csharp
-var motorSpeed = client.Generated().Tags.MotorSpeed;
-
-Responce<float> read = await motorSpeed.ReadAsync();
-if (read.IsSucceed)
-{
-    Console.WriteLine($"Motor speed: {read.Value} rpm");
+    ushort[] next = [before.Value![0], 250, before.Value[2]];
+    var write = await plc.WriteWordsAsync("D200", next, CancellationToken.None);
+    if (!write.IsSucceed) Console.Error.WriteLine(write.Err);
 }
 
-Responce write = await motorSpeed.WriteAsync(123.4f);
-Console.WriteLine(write.IsSucceed ? "Speed written" : write.Err);
+var inputs = await plc.ReadBitsAsync("X10", 8, CancellationToken.None);
+if (inputs.IsSucceed)
+    await plc.WriteBitsAsync("M100", inputs.Value!, CancellationToken.None);
 ```
 
-Generated tag client API:
-
-| API | Signature | Purpose |
-|---|---|---|
-| `ReadAsync` | `Task<Responce<T>> ReadAsync(CancellationToken cancellationToken = default)` | Reads the runtime tag by name using the generated .NET type. |
-| `WriteAsync` | `Task<Responce> WriteAsync(T value, CancellationToken cancellationToken = default)` | Writes the runtime tag by name using the generated .NET type. |
-| `Observe` | `IObservable<MitsubishiReactiveValue<T>> Observe(TimeSpan pollInterval, TimeSpan? minimumUpdateSpacing = null)` | Polls the runtime tag and emits quality envelopes. |
-
-Tag observation example:
+Use a contiguous batch read whenever addresses are nearby. Use random access only when grouping would read a large irrelevant gap:
 
 ```csharp
-using var generatedTagSub = client.Generated().Tags.MotorSpeed
-    .Observe(TimeSpan.FromMilliseconds(250))
-    .Subscribe(value =>
-    {
-        if (value.Quality == MitsubishiReactiveQuality.Good)
-        {
-            Console.WriteLine(value.Value);
-        }
-    });
+var sparse = await plc.RandomReadWordsAsync(["D100", "D220", "W10"], CancellationToken.None);
+var commit = await plc.RandomWriteWordsAsync(
+    new[] { new KeyValuePair<string, ushort>("D100", 12), new("W10", 9) },
+    CancellationToken.None);
 ```
 
-Generated tags still require `client.TagDatabase` to contain matching tag names at runtime:
+`RegisterMonitorAsync(addresses)` programs the PLC-side monitor list and `ExecuteMonitorAsync` obtains its raw response. Register once after connection/reconfiguration, then execute repeatedly; re-register after reconnect if the target controller does not preserve monitor state. `ReadBlocksAsync`/`WriteBlocksAsync` accept `MitsubishiBlockRequest`, which combines `MitsubishiWordBlock` and `MitsubishiBitBlock` for a single multi-block command. These APIs return raw bytes because the response layout follows the request blocks; decode only with the same block ordering used to construct the request.
 
 ```csharp
-client.TagDatabase = MitsubishiTagDatabase.FromJson("""
+var registered = await plc.RegisterMonitorAsync(["D100", "M20", "D300"], CancellationToken.None);
+if (registered.IsSucceed)
 {
-  "tags": [
-    { "name": "MotorSpeed", "address": "D100", "dataType": "Float" },
-    { "name": "Mode", "address": "D102", "dataType": "UInt16" },
-    { "name": "PumpRunning", "address": "M10", "dataType": "Bit" }
-  ],
-  "groups": [
-    { "name": "Line1", "tagNames": ["MotorSpeed", "Mode", "PumpRunning"] }
-  ]
-}
-""");
-```
-
-#### Generated group clients and snapshots
-
-For each schema group, the generator emits a group property under `Groups`, a sealed group client type, and a partial snapshot record named `<GroupName>Snapshot`. For the `Line1` schema above, the snapshot shape is:
-
-```csharp
-public sealed partial record Line1Snapshot(float MotorSpeed, ushort Mode, bool PumpRunning);
-```
-
-Read and write a generated group snapshot:
-
-```csharp
-var line1 = await client.Generated().Groups.Line1.ReadAsync();
-if (line1.Value is not null)
-{
-    Console.WriteLine($"Mode={line1.Value.Mode}");
-
-    var updated = line1.Value with { Mode = 2 };
-    await client.Generated().Groups.Line1.WriteAsync(updated);
-}
-```
-
-Generated group client API:
-
-| API | Signature | Purpose |
-|---|---|---|
-| `ReadAsync` | `Task<Responce<TSnapshot>> ReadAsync(CancellationToken cancellationToken = default)` | Reads the runtime group and maps all values through `TSnapshot.FromSnapshot`. |
-| `ReadOptionalAsync` | `Task<Responce<TSnapshot?>> ReadOptionalAsync(CancellationToken cancellationToken = default)` | Reads the runtime group and returns `null` when values are missing or wrong-typed. |
-| `WriteAsync` | `Task<Responce> WriteAsync(TSnapshot value, CancellationToken cancellationToken = default)` | Converts the generated snapshot to `MitsubishiTagGroupSnapshot` and writes it through `WriteTagGroupSnapshotAsync`. |
-| `Observe` | `IObservable<MitsubishiReactiveValue<TSnapshot>> Observe(TimeSpan pollInterval, TimeSpan? minimumUpdateSpacing = null)` | Observes the runtime group and maps each value to the generated snapshot type. |
-| `ObserveOptional` | `IObservable<MitsubishiReactiveValue<TSnapshot?>> ObserveOptional(TimeSpan pollInterval, TimeSpan? minimumUpdateSpacing = null)` | Observes the runtime group and emits nullable generated snapshots when values are incomplete or mismatched. |
-
-Optional read and group observation examples:
-
-```csharp
-var optionalLine1 = await client.Generated().Groups.Line1.ReadOptionalAsync();
-Console.WriteLine(optionalLine1.Value?.Mode);
-
-using var generatedGroupSub = client.Generated().Groups.Line1.Observe(TimeSpan.FromSeconds(1))
-    .Subscribe(value => Console.WriteLine(value.Value?.Mode));
-
-using var optionalGeneratedGroupSub = client.Generated().Groups.Line1.ObserveOptional(TimeSpan.FromSeconds(1))
-    .Subscribe(value => Console.WriteLine(value.Value?.Mode));
-```
-
-Generated snapshot helper API:
-
-| API | Signature | Purpose |
-|---|---|---|
-| `FromSnapshot` | `static TSnapshot FromSnapshot(MitsubishiTagGroupSnapshot snapshot)` | Required conversion using `snapshot.GetRequired<T>(tagName)`. Throws if a value is missing or has the wrong type. |
-| `TryFromSnapshot` | `static TSnapshot? TryFromSnapshot(MitsubishiTagGroupSnapshot? snapshot)` | Optional conversion. Returns `null` for missing snapshots, missing tag values, or invalid casts. |
-| `ToSnapshot` | `MitsubishiTagGroupSnapshot ToSnapshot()` | Converts the generated record back to a runtime group snapshot for writes. |
-| `MapReactive` | `static MitsubishiReactiveValue<TSnapshot> MapReactive(MitsubishiReactiveValue<MitsubishiTagGroupSnapshot> value)` | Converts a runtime reactive group envelope to a generated typed envelope. Mapping errors become `MitsubishiReactiveQuality.Error`. |
-| `MapReactiveOptional` | `static MitsubishiReactiveValue<TSnapshot?> MapReactiveOptional(MitsubishiReactiveValue<MitsubishiTagGroupSnapshot> value)` | Converts a runtime reactive group envelope to a nullable generated typed envelope. |
-
-```csharp
-MitsubishiTagGroupSnapshot runtimeSnapshot = line1.Value!.ToSnapshot();
-Line1Snapshot typed = Line1Snapshot.FromSnapshot(runtimeSnapshot);
-Line1Snapshot? optional = Line1Snapshot.TryFromSnapshot(runtimeSnapshot);
-```
-
-#### Compile-time diagnostics
-
-The generator validates schema authoring mistakes before generated API use reaches runtime. Diagnostics use category `MitsubishiRx.Generators` and severity `Error`.
-
-| ID | Title | Meaning | Fix |
-|---|---|---|---|
-| `MRTXGEN001` | Failed to generate Mitsubishi tag client | JSON parsing or generation failed unexpectedly. | Check that the schema string is valid JSON. |
-| `MRTXGEN002` | Duplicate generated tag name | Two tag entries have the same `name`, case-insensitively. | Keep each tag name unique. |
-| `MRTXGEN003` | Unknown generated group tag reference | A group `tagNames` entry does not match any schema tag. | Add the missing tag or remove/fix the group reference. |
-| `MRTXGEN004` | Unsupported generated tag data type | A tag uses a `dataType` outside the supported generator set. | Use `Bit`, `Word`, `DWord`, `Float`, `String`, `Int16`, `UInt16`, `Int32`, or `UInt32`. |
-| `MRTXGEN005` | Generated identifier collision | Different tag or group names sanitize to the same C# identifier. | Rename one schema item, for example avoid both `Motor Speed` and `Motor-Speed`. |
-| `MRTXGEN006` | Empty generated tag name | A tag name is missing, empty, or whitespace. | Supply a non-empty `tags[].name`. |
-| `MRTXGEN007` | Empty generated group name | A group name is missing, empty, or whitespace. | Supply a non-empty `groups[].name`. |
-| `MRTXGEN008` | Empty generated group membership | A group has no `tagNames`. | Add at least one tag reference or remove the group. |
-| `MRTXGEN009` | Duplicate generated group name | Two group entries have the same `name`, case-insensitively. | Keep each group name unique. |
-| `MRTXGEN010` | Empty generated group tag reference | A group contains an empty or whitespace tag reference. | Remove the empty entry or replace it with a valid tag name. |
-| `MRTXGEN011` | Duplicate generated group tag reference | A group references the same tag more than once, case-insensitively. | Keep each group membership list unique. |
-
-Invalid schema example:
-
-```csharp
-[MitsubishiTagClientSchema(
-    """
-    {
-      "tags": [
-        { "name": "Motor Speed", "dataType": "Float" },
-        { "name": "Motor-Speed", "dataType": "UInt16" }
-      ],
-      "groups": [
-        { "name": "Line1", "tagNames": ["MissingTag"] }
-      ]
-    }
-    """)]
-internal sealed class InvalidSchema;
-```
-
-This schema reports `MRTXGEN005` because both tag names sanitize to `MotorSpeed`, and `MRTXGEN003` because `Line1` references `MissingTag`.
-
-#### Generated-client startup checklist
-
-Use this pattern in production applications:
-
-```csharp
-client.TagDatabase = MitsubishiTagDatabase.Load("plc-tags.yaml");
-
-var validation = client.ValidateTagDatabase();
-if (!validation.IsSucceed)
-{
-    throw new InvalidOperationException(validation.Err);
+    Responce<byte[]> sample = await plc.ExecuteMonitorAsync(CancellationToken.None);
+    if (sample.IsSucceed) Console.WriteLine(Convert.ToHexString(sample.Value!));
 }
 
-await client.OpenAsync();
-
-var generated = client.Generated();
-var mode = await generated.Tags.Mode.ReadAsync();
-Console.WriteLine(mode.IsSucceed ? mode.Value : mode.Err);
-```
-
-The compile-time generator schema and runtime tag database should describe the same tag and group names. The generator gives strongly typed code; the runtime database still controls how those names map to PLC devices.
-
-### Operation logs and sampled diagnostics
-
-```csharp
-using var logs = client.OperationLogs.Subscribe(log =>
-{
-    Console.WriteLine($"{log.TimestampUtc:u} {log.Description} success={log.Success}");
-});
-```
-
-```csharp
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Signals;
-
-var diagnosticTrigger = Signal.Interval(TimeSpan.FromSeconds(2)).Select(_ => new object());
-using var diagnostics = client.SampleDiagnostics(diagnosticTrigger).Subscribe(log =>
-{
-    Console.WriteLine(log.Description);
-});
-```
-
-### Connection health
-
-```csharp
-using var health = client.ObserveConnectionHealth(TimeSpan.FromSeconds(10)).Subscribe(state =>
-{
-    Console.WriteLine($"Connection stale={state.IsStale}, state={state.Update}");
-});
-```
-
-### Reactive operators used internally
-
-The library meaningfully uses these `ReactiveUI.Primitives.Extensions` operators:
-- `RetryWithBackoff(...)`
-- `SelectAsyncSequential(...)`
-- `SelectLatestAsync(...)`
-- `Heartbeat(...)`
-- `DetectStale(...)`
-- `Conflate(...)`
-- `SampleLatest(...)`
-- `DoOnSubscribe(...)`
-- `DoOnDispose(...)`
-
----
-
-## Tag database: use tag names instead of PLC addresses
-
-For production applications, raw addresses like `D100` and `M10` usually belong in configuration, not code.
-
-The library now includes an in-memory **tag database** that maps symbolic names to PLC addresses.
-
-### What it gives you
-
-Instead of this:
-
-```csharp
-var speed = await client.ReadWordsAsync("D100", 2);
-var pump = await client.ReadBitsAsync("M10", 1);
-await client.WriteWordsAsync("D300", new ushort[] { 12 });
-await client.RandomWriteWordsAsync(new[]
-{
-    new KeyValuePair<string, ushort>("D500", 100),
-    new KeyValuePair<string, ushort>("D501", 200),
-});
-```
-
-you can do this:
-
-```csharp
-var speed = await client.ReadWordsByTagAsync("MotorSpeed", 2);
-var pump = await client.ReadBitsByTagAsync("PumpRunning", 1);
-await client.WriteWordsByTagAsync("RecipeNumber", new ushort[] { 12 });
-await client.RandomWriteWordsByTagAsync(new[]
-{
-    new KeyValuePair<string, ushort>("RecipeSetpointA", 100),
-    new KeyValuePair<string, ushort>("RecipeSetpointB", 200),
-});
-```
-
-### Tag database types
-
-- `MitsubishiTagDefinition`
-- `MitsubishiTagDatabase`
-- `MitsubishiTagGroupDefinition`
-- `MitsubishiTagGroupSnapshot`
-- `MitsubishiRx.TagDatabase`
-- `ReadWordsByTagAsync(...)`
-- `ReadBitsByTagAsync(...)`
-- `WriteWordsByTagAsync(...)`
-- `WriteBitsByTagAsync(...)`
-- `RandomReadWordsByTagAsync(...)`
-- `RandomWriteWordsByTagAsync(...)`
-- `ReadInt16ByTagAsync(...)`
-- `WriteInt16ByTagAsync(...)`
-- `ReadUInt16ByTagAsync(...)`
-- `WriteUInt16ByTagAsync(...)`
-- `ReadInt32ByTagAsync(...)`
-- `WriteInt32ByTagAsync(...)`
-- `ReadDWordByTagAsync(...)`
-- `WriteDWordByTagAsync(...)`
-- `ReadFloatByTagAsync(...)`
-- `WriteFloatByTagAsync(...)`
-- `ReadScaledDoubleByTagAsync(...)`
-- `WriteScaledDoubleByTagAsync(...)`
-- `ReadStringByTagAsync(...)`
-- `WriteStringByTagAsync(...)`
-- `ValidateTagDatabase()`
-- `ReadTagGroupSnapshotAsync(...)`
-
-### Build a tag database in code
-
-```csharp
-using MitsubishiRx;
-
-var tags = new MitsubishiTagDatabase(new[]
-{
-    new MitsubishiTagDefinition(
-        Name: "MotorSpeed",
-        Address: "D100",
-        DataType: "Word",
-        Description: "Main spindle RPM",
-        Scale: 0.1,
-        Offset: 0.0,
-        Notes: "Engineering scaling 0.1 RPM per count"),
-
-    new MitsubishiTagDefinition(
-        Name: "PumpRunning",
-        Address: "M10",
-        DataType: "Bit",
-        Description: "Coolant pump running"),
-
-    new MitsubishiTagDefinition(
-        Name: "RecipeNumber",
-        Address: "D300",
-        DataType: "Word",
-        Description: "Selected recipe number"),
-
-    new MitsubishiTagDefinition(
-        Name: "RecipeSetpointA",
-        Address: "D500",
-        DataType: "Word"),
-
-    new MitsubishiTagDefinition(
-        Name: "RecipeSetpointB",
-        Address: "D501",
-        DataType: "Word"),
-});
-
-client.TagDatabase = tags;
-```
-
-### Read and write using tag names
-
-```csharp
-var speed = await client.ReadWordsByTagAsync("MotorSpeed", 2);
-var running = await client.ReadBitsByTagAsync("PumpRunning", 1);
-
-await client.WriteWordsByTagAsync("RecipeNumber", new ushort[] { 12 });
-await client.WriteBitsByTagAsync("PumpRunning", new[] { true });
-```
-
-### Random operations using tag names
-
-```csharp
-var recipeValues = await client.RandomReadWordsByTagAsync(new[]
-{
-    "RecipeSetpointA",
-    "RecipeSetpointB",
-    "RecipeNumber",
-});
-
-await client.RandomWriteWordsByTagAsync(new[]
-{
-    new KeyValuePair<string, ushort>("RecipeSetpointA", 100),
-    new KeyValuePair<string, ushort>("RecipeSetpointB", 200),
-    new KeyValuePair<string, ushort>("RecipeNumber", 12),
-});
-```
-
-### Typed tag helpers
-
-Use `DataType` to make tag intent explicit and then call the typed helpers directly.
-
-```csharp
-var signedTemp = await client.ReadInt16ByTagAsync("SignedTemp");
-await client.WriteInt16ByTagAsync("SignedTemp", -100);
-
-var wordValue = await client.ReadUInt16ByTagAsync("RecipeNumber");
-await client.WriteUInt16ByTagAsync("RecipeNumber", 12);
-
-var signedTotal = await client.ReadInt32ByTagAsync("SignedTotal");
-await client.WriteInt32ByTagAsync("SignedTotal", 123456);
-
-var totalCount = await client.ReadDWordByTagAsync("TotalCount");
-await client.WriteDWordByTagAsync("TotalCount", 123456u);
-
-var processValue = await client.ReadFloatByTagAsync("ProcessValue");
-await client.WriteFloatByTagAsync("ProcessValue", 12.5f);
-```
-
-Integer helpers supported in the current API surface:
-- `ReadInt16ByTagAsync(...)`
-- `WriteInt16ByTagAsync(...)`
-- `ReadUInt16ByTagAsync(...)`
-- `WriteUInt16ByTagAsync(...)`
-- `ReadInt32ByTagAsync(...)`
-- `WriteInt32ByTagAsync(...)`
-- `ReadDWordByTagAsync(...)`
-- `WriteDWordByTagAsync(...)`
-- `ReadFloatByTagAsync(...)`
-- `WriteFloatByTagAsync(...)`
-
-`Int32`, `UInt32`/`DWord`, and `Float` values are encoded across two Mitsubishi words. `ByteOrder` controls whether those two words are interpreted as `LittleEndian` or `BigEndian`.
-
-### Scaled engineering values
-
-If a tag carries engineering metadata in `Scale` and `Offset`, use the scaled helpers so application code can work with engineering units instead of raw PLC counts.
-
-```csharp
-var headTemp = await client.ReadScaledDoubleByTagAsync("HeadTemp");
-await client.WriteScaledDoubleByTagAsync("HeadTemp", 15.0d);
-```
-
-With this CSV row:
-
-```csv
-Name,Address,DataType,Scale,Offset
-HeadTemp,D200,Word,0.1,-10
-```
-
-the PLC raw value `250` becomes `(250 * 0.1) + (-10) = 15.0`.
-
-Scaled read/write currently supports:
-- `Word`
-- `DWord`
-- `Float`
-
-### PLC strings using tag names
-
-For PLC text stored in word registers, use the string helpers with an explicit word length or let the tag schema provide it.
-
-```csharp
-var message = await client.ReadStringByTagAsync("OperatorMessage", wordLength: 8);
-await client.WriteStringByTagAsync("OperatorMessage", "READY", wordLength: 8);
-
-var schemaDrivenMessage = await client.ReadStringByTagAsync("Utf8Message");
-await client.WriteStringByTagAsync("Utf8Message", "Aé");
-```
-
-String values are packed into successive words using the configured `Encoding`. Each Mitsubishi word stores two bytes, and `ByteOrder` controls how those two bytes are packed inside each word.
-
-### How tag resolution works
-
-- tag names are resolved case-insensitively
-- the resolved tag supplies the PLC `Address`
-- `DataType` is validated when tags are added or imported from CSV
-- supported `DataType` values are:
-  - `Bit`
-  - `Word`
-  - `DWord`
-  - `Float`
-  - `String`
-- `DataType` matching is case-insensitive and normalized to the canonical values above
-- the current tag-based convenience API supports:
-  - `ReadWordsByTagAsync(...)`
-  - `ReadBitsByTagAsync(...)`
-  - `WriteWordsByTagAsync(...)`
-  - `WriteBitsByTagAsync(...)`
-  - `RandomReadWordsByTagAsync(...)`
-  - `RandomWriteWordsByTagAsync(...)`
-  - `ReadDWordByTagAsync(...)`
-  - `WriteDWordByTagAsync(...)`
-  - `ReadFloatByTagAsync(...)`
-  - `WriteFloatByTagAsync(...)`
-  - `ReadScaledDoubleByTagAsync(...)`
-  - `WriteScaledDoubleByTagAsync(...)`
-  - `ReadStringByTagAsync(...)`
-  - `WriteStringByTagAsync(...)`
-- tag APIs are transport/frame agnostic: they work with `1E`, `3E`, `4E`, `TCP`, `UDP`, `Binary`, and `Ascii` wherever the underlying operation is supported by the target PLC family/module
-- all tag APIs eventually resolve to the same raw address-based methods, so protocol behavior stays identical after resolution
-- other operations can still use the same database manually:
-
-```csharp
-var tag = client.TagDatabase!.GetRequired("RecipeSetpointA");
-await client.WriteWordsAsync(tag.Address, new ushort[] { 2500 });
-```
-
-### Recommended usage model
-
-- store PLC addressing in CSV/configuration
-- load it at application startup
-- assign it to `client.TagDatabase`
-- keep application logic written against stable tag names
-- let maintenance teams change addresses in CSV without changing application code
-- define `MitsubishiTagGroupDefinition` scan classes for common screens, loops, and reporting views
-- call `ValidateTagDatabase()` during startup so bad addresses, missing string lengths, and broken group references fail fast
-
-### Tag groups and grouped snapshots
-
-For higher-level workflows, define named groups of tags and read them as a single heterogeneous snapshot.
-
-```csharp
-var tags = MitsubishiTagDatabase.FromCsv(File.ReadAllText("plc-tags.csv"));
-
-tags.AddGroup(new MitsubishiTagGroupDefinition(
-    Name: "Line1Overview",
-    TagNames: new[]
-    {
-        "SignedTemp",
-        "TotalCount",
-        "OperatorMessage",
-        "PumpRunning",
-    }));
-
-tags.AddGroup(new MitsubishiTagGroupDefinition(
-    Name: "RecipeWrite",
-    TagNames: new[]
-    {
-        "RecipeNumber",
-        "OperatorMessage",
-    }));
-
-client.TagDatabase = tags;
-
-var validation = client.ValidateTagDatabase();
-if (!validation.IsSucceed)
-{
-    throw new InvalidOperationException(validation.Err);
-}
-
-var snapshot = await client.ReadTagGroupSnapshotAsync("Line1Overview");
-
-var signedTemp = snapshot.Value!.GetRequired<short>("SignedTemp");
-var totalCount = snapshot.Value.GetRequired<uint>("TotalCount");
-var operatorMessage = snapshot.Value.GetRequired<string>("OperatorMessage");
-var pumpRunning = snapshot.Value.GetRequired<bool>("PumpRunning");
-```
-
-Use tag groups when you want:
-- startup validation of known screen/report/scan-class dependencies
-- a single named collection for related tags
-- typed access to heterogeneous values without scattering tag names across the application
-
-### Grouped writes and setpoint commits
-
-For HMI/setpoint workflows, validate and write only the values you want to commit.
-
-```csharp
-var pendingValues = new Dictionary<string, object?>
-{
-    ["RecipeNumber"] = (ushort)7,
-    ["OperatorMessage"] = "OK!",
-};
-
-var writeValidation = client.ValidateTagGroupWrite("RecipeWrite", pendingValues);
-if (!writeValidation.IsSucceed)
-{
-    throw new InvalidOperationException(writeValidation.Err);
-}
-
-await client.WriteTagGroupValuesAsync("RecipeWrite", pendingValues);
-```
-
-You can also write a full grouped snapshot directly:
-
-```csharp
-var writeSnapshot = new MitsubishiTagGroupSnapshot(
-    "Line1Overview",
-    new Dictionary<string, object?>
-    {
-        ["SignedTemp"] = (short)-100,
-        ["TotalCount"] = 0x12345678u,
-        ["OperatorMessage"] = "OK!",
-    });
-
-await client.WriteTagGroupSnapshotAsync(writeSnapshot);
-```
-
-`ValidateTagGroupWrite(...)` reports:
-- values whose CLR types do not match the target tag schema
-- values for tags that are not part of the named group
-- the same underlying tag/schema issues already enforced by the individual tag helpers
-
----
-
-## CSV import: initialize the tag database from a file
-
-You can initialize the tag database directly from CSV.
-
-### Supported required/optional columns
-
-| Column | Required | Meaning |
-|---|---|---|
-| `Name` | **Yes** | Unique symbolic tag name used by application code |
-| `Address` | **Yes** | Mitsubishi PLC address such as `D100`, `M10`, `X20`, `ZR200` |
-| `DataType` | No | Type hint such as `Bit`, `Word`, `DWord`, `Float`, `String`, `Int16`, `UInt16`, `Int32`, `UInt32` |
-| `Description` | No | Human-readable description |
-| `Scale` | No | Engineering scale factor, default `1.0` |
-| `Offset` | No | Engineering offset, default `0.0` |
-| `Length` | No | Logical tag length in PLC words, mainly used by string tags and fixed-width layouts |
-| `Encoding` | No | Text encoding hint such as `Ascii`, `Utf8`, or `Utf16` |
-| `Units` | No | Engineering units label such as `rpm`, `°C`, or `items` |
-| `Signed` | No | Boolean signedness hint for integer word/double-word tags, default `false` |
-| `ByteOrder` | No | Multi-word and string packing order: `LittleEndian` or `BigEndian` |
-| `Notes` | No | Free-form notes |
-
-### Required CSV formatting
-
-- first row **must** be a header row
-- at minimum the header must include:
-  - `Name`
-  - `Address`
-- column names are matched case-insensitively
-- blank lines are ignored
-- quoted CSV fields are supported
-- embedded double quotes inside quoted fields should be escaped as `""`
-- numeric `Scale`, `Offset`, and `Length` values should use invariant-culture formatting
-- `Signed` should be `true` or `false`
-- do **not** include engineering units inside `Scale` or `Offset`
-- `Address` must contain a valid Mitsubishi device address string usable by the client
-- if `DataType` is supplied it must be one of:
-  - `Bit`
-  - `Word`
-  - `DWord`
-  - `Float`
-  - `String`
-  - `Int16`
-  - `UInt16`
-  - `Int32`
-  - `UInt32`
-- if `Encoding` is supplied it must be one of:
-  - `Ascii`
-  - `Utf8`
-  - `Utf16`
-- if `ByteOrder` is supplied it must be one of:
-  - `LittleEndian`
-  - `BigEndian`
-- `DataType`, `Encoding`, and `ByteOrder` matching is case-insensitive when imported, but stored in canonical form
-- use one logical PLC item per CSV row
-- keep `Name` unique across the file so it can be used safely as the application lookup key
-
-### Example CSV file
-
-```csv
-Name,Address,DataType,Description,Scale,Offset,Length,Encoding,Units,Signed,ByteOrder,Notes
-MotorSpeed,D100,Word,Main spindle RPM,0.1,0,,,rpm,false,,From commissioning sheet
-PumpRunning,M10,Bit,Coolant pump running,1,0,,,,false,,
-HeadTemp,D200,Word,Head temperature,0.1,-10,,,°C,true,,Signed engineering temperature tag
-RecipeNumber,D300,UInt16,Selected recipe,1,0,,,recipe,false,,
-TotalCount,D400,UInt32,Accumulated production count,1,0,,,items,false,LittleEndian,32-bit unsigned counter
-ProcessValue,D500,Float,Engineering process value,1,0,,,bar,false,LittleEndian,IEEE754 single precision across two words
-OperatorMessage,D600,String,Operator status message,1,0,8,Ascii,,false,LittleEndian,Packed text in word registers
-SignedTemp,D700,Int16,Signed temperature raw count,1,0,,,counts,true,,Two's complement 16-bit value
-SignedTotal,D710,Int32,Signed accumulated count,1,0,,,items,true,BigEndian,Big-endian multiword example
-Utf8Message,D720,String,UTF-8 operator text,1,0,2,Utf8,,false,LittleEndian,Schema-driven string length
-ServoReady,M100,Bit,Servo ready,1,0,,,,false,,
-XAxisLimit,X20,Bit,X-axis forward limit,1,0,,,,false,,X uses configured XyNotation
-ZoneRegister,ZR200,Word,Zone parameter register,1,0,,,,false,,
-```
-
-### Load from a CSV string
-
-```csharp
-var csv = File.ReadAllText("plc-tags.csv");
-var tagDatabase = MitsubishiTagDatabase.FromCsv(csv);
-client.TagDatabase = tagDatabase;
-```
-
-Or load the same CSV directly by file extension:
-
-```csharp
-client.TagDatabase = MitsubishiTagDatabase.Load("plc-tags.csv");
-```
-
-### Full startup example
-
-```csharp
-using MitsubishiRx;
-
-var options = new MitsubishiClientOptions(
-    Host: "192.168.0.10",
-    Port: 5000,
-    FrameType: MitsubishiFrameType.ThreeE,
-    DataCode: CommunicationDataCode.Binary,
-    TransportKind: MitsubishiTransportKind.Tcp,
-    Route: MitsubishiRoute.Default,
-    MonitoringTimer: 0x0010,
-    XyNotation: XyAddressNotation.Octal);
-
-var csv = File.ReadAllText("plc-tags.csv");
-var tags = MitsubishiTagDatabase.FromCsv(csv);
-
-await using var client = new MitsubishiRx.MitsubishiRx(options)
-{
-    TagDatabase = tags,
-};
-
-var speed = await client.ReadWordsByTagAsync("MotorSpeed", 2);
-var pump = await client.ReadBitsByTagAsync("PumpRunning", 1);
-await client.WriteUInt16ByTagAsync("RecipeNumber", 7);
-await client.RandomWriteWordsByTagAsync(new[]
-{
-    new KeyValuePair<string, ushort>("RecipeSetpointA", 100),
-    new KeyValuePair<string, ushort>("RecipeSetpointB", 200),
-});
-
-var signedTemp = await client.ReadInt16ByTagAsync("SignedTemp");
-var signedTotal = await client.ReadInt32ByTagAsync("SignedTotal");
-var totalCount = await client.ReadDWordByTagAsync("TotalCount");
-var processValue = await client.ReadFloatByTagAsync("ProcessValue");
-var engineeringTemp = await client.ReadScaledDoubleByTagAsync("HeadTemp");
-var operatorMessage = await client.ReadStringByTagAsync("OperatorMessage");
-var utf8Message = await client.ReadStringByTagAsync("Utf8Message");
-```
-
-### JSON and YAML schema workflows
-
-CSV is useful for spreadsheets and maintenance exports, but JSON/YAML are better when you want full schema persistence, groups, and richer version-controlled configuration.
-
-### Export the full schema to JSON
-
-```csharp
-client.TagDatabase!.Save("plc-tags.json");
-```
-
-Equivalent explicit form:
-
-```csharp
-var json = client.TagDatabase!.ToJson();
-File.WriteAllText("plc-tags.json", json);
-```
-
-### Load the full schema from JSON
-
-```csharp
-client.TagDatabase = MitsubishiTagDatabase.Load("plc-tags.json");
-```
-
-Equivalent explicit form:
-
-```csharp
-var json = File.ReadAllText("plc-tags.json");
-var tags = MitsubishiTagDatabase.FromJson(json);
-client.TagDatabase = tags;
-```
-
-### Export the full schema to YAML
-
-```csharp
-client.TagDatabase!.Save("plc-tags.yaml");
-client.TagDatabase!.Save("plc-tags.yml");
-```
-
-Equivalent explicit form:
-
-```csharp
-var yaml = client.TagDatabase!.ToYaml();
-File.WriteAllText("plc-tags.yaml", yaml);
-```
-
-### Load the full schema from YAML
-
-```csharp
-client.TagDatabase = MitsubishiTagDatabase.Load("plc-tags.yaml");
-client.TagDatabase = MitsubishiTagDatabase.Load("plc-tags.yml");
-```
-
-Equivalent explicit form:
-
-```csharp
-var yaml = File.ReadAllText("plc-tags.yaml");
-var tags = MitsubishiTagDatabase.FromYaml(yaml);
-client.TagDatabase = tags;
-```
-
-### Example YAML schema with groups
-
-```yaml
-tags:
-  - name: SignedTemp
-    address: D700
-    dataType: Int16
-    signed: true
-    units: °C
-  - name: OperatorMessage
-    address: D600
-    dataType: String
-    length: 2
-    encoding: Utf8
-    byteOrder: BigEndian
-groups:
-  - name: Overview
-    tagNames:
-      - SignedTemp
-      - OperatorMessage
-```
-
-Use JSON/YAML when you want:
-- full schema persistence including groups
-- easier code review of tag model changes in version control
-- richer metadata than a compact CSV worksheet usually carries
-
-Use `MitsubishiTagDatabase.Load(path)` / `Save(path)` when you want one-line startup configuration or persistence with automatic detection for `.csv`, `.json`, `.yaml`, and `.yml`.
-
-For commissioning workflows, `client.LoadAndValidateTagDatabase(path)` loads, validates, and applies the schema in one step, `client.PreviewTagDatabaseDiff(path)` shows what would change before you commit it, and `client.ObserveTagDatabaseReload(path, pollInterval)` / `client.ObserveTagDatabaseDiff(path, pollInterval)` provide reactive reload and audit streams. Use rollout policies when you want to allow metadata/group edits automatically while blocking address or datatype changes.
-
-### Load, validate, and apply a schema in one step
-
-```csharp
-var loadResult = client.LoadAndValidateTagDatabase("plc-tags.yaml");
-if (!loadResult.IsSucceed)
-{
-    throw new InvalidOperationException(loadResult.Err);
-}
-```
-
-### Reactively hot-reload a schema during commissioning
-
-```csharp
-using var schemaReload = client
-    .ObserveTagDatabaseReload("plc-tags.yaml", TimeSpan.FromSeconds(2))
-    .Subscribe(result =>
-    {
-        if (!result.IsSucceed)
-        {
-            Console.WriteLine($"Schema reload failed: {result.Err}");
-            return;
-        }
-
-        Console.WriteLine($"Reloaded {result.Value!.Count} tags and {result.Value.GroupCount} groups");
-    });
-```
-
-`ObserveTagDatabaseReload(...)` only applies a newly loaded database when validation succeeds. Invalid reloads are emitted as failed results and the last valid `client.TagDatabase` remains active.
-
-### Preview schema changes before applying them
-
-```csharp
-var preview = client.PreviewTagDatabaseDiff("plc-tags.yaml");
-if (!preview.IsSucceed)
-{
-    throw new InvalidOperationException(preview.Err);
-}
-
-Console.WriteLine($"Added tags: {preview.Value!.AddedTags.Count}");
-Console.WriteLine($"Removed tags: {preview.Value.RemovedTags.Count}");
-Console.WriteLine($"Changed tags: {preview.Value.ChangedTags.Count}");
-```
-
-### Reactively audit schema changes during hot reload
-
-```csharp
-using var schemaAudit = client
-    .ObserveTagDatabaseDiff("plc-tags.yaml", TimeSpan.FromSeconds(2), emitInitial: false)
-    .Subscribe(result =>
-    {
-        if (!result.IsSucceed)
-        {
-            Console.WriteLine($"Schema diff failed: {result.Err}");
-            return;
-        }
-
-        var diff = result.Value!;
-        Console.WriteLine($"Schema changed: {diff.ChangeCount} semantic changes");
-    });
-```
-
-`ObserveTagDatabaseDiff(...)` emits semantic tag/group changes for each successful reload and keeps the last valid `client.TagDatabase` when an update is invalid.
-
-### Apply rollout policy gates during commissioning
-
-```csharp
-var gatedLoad = client.LoadAndValidateTagDatabase(
-    "plc-tags.yaml",
-    MitsubishiTagRolloutPolicy.SafeMetadataAndGroups);
-
-if (!gatedLoad.IsSucceed)
-{
-    throw new InvalidOperationException(gatedLoad.Err);
-}
-```
-
-`MitsubishiTagRolloutPolicy.SafeMetadataAndGroups` allows:
-- metadata-only tag changes
-- tag-group membership/order changes
-
-It rejects:
-- address changes
-- datatype/encoding/length/signedness/byte-order changes
-- added/removed tags or groups
-
-### Preview classified changes before applying them
-
-```csharp
-var preview = client.PreviewTagDatabaseDiff(
-    "plc-tags.yaml",
-    MitsubishiTagRolloutPolicy.SafeMetadataAndGroups);
-
-if (preview.Value is not null)
-{
-    Console.WriteLine($"Kinds: {preview.Value.ChangeKinds}");
-    Console.WriteLine($"Total changes: {preview.Value.ChangeCount}");
-}
-```
-
-### Reactively enforce rollout policy during hot reload
-
-```csharp
-using var gatedReload = client
-    .ObserveTagDatabaseReload(
-        "plc-tags.yaml",
-        TimeSpan.FromSeconds(2),
-        emitInitial: false,
-        policy: MitsubishiTagRolloutPolicy.SafeMetadataAndGroups)
-    .Subscribe(result =>
-    {
-        if (!result.IsSucceed)
-        {
-            Console.WriteLine($"Reload blocked: {result.Err}");
-        }
-    });
-```
-
-### Practical CSV rules for maintenance teams
-
-Recommended conventions:
-- `Name`: PascalCase or a consistent SCADA/HMI-friendly convention
-- `Address`: exact Mitsubishi address string with no extra spaces
-- `DataType`: one of `Bit`, `Word`, `DWord`, `Float`, `String`, `Int16`, `UInt16`, `Int32`, `UInt32`
-- `Length`: set this for string tags so code can call `ReadStringByTagAsync(tagName)` without supplying a length each time
-- `Encoding`: use `Ascii` unless the PLC text really requires `Utf8` or `Utf16`
-- `Signed`: set to `true` for signed integer word/double-word values or signed scaled engineering values
-- `ByteOrder`: use `LittleEndian` for the normal two-word Mitsubishi layout and `BigEndian` only when the external data contract requires it
-- `Units`: use for UI/reporting metadata such as `rpm`, `°C`, or `items`
-- `Description`: operator-facing sentence
-- `Notes`: use for commissioning notes, source document, or unit conversion notes
-
-### Example with quoted fields
-
-```csv
-Name,Address,DataType,Description,Scale,Offset,Notes
-LineSpeed,D110,Word,"Main conveyor speed, calculated",0.01,0,"Imported from ""Line-1 IO List"""
-```
-
-### Validation behavior
-
-`MitsubishiTagDatabase.FromCsv(...)` will fail when:
-- there is no header row
-- `Name` is missing from the header
-- `Address` is missing from the header
-- a row has an empty required value for `Name` or `Address`
-- `Scale`, `Offset`, or `Length` contain invalid numeric values
-- `Signed` contains an invalid boolean value
-- `DataType` contains an unsupported value
-- `Encoding` contains an unsupported value
-- `ByteOrder` contains an unsupported value
-
-`client.ValidateTagDatabase()` additionally reports:
-- tag addresses that cannot be parsed for the configured `XyNotation`
-- string tags that do not define a positive `Length`
-- tag groups that reference missing tags
-
-The accepted `DataType` values are exactly:
-- `Bit`
-- `Word`
-- `DWord`
-- `Float`
-- `String`
-- `Int16`
-- `UInt16`
-- `Int32`
-- `UInt32`
-
-The accepted `Encoding` values are exactly:
-- `Ascii`
-- `Utf8`
-- `Utf16`
-
-The accepted `ByteOrder` values are exactly:
-- `LittleEndian`
-- `BigEndian`
-
----
-
-## PLC-family-specific usage guidance
-
-This section shows how to think about feature usage by PLC family.
-
-### A / AnS legacy paths
-
-Use **1E** when the installed Ethernet interface/module exposes A-compatible MC protocol only.
-
-Typical operations:
-- `ReadWordsAsync`
-- `WriteWordsAsync`
-- `ReadBitsAsync`
-- `WriteBitsAsync`
-- `ReadTypeNameAsync`
-- `LoopbackAsync`
-- core remote operations where supported by the target path
-
-Example:
-
-```csharp
-var options = new MitsubishiClientOptions(
-    Host: "192.168.0.20",
-    Port: 5000,
-    FrameType: MitsubishiFrameType.OneE,
-    DataCode: CommunicationDataCode.Binary,
-    TransportKind: MitsubishiTransportKind.Tcp,
-    MonitoringTimer: 0x0010,
-    CpuType: CpuType.ASeries,
-    LegacyPcNumber: 0xFF);
-```
-
-### Q / QnA / L / iQ-R / iQ-F / FX5 modern Ethernet
-
-Use **3E** as the default unless the integration explicitly needs **4E** serial correlation.
-
-Typical operations:
-- all batch operations
-- random read/write
-- block read/write
-- monitor registration/execute
-- type-name read
-- remote control
-- password unlock/lock
-- memory and extend-unit access
-- TCP or UDP depending on endpoint configuration
-
-3E example:
-
-```csharp
-var options = new MitsubishiClientOptions(
-    Host: "192.168.0.30",
-    Port: 5000,
-    FrameType: MitsubishiFrameType.ThreeE,
-    DataCode: CommunicationDataCode.Binary,
-    TransportKind: MitsubishiTransportKind.Tcp,
-    Route: MitsubishiRoute.Default,
-    MonitoringTimer: 0x0010);
-```
-
-4E example:
-
-```csharp
-var options = new MitsubishiClientOptions(
-    Host: "192.168.0.31",
-    Port: 5000,
-    FrameType: MitsubishiFrameType.FourE,
-    DataCode: CommunicationDataCode.Binary,
-    TransportKind: MitsubishiTransportKind.Tcp,
-    Route: MitsubishiRoute.Default,
-    MonitoringTimer: 0x0010,
-    SerialNumberProvider: () => (ushort)Environment.TickCount);
-```
-
-### ASCII endpoint example
-
-```csharp
-var asciiOptions = new MitsubishiClientOptions(
-    Host: "192.168.0.40",
-    Port: 5000,
-    FrameType: MitsubishiFrameType.ThreeE,
-    DataCode: CommunicationDataCode.Ascii,
-    TransportKind: MitsubishiTransportKind.Tcp,
-    Route: MitsubishiRoute.Default,
-    MonitoringTimer: 0x0010);
-```
-
-### UDP endpoint example
-
-```csharp
-var udpOptions = new MitsubishiClientOptions(
-    Host: "192.168.0.50",
-    Port: 5000,
-    FrameType: MitsubishiFrameType.ThreeE,
-    DataCode: CommunicationDataCode.Binary,
-    TransportKind: MitsubishiTransportKind.Udp,
-    Route: MitsubishiRoute.Default,
-    MonitoringTimer: 0x0010);
-```
-
-### Serial endpoint example
-
-```csharp
-using System.IO.Ports;
-
-var serialEndpoint = new MitsubishiClientOptions(
-    Host: "COM3",
-    Port: 0,
-    FrameType: MitsubishiFrameType.OneC,
-    DataCode: CommunicationDataCode.Ascii,
-    TransportKind: MitsubishiTransportKind.Serial,
-    Timeout: TimeSpan.FromSeconds(2),
-    CpuType: CpuType.Fx3,
-    Serial: new MitsubishiSerialOptions(
-        PortName: "COM3",
-        BaudRate: 9600,
-        DataBits: 7,
-        Parity: Parity.Even,
-        StopBits: StopBits.One,
-        Handshake: Handshake.None,
-        MessageFormat: MitsubishiSerialMessageFormat.Format1,
-        StationNumber: 0x00,
-        PcNumber: 0xFF,
-        MessageWait: 0x0));
-```
-
----
-
-## Feature-to-API quick map
-
-| Feature | API |
-|---|---|
-| Default package | `MitsubishiRx` namespace, `ReactiveUI.Primitives`, `SerialPortRx` |
-| Reactive bridge package | `MitsubishiRx.Reactive` namespace, `ReactiveUI.Primitives.Reactive`, `SerialPortRx.Reactive` |
-| Open transport | `OpenAsync()` / `Open()` |
-| Close transport | `CloseAsync()` / `Close()` |
-| Batch word read | `ReadWordsAsync(address, points)` |
-| Batch word write | `WriteWordsAsync(address, values)` |
-| Batch bit read | `ReadBitsAsync(address, points)` |
-| Batch bit write | `WriteBitsAsync(address, values)` |
-| Random word read | `RandomReadWordsAsync(addresses)` |
-| Random word write | `RandomWriteWordsAsync(values)` |
-| Register monitor devices | `RegisterMonitorAsync(addresses)` |
-| Execute monitor | `ExecuteMonitorAsync()` |
-| Block read | `ReadBlocksAsync(request)` |
-| Block write | `WriteBlocksAsync(request)` |
-| Read PLC type | `ReadTypeNameAsync()` |
-| Remote RUN | `RemoteRunAsync(force, clearMode)` |
-| Remote STOP | `RemoteStopAsync()` |
-| Remote PAUSE | `RemotePauseAsync()` |
-| Remote LATCH CLEAR | `RemoteLatchClearAsync()` |
-| Remote RESET | `RemoteResetAsync()` |
-| Unlock | `UnlockAsync(password)` |
-| Lock | `LockAsync(password)` |
-| Clear error | `ClearErrorAsync()` |
-| Loopback | `LoopbackAsync(data)` |
-| Memory read | `ReadMemoryAsync(command, address, length)` |
-| Memory write | `WriteMemoryAsync(command, address, values)` |
-| Raw command execution | `ExecuteRawAsync(request)` |
-| Observe words | `ObserveWords(...)` |
-| Observe bits | `ObserveBits(...)` |
-| Observe heartbeat | `ObserveWordsHeartbeat(...)` |
-| Observe staleness | `ObserveWordsStale(...)` |
-| Triggered latest read | `ObserveWordsLatest(...)` |
-| Observe tag group | `ObserveTagGroup(...)` |
-| Observe tag group heartbeat | `ObserveTagGroupHeartbeat(...)` |
-| Observe tag group staleness | `ObserveTagGroupStale(...)` |
-| Triggered latest tag-group read | `ObserveTagGroupLatest(...)` |
-| Operation logs | `OperationLogs` |
-| Connection states | `ConnectionStates` |
-| Connection stale detection | `ObserveConnectionHealth(...)` |
-| Symbolic word read | `ReadWordsByTagAsync(tagName, points)` |
-| Symbolic bit read | `ReadBitsByTagAsync(tagName, points)` |
-| Symbolic word write | `WriteWordsByTagAsync(tagName, values)` |
-| Symbolic bit write | `WriteBitsByTagAsync(tagName, values)` |
-| Symbolic random word read | `RandomReadWordsByTagAsync(tagNames)` |
-| Symbolic random word write | `RandomWriteWordsByTagAsync(values)` |
-| Symbolic Int16 read | `ReadInt16ByTagAsync(tagName)` |
-| Symbolic Int16 write | `WriteInt16ByTagAsync(tagName, value)` |
-| Symbolic UInt16 read | `ReadUInt16ByTagAsync(tagName)` |
-| Symbolic UInt16 write | `WriteUInt16ByTagAsync(tagName, value)` |
-| Symbolic Int32 read | `ReadInt32ByTagAsync(tagName)` |
-| Symbolic Int32 write | `WriteInt32ByTagAsync(tagName, value)` |
-| Symbolic DWord read | `ReadDWordByTagAsync(tagName)` |
-| Symbolic DWord write | `WriteDWordByTagAsync(tagName, value)` |
-| Symbolic float read | `ReadFloatByTagAsync(tagName)` |
-| Symbolic float write | `WriteFloatByTagAsync(tagName, value)` |
-| Symbolic scaled read | `ReadScaledDoubleByTagAsync(tagName)` |
-| Symbolic scaled write | `WriteScaledDoubleByTagAsync(tagName, value)` |
-| Symbolic string read | `ReadStringByTagAsync(tagName, wordLength)` / `ReadStringByTagAsync(tagName)` |
-| Symbolic string write | `WriteStringByTagAsync(tagName, value, wordLength)` / `WriteStringByTagAsync(tagName, value)` |
-| Tag group definition | `MitsubishiTagGroupDefinition(name, tagNames)` |
-| Tag group registration | `TagDatabase.AddGroup(group)` |
-| Tag database validation | `ValidateTagDatabase()` |
-| Tag database load + validate | `LoadAndValidateTagDatabase(path)` / `LoadAndValidateTagDatabase(path, policy)` |
-| Tag database diff preview | `PreviewTagDatabaseDiff(path)` / `PreviewTagDatabaseDiff(path, policy)` |
-| Tag database reload stream | `ObserveTagDatabaseReload(path, pollInterval)` / `ObserveTagDatabaseReload(path, pollInterval, emitInitial, policy)` |
-| Tag database diff stream | `ObserveTagDatabaseDiff(path, pollInterval)` / `ObserveTagDatabaseDiff(path, pollInterval, emitInitial, policy)` |
-| Tag group snapshot read | `ReadTagGroupSnapshotAsync(groupName)` |
-| Snapshot typed accessor | `snapshot.GetRequired<T>(tagName)` |
-| Tag group write validation | `ValidateTagGroupWrite(groupName, values)` |
-| Partial tag-group write | `WriteTagGroupValuesAsync(groupName, values)` |
-| Full tag-group snapshot write | `WriteTagGroupSnapshotAsync(snapshot)` |
-| Tag database assignment | `client.TagDatabase = ...` |
-| CSV tag import | `MitsubishiTagDatabase.FromCsv(csvContent)` |
-| Schema file load | `MitsubishiTagDatabase.Load(path)` |
-| Schema file save | `TagDatabase.Save(path)` |
-| JSON schema import | `MitsubishiTagDatabase.FromJson(json)` |
-| JSON schema export | `TagDatabase.ToJson()` |
-| YAML schema import | `MitsubishiTagDatabase.FromYaml(yaml)` |
-| YAML schema export | `TagDatabase.ToYaml()` |
-| Generator schema marker | `[MitsubishiTagClientSchema("""{ ... }""")]` |
-| Generated typed client root | `client.Generated()` |
-| Generated typed tag read/write/observe | `client.Generated().Tags.<Tag>.ReadAsync()` / `WriteAsync(...)` / `Observe(...)` |
-| Generated typed group read/write/observe | `client.Generated().Groups.<Group>.ReadAsync()` / `ReadOptionalAsync()` / `WriteAsync(...)` / `Observe(...)` / `ObserveOptional(...)` |
-| Generated snapshot conversion | `<Group>Snapshot.FromSnapshot(...)` / `TryFromSnapshot(...)` / `ToSnapshot()` |
-| Generator diagnostics | `MRTXGEN001` through `MRTXGEN011` |
-
-### Serial coverage note
-
-The quick map lists the full public API surface. Serial support covers `1C`, `3C`, and `4C` paths through `MitsubishiTransportKind.Serial`. Verified serial operations include **batch word read** via `ReadWordsAsync(address, points)`, **batch word write** via `WriteWordsAsync(address, values)`, **batch bit read** via `ReadBitsAsync(address, points)`, **batch bit write** via `WriteBitsAsync(address, values)`, **random word read/write** via `RandomReadWordsAsync(addresses)` / `RandomWriteWordsAsync(values)`, **block read/write** via `ReadBlocksAsync(request)` / `WriteBlocksAsync(request)`, **monitor registration/execution** via `RegisterMonitorAsync(addresses)` / `ExecuteMonitorAsync()`, **remote control** via `RemoteRunAsync(force, clearMode)`, `RemoteStopAsync()`, `RemotePauseAsync()`, `RemoteLatchClearAsync()`, and `RemoteResetAsync()`, **type-name read**, **loopback**, **memory / extend-unit access**, and **raw command execution**. For `1C`, random, block, and monitor operations are implemented as deterministic client-side compositions over the verified 1C batch read/write path.
-
-## Complete API reference
-
-This section is the authoritative quick reference for the public API exposed by `MitsubishiRx` and `MitsubishiRx.Reactive`. Earlier sections explain the recommended workflow and provide larger examples; this section gives signatures, return types, and when to use each member.
-
-### API conventions
-
-- All async PLC operations return `Task<Responce>` or `Task<Responce<T>>`.
-- Check `IsSucceed` before using `Value`.
-- Failure details are available through `Err`, `ErrCode`, `ErrList`, and `Exception`.
-- Optional `CancellationToken` parameters cancel the client-side request wait; PLC command support and PLC-side execution semantics remain target dependent.
-- Address-based methods accept Mitsubishi device strings such as `D100`, `M10`, `X20`, `W10`, or `ZR200`.
-- Tag-based methods require `client.TagDatabase` to be assigned first.
-- Ethernet `1E` paths have a smaller command set than `3E` / `4E`. Serial `1C`, `3C`, and `4C` paths cover the public serial API surface; see the serial coverage notes above for the 1C composition behavior.
-
-### Package-specific API surface
-
-The runtime PLC, tag, reactive polling, hot stream, write pipeline, protocol, transport, and model APIs are compiled into both packages. Replace the namespace prefix when moving examples between packages.
-
-| Area | `MitsubishiRx` | `MitsubishiRx.Reactive` |
-|---|---|---|
-| Package id | `MitsubishiRx` | `MitsubishiRx.Reactive` |
-| Root namespace | `MitsubishiRx` | `MitsubishiRx.Reactive` |
-| Target frameworks | `net8.0`, `net9.0`, `net10.0`, `net11.0` | `net8.0`, `net9.0`, `net10.0`, `net11.0` |
-| Reactive dependencies | `ReactiveUI.Primitives`, `ReactiveUI.Primitives.Async`, `ReactiveUI.Primitives.Extensions` | `ReactiveUI.Primitives.Reactive`, `ReactiveUI.Primitives.Extensions.Reactive` |
-| Serial dependency | `SerialPortRx` | `SerialPortRx.Reactive` |
-| Scheduler constructor type | `ReactiveUI.Primitives.Concurrency.ISequencer?` | `System.Reactive.Concurrency.IScheduler?` |
-| Latest trigger unit type | `ReactiveUI.Primitives.RxVoid` | `System.Reactive.Unit` |
-| Source generator | Included as analyzer and emits `MitsubishiRx` generated clients | Included as analyzer, but generated typed clients currently target the base `MitsubishiRx` namespace |
-
-Package-specific construction examples:
-
-```csharp
-using MitsubishiRx;
-
-await using var client = new MitsubishiRx.MitsubishiRx(options);
-```
-
-```csharp
-using MitsubishiRx.Reactive;
-
-await using var client = new MitsubishiRx.Reactive.MitsubishiRx(options);
-```
-
-For `MitsubishiRx.Reactive`, prefer the runtime APIs in the tables below for tag reads, group reads, polling, hot observables, and write pipelines. Generated typed clients are documented separately because they currently target the base package namespace.
-
-```csharp
-var result = await client.ReadWordsAsync("D100", 2);
-if (!result.IsSucceed)
-{
-    Console.WriteLine($"PLC read failed: {result.Err} code={result.ErrCode}");
-    return;
-}
-
-ushort firstWord = result.Value![0];
-```
-
-### Client construction and state
-
-| API | Signature | Purpose |
-|---|---|---|
-| Modern constructor | `MitsubishiRx(MitsubishiClientOptions options, IMitsubishiTransport? transport = null, IScheduler? scheduler = null)` | Preferred constructor. Pass options and optionally inject a custom transport or scheduler for tests/advanced integrations. |
-| Legacy constructor | `MitsubishiRx(CpuType cpuType, string ip, int port, int timeout = 1500)` | Compatibility shortcut for older socket-style code. Prefer `MitsubishiClientOptions` for new code. |
-| `Options` | `MitsubishiClientOptions Options { get; }` | Effective immutable client options. |
-| `TagDatabase` | `MitsubishiTagDatabase? TagDatabase { get; set; }` | Optional symbolic tag schema used by tag/group/generated APIs. |
-| `Connected` | `bool Connected { get; }` | Current transport connection flag. |
-| `ConnectionStates` | `IObservable<MitsubishiConnectionState> ConnectionStates { get; }` | Reactive connection-state stream. |
-| `OperationLogs` | `IObservable<MitsubishiOperationLog> OperationLogs { get; }` | Request/response log stream for diagnostics and audit. |
-
-```csharp
-await using var client = new MitsubishiRx.MitsubishiRx(options);
-client.TagDatabase = MitsubishiTagDatabase.Load("plc-tags.yaml");
-
-using var stateSubscription = client.ConnectionStates.Subscribe(state => Console.WriteLine(state));
-```
-
-### Connection lifecycle
-
-| API | Signature | Purpose |
-|---|---|---|
-| `Open` | `Responce Open()` | Synchronous open wrapper. |
-| `OpenAsync` | `Task<Responce> OpenAsync(CancellationToken cancellationToken = default)` | Opens TCP/UDP/serial transport. |
-| `Close` | `Responce Close()` | Synchronous close wrapper. |
-| `CloseAsync` | `Task<Responce> CloseAsync(CancellationToken cancellationToken = default)` | Closes the transport. |
-| `Dispose` | `void Dispose()` | Disposes transport, subscriptions, and reactive caches. |
-| `DisposeAsync` | `ValueTask DisposeAsync()` | Async disposal path; preferred with `await using`. |
-
-```csharp
-var open = await client.OpenAsync();
-if (!open.IsSucceed)
-{
-    throw new InvalidOperationException(open.Err);
-}
-
-await client.CloseAsync();
-```
-
-### Core address-based PLC operations
-
-| API | Signature | Returns | Purpose |
-|---|---|---|---|
-| `ReadWordsAsync` | `Task<Responce<ushort[]>> ReadWordsAsync(string address, int points, CancellationToken cancellationToken = default)` | Word values | Batch word read from consecutive devices. |
-| `WriteWordsAsync` | `Task<Responce> WriteWordsAsync(string address, IReadOnlyList<ushort> values, CancellationToken cancellationToken = default)` | Completion | Batch word write. |
-| `ReadBitsAsync` | `Task<Responce<bool[]>> ReadBitsAsync(string address, int points, CancellationToken cancellationToken = default)` | Bit values | Batch bit read. |
-| `WriteBitsAsync` | `Task<Responce> WriteBitsAsync(string address, IReadOnlyList<bool> values, CancellationToken cancellationToken = default)` | Completion | Batch bit write. |
-| `RandomReadWordsAsync` | `Task<Responce<ushort[]>> RandomReadWordsAsync(IEnumerable<string> addresses, CancellationToken cancellationToken = default)` | Word values in request order | Sparse word read. |
-| `RandomWriteWordsAsync` | `Task<Responce> RandomWriteWordsAsync(IEnumerable<KeyValuePair<string, ushort>> values, CancellationToken cancellationToken = default)` | Completion | Sparse word write. |
-| `RegisterMonitorAsync` | `Task<Responce> RegisterMonitorAsync(IEnumerable<string> addresses, CancellationToken cancellationToken = default)` | Completion | Registers devices for later monitor execution. |
-| `ExecuteMonitorAsync` | `Task<Responce<byte[]>> ExecuteMonitorAsync(CancellationToken cancellationToken = default)` | Raw monitor payload | Executes the registered monitor. |
-| `ReadBlocksAsync` | `Task<Responce<byte[]>> ReadBlocksAsync(MitsubishiBlockRequest request, CancellationToken cancellationToken = default)` | Raw block payload | Reads multiple word/bit blocks. |
-| `WriteBlocksAsync` | `Task<Responce> WriteBlocksAsync(MitsubishiBlockRequest request, CancellationToken cancellationToken = default)` | Completion | Writes multiple word/bit blocks. |
-| `ReadTypeNameAsync` | `Task<Responce<MitsubishiTypeName>> ReadTypeNameAsync(CancellationToken cancellationToken = default)` | PLC model information | Reads CPU/module type name and code. |
-| `RemoteRunAsync` | `Task<Responce> RemoteRunAsync(bool force = true, bool clearMode = false, CancellationToken cancellationToken = default)` | Completion | Issues remote RUN. |
-| `RemoteStopAsync` | `Task<Responce> RemoteStopAsync(CancellationToken cancellationToken = default)` | Completion | Issues remote STOP. |
-| `RemotePauseAsync` | `Task<Responce> RemotePauseAsync(CancellationToken cancellationToken = default)` | Completion | Issues remote PAUSE. |
-| `RemoteLatchClearAsync` | `Task<Responce> RemoteLatchClearAsync(CancellationToken cancellationToken = default)` | Completion | Clears latched device state where supported. |
-| `RemoteResetAsync` | `Task<Responce> RemoteResetAsync(CancellationToken cancellationToken = default)` | Completion | Issues remote RESET. |
-| `UnlockAsync` | `Task<Responce> UnlockAsync(string password, CancellationToken cancellationToken = default)` | Completion | Remote password unlock. |
-| `LockAsync` | `Task<Responce> LockAsync(string password, CancellationToken cancellationToken = default)` | Completion | Remote password lock. |
-| `ClearErrorAsync` | `Task<Responce> ClearErrorAsync(CancellationToken cancellationToken = default)` | Completion | Clears error/LED indication where supported. |
-| `LoopbackAsync` | `Task<Responce<byte[]>> LoopbackAsync(byte[] data, CancellationToken cancellationToken = default)` | Echoed payload | Link/protocol loopback test. |
-| `ReadMemoryAsync` | `Task<Responce<ushort[]>> ReadMemoryAsync(ushort command, ushort address, int length, CancellationToken cancellationToken = default)` | Word values | Memory or intelligent-module buffer read. |
-| `WriteMemoryAsync` | `Task<Responce> WriteMemoryAsync(ushort command, ushort address, IReadOnlyList<ushort> values, CancellationToken cancellationToken = default)` | Completion | Memory or intelligent-module buffer write. |
-| `ExecuteRawAsync` | `Task<Responce<byte[]>> ExecuteRawAsync(MitsubishiRawCommandRequest request, CancellationToken cancellationToken = default)` | Raw decoded payload | Advanced raw MC/SLMP command execution. |
-
-```csharp
 var blocks = new MitsubishiBlockRequest(
-    WordBlocks: [new MitsubishiWordBlock(MitsubishiDeviceAddress.Parse("D100"), new ushort[4])],
-    BitBlocks: [new MitsubishiBitBlock(MitsubishiDeviceAddress.Parse("M10"), new bool[8])]);
-
-var blockPayload = await client.ReadBlocksAsync(blocks);
+    [new MitsubishiWordBlock(MitsubishiDeviceAddress.Parse("D100", options.XyNotation), new ushort[] { 1, 2, 3, 4 })],
+    [new MitsubishiBitBlock(MitsubishiDeviceAddress.Parse("M100", options.XyNotation), new bool[] { true, false })]);
+var blockRead = await plc.ReadBlocksAsync(blocks, CancellationToken.None);
+var blockWrite = await plc.WriteBlocksAsync(blocks, CancellationToken.None);
+if (!blockWrite.IsSucceed) Console.Error.WriteLine(blockWrite.Err);
 ```
 
-### Low-level compatibility methods
+### Controller diagnostics, control, and raw protocol access
 
-These methods exist for compatibility with older socket-style consumers. Prefer the typed high-level APIs for new code because they apply frame-specific encoding/decoding and diagnostics consistently.
-
-| API | Signature | Purpose |
-|---|---|---|
-| `SendPackage` | `Responce<byte[]> SendPackage(byte[] command, int receiveCount)` | Send a raw command and expect a fixed receive count. |
-| `SendPackageSingle` | `Responce<byte[]> SendPackageSingle(byte[] command)` | Send one raw command using default receive handling. |
-| `SendPackageReliable` | `Responce<byte[]> SendPackageReliable(byte[] command)` | Send one raw command using the reliable exchange path. |
-
-### Tag-based APIs
-
-Tag APIs resolve `tagName` through `client.TagDatabase`, then delegate to address-based operations or typed conversion helpers.
-
-| API | Signature | Purpose |
-|---|---|---|
-| `ReadWordsByTagAsync` | `Task<Responce<ushort[]>> ReadWordsByTagAsync(string tagName, int points, CancellationToken cancellationToken = default)` | Read raw words from a configured tag address. |
-| `ReadBitsByTagAsync` | `Task<Responce<bool[]>> ReadBitsByTagAsync(string tagName, int points, CancellationToken cancellationToken = default)` | Read bits from a configured tag address. |
-| `WriteWordsByTagAsync` | `Task<Responce> WriteWordsByTagAsync(string tagName, IReadOnlyList<ushort> values, CancellationToken cancellationToken = default)` | Write raw words to a configured tag address. |
-| `WriteBitsByTagAsync` | `Task<Responce> WriteBitsByTagAsync(string tagName, IReadOnlyList<bool> values, CancellationToken cancellationToken = default)` | Write bits to a configured tag address. |
-| `RandomReadWordsByTagAsync` | `Task<Responce<ushort[]>> RandomReadWordsByTagAsync(IEnumerable<string> tagNames, CancellationToken cancellationToken = default)` | Sparse word read by tag names. |
-| `RandomWriteWordsByTagAsync` | `Task<Responce> RandomWriteWordsByTagAsync(IEnumerable<KeyValuePair<string, ushort>> values, CancellationToken cancellationToken = default)` | Sparse word write by tag names. |
-| `ReadGeneratedBitTagAsync` | `Task<Responce<bool>> ReadGeneratedBitTagAsync(string tagName, CancellationToken cancellationToken = default)` | Helper used by generated bit-tag accessors. Usually called through `client.Generated().Tags.X.ReadAsync()`. |
-| `WriteGeneratedBitTagAsync` | `Task<Responce> WriteGeneratedBitTagAsync(string tagName, bool value, CancellationToken cancellationToken = default)` | Helper used by generated bit-tag accessors. |
+`ReadTypeNameAsync` returns `MitsubishiTypeName` (model name and model code). `ClearErrorAsync`, `LoopbackAsync`, and `ReadMemoryAsync`/`WriteMemoryAsync` support commissioning and diagnosis. Their result follows the same `Responce` model; `LoopbackAsync` returns the echoed bytes and memory reads return `ushort[]`. Memory calls require the documented MC-memory command as well as address and length/value payload.
 
 ```csharp
-client.TagDatabase = MitsubishiTagDatabase.FromCsv(File.ReadAllText("plc-tags.csv"));
-
-await client.WriteWordsByTagAsync("RecipeNumber", [7]);
-var running = await client.ReadBitsByTagAsync("PumpRunning", 1);
+var identity = await plc.ReadTypeNameAsync(CancellationToken.None);
+var echoed = await plc.LoopbackAsync([0x01, 0x02], CancellationToken.None);
+var buffer = await plc.ReadMemoryAsync(command: 0x0613, address: 0x1000, length: 16,
+    cancellationToken: CancellationToken.None);
+if (buffer.IsSucceed)
+    await plc.WriteMemoryAsync(command: 0x1613, address: 0x1000, values: buffer.Value!,
+        cancellationToken: CancellationToken.None);
 ```
 
-### Typed tag conversion APIs
-
-| API | Signature | PLC words used | Purpose |
-|---|---|---:|---|
-| `ReadInt16ByTagAsync` | `Task<Responce<short>> ReadInt16ByTagAsync(string tagName, CancellationToken cancellationToken = default)` | 1 | Signed 16-bit read. |
-| `WriteInt16ByTagAsync` | `Task<Responce> WriteInt16ByTagAsync(string tagName, short value, CancellationToken cancellationToken = default)` | 1 | Signed 16-bit write. |
-| `ReadUInt16ByTagAsync` | `Task<Responce<ushort>> ReadUInt16ByTagAsync(string tagName, CancellationToken cancellationToken = default)` | 1 | Unsigned 16-bit read. |
-| `WriteUInt16ByTagAsync` | `Task<Responce> WriteUInt16ByTagAsync(string tagName, ushort value, CancellationToken cancellationToken = default)` | 1 | Unsigned 16-bit write. |
-| `ReadInt32ByTagAsync` | `Task<Responce<int>> ReadInt32ByTagAsync(string tagName, CancellationToken cancellationToken = default)` | 2 | Signed 32-bit read. Honors `ByteOrder`. |
-| `WriteInt32ByTagAsync` | `Task<Responce> WriteInt32ByTagAsync(string tagName, int value, CancellationToken cancellationToken = default)` | 2 | Signed 32-bit write. Honors `ByteOrder`. |
-| `ReadDWordByTagAsync` | `Task<Responce<uint>> ReadDWordByTagAsync(string tagName, CancellationToken cancellationToken = default)` | 2 | Unsigned 32-bit / DWord read. |
-| `WriteDWordByTagAsync` | `Task<Responce> WriteDWordByTagAsync(string tagName, uint value, CancellationToken cancellationToken = default)` | 2 | Unsigned 32-bit / DWord write. |
-| `ReadFloatByTagAsync` | `Task<Responce<float>> ReadFloatByTagAsync(string tagName, CancellationToken cancellationToken = default)` | 2 | IEEE754 single-precision read. |
-| `WriteFloatByTagAsync` | `Task<Responce> WriteFloatByTagAsync(string tagName, float value, CancellationToken cancellationToken = default)` | 2 | IEEE754 single-precision write. |
-| `ReadScaledDoubleByTagAsync` | `Task<Responce<double>> ReadScaledDoubleByTagAsync(string tagName, CancellationToken cancellationToken = default)` | Depends on `DataType` | Engineering value read using `(raw * Scale) + Offset`. |
-| `WriteScaledDoubleByTagAsync` | `Task<Responce> WriteScaledDoubleByTagAsync(string tagName, double value, CancellationToken cancellationToken = default)` | Depends on `DataType` | Engineering value write using `(value - Offset) / Scale`. |
-| `ReadStringByTagAsync` | `Task<Responce<string>> ReadStringByTagAsync(string tagName, CancellationToken cancellationToken = default)` | `Length` metadata | Schema-driven string read. |
-| `ReadStringByTagAsync` | `Task<Responce<string>> ReadStringByTagAsync(string tagName, int wordLength, CancellationToken cancellationToken = default)` | `wordLength` | Explicit-length string read. |
-| `WriteStringByTagAsync` | `Task<Responce> WriteStringByTagAsync(string tagName, string value, CancellationToken cancellationToken = default)` | `Length` metadata | Schema-driven string write. |
-| `WriteStringByTagAsync` | `Task<Responce> WriteStringByTagAsync(string tagName, string value, int wordLength, CancellationToken cancellationToken = default)` | `wordLength` | Explicit-length string write. |
+`RemoteRunAsync`, `RemoteStopAsync`, `RemotePauseAsync`, `RemoteLatchClearAsync`, `RemoteResetAsync`, `UnlockAsync`, and `LockAsync` change controller state or protection. Put an application-level authorization, interlock, confirmation record, and a read-back check around them. Do not expose these calls directly to an untrusted UI. `ExecuteRawAsync(MitsubishiRawCommandRequest, token)` is for a documented command not yet wrapped by the higher-level methods; it returns its wire reply and should be isolated behind a versioned, tested adapter. Legacy `SendPackage`, `SendPackageSingle`, and `SendPackageReliable` are synchronous byte-package compatibility APIs; new code should prefer `ExecuteRawAsync`.
 
 ```csharp
-var total = await client.ReadDWordByTagAsync("TotalCount");
-var pressure = await client.ReadFloatByTagAsync("ProcessValue");
-var operatorMessage = await client.ReadStringByTagAsync("OperatorMessage");
+if (operatorApproved && await IsPlantSafeAsync())
+{
+    var stopped = await plc.RemoteStopAsync(CancellationToken.None);
+    if (!stopped.IsSucceed) throw new InvalidOperationException(stopped.Err);
+    var clear = await plc.ClearErrorAsync(CancellationToken.None);
+}
 
-await client.WriteScaledDoubleByTagAsync("HeadTemp", 22.5d);
+var request = new MitsubishiRawCommandRequest(Command: 0x0619, Subcommand: 0,
+    Body: Array.Empty<byte>(), Description: "Site-approved diagnostic");
+Responce<byte[]> raw = await plc.ExecuteRawAsync(request, CancellationToken.None);
 ```
 
-### Tag database and schema APIs
+### Polling, freshness, triggers, and write queues
 
-| API | Signature | Purpose |
-|---|---|---|
-| `MitsubishiTagDatabase` | `MitsubishiTagDatabase(IEnumerable<MitsubishiTagDefinition> tags)` | Creates an in-memory tag database. |
-| Serialization document helpers | `MitsubishiTagDefinitionDocument.ToModel()`, `MitsubishiTagDefinitionDocument.FromModel(...)`, `MitsubishiTagGroupDefinitionDocument.ToModel()`, `MitsubishiTagGroupDefinitionDocument.FromModel(...)` | DTO mapping helpers used by JSON/YAML persistence; application code normally uses `FromJson`, `FromYaml`, `ToJson`, `ToYaml`, `Load`, and `Save`. |
-| `Count` | `int Count { get; }` | Number of tags. |
-| `GroupCount` | `int GroupCount { get; }` | Number of groups. |
-| `Tags` | `IReadOnlyCollection<MitsubishiTagDefinition> Tags { get; }` | Tag definitions. |
-| `Groups` | `IReadOnlyCollection<MitsubishiTagGroupDefinition> Groups { get; }` | Group definitions. |
-| `Add` | `void Add(MitsubishiTagDefinition tag)` | Adds or replaces a tag after validating metadata. |
-| `TryGet` | `bool TryGet(string name, out MitsubishiTagDefinition tag)` | Case-insensitive optional tag lookup. |
-| `GetRequired` | `MitsubishiTagDefinition GetRequired(string name)` | Case-insensitive required tag lookup. |
-| `AddGroup` | `void AddGroup(MitsubishiTagGroupDefinition group)` | Adds or replaces a group. |
-| `TryGetGroup` | `bool TryGetGroup(string name, out MitsubishiTagGroupDefinition group)` | Optional group lookup. |
-| `GetRequiredGroup` | `MitsubishiTagGroupDefinition GetRequiredGroup(string name)` | Required group lookup. |
-| `FromCsv` | `static MitsubishiTagDatabase FromCsv(string csvContent)` | Loads tag definitions from CSV. |
-| `FromJson` | `static MitsubishiTagDatabase FromJson(string json)` | Loads full schema from JSON. |
-| `FromYaml` | `static MitsubishiTagDatabase FromYaml(string yaml)` | Loads full schema from YAML. |
-| `Load` | `static MitsubishiTagDatabase Load(string path)` | Loads by extension: `.csv`, `.json`, `.yaml`, `.yml`. |
-| `ToJson` | `string ToJson()` | Serializes full schema to JSON. |
-| `ToYaml` | `string ToYaml()` | Serializes full schema to YAML. |
-| `Save` | `void Save(string path)` | Saves by extension. CSV is tag-only; JSON/YAML preserve groups. |
-| `CompareWith` | `MitsubishiTagDatabaseDiff CompareWith(MitsubishiTagDatabase other)` | Computes semantic schema diff. |
+`ObserveWords` and `ObserveBits` repeatedly invoke their direct counterparts at an interval. `ObserveWordsHeartbeat` wraps each poll in a `Heartbeat<T>`; `ObserveWordsStale` emits `Stale<T>` when no new value arrives within the configured age. `ObserveWordsLatest` accepts an observable trigger and keeps only the newest in-flight result, which is appropriate for bursty UI refresh events. Dispose each subscription to stop scheduling and retain no subscription after the client is disposed.
 
 ```csharp
-var tags = new MitsubishiTagDatabase([
-    new MitsubishiTagDefinition("MotorSpeed", "D100", DataType: "Float", Units: "rpm"),
-    new MitsubishiTagDefinition("PumpRunning", "M10", DataType: "Bit")
+using var cts = new CancellationTokenSource();
+using var telemetry = plc.ObserveWordsHeartbeat("D100", 2, TimeSpan.FromMilliseconds(250),
+    heartbeatAfter: TimeSpan.FromSeconds(1), minimumUpdateSpacing: null, pollTimeout: null)
+    .Subscribe(beat => Console.WriteLine($"{beat.Value.Value?[0]} @ {beat.Timestamp:O}"));
+using var health = plc.ObserveWordsStale("D100", 2, TimeSpan.FromMilliseconds(250),
+    TimeSpan.FromSeconds(2), minimumUpdateSpacing: null)
+    .Subscribe(stale => Console.WriteLine(stale.IsStale));
+```
+
+`ObserveReactiveWords`, `ObserveReactiveTag<T>`, and `ObserveReactiveTagGroup` add a `MitsubishiReactiveValue<T>` with `MitsubishiReactiveQuality` (`Good`, error/stale/heartbeat states) and timestamp/error context. Use it for view models and downstream decisions that must distinguish a valid zero from a failed or stale read. `CreateReactiveWordWritePipeline` and `CreateReactiveTagWritePipeline<T>` accept a source of desired values, serialize writes, and report `MitsubishiReactiveWriteResult`; choose `MitsubishiReactiveWriteMode` deliberately (for example, latest-only for a slider and every value for an auditable setpoint sequence).
+
+```csharp
+using var values = plc.ObserveReactiveWords("D100", 1, TimeSpan.FromSeconds(1))
+    .Where(v => v.Quality == MitsubishiReactiveQuality.Good)
+    .Subscribe(v => Render(v.Value![0]));
+
+using var writer = plc.CreateReactiveWordWritePipeline("D200",
+    MitsubishiReactiveWriteMode.LatestWins, TimeSpan.FromMilliseconds(100));
+using var writeResults = writer.Results.Subscribe(r => Console.WriteLine(r.Success));
+writer.Post(new ushort[] { 42 });
+```
+
+### Tag database, typed values, groups, and schema rollout
+
+`MitsubishiTagDatabase` maps stable names to `MitsubishiTagDefinition` records. A tag can declare address, data type, point count, string length/encoding and engineering scale metadata; `MitsubishiTagValueConverter` performs the conversion. Build it with the constructor/Add methods, `FromCsv`, `FromJson`, `FromYaml`, or `Load`; persist using `ToCsv`, `ToJson`, `ToYaml`, and `Save`. Assign the database to `TagDatabase`, call `ValidateTagDatabase`, and only then use the by-tag APIs. Failure to assign or validate a database is an application configuration error, not a retryable PLC fault.
+
+```csharp
+var database = new MitsubishiTagDatabase([
+    new MitsubishiTagDefinition("Temperature", "D100", "Float"),
+    new MitsubishiTagDefinition("Enable", "M100", "Bit"),
+    new MitsubishiTagDefinition("Recipe", "D200", "String", Length: 20),
+    new MitsubishiTagDefinition("Flow", "D120", "UInt16", Scale: 0.1, Units: "L/min")
 ]);
+database.AddGroup(new MitsubishiTagGroupDefinition("RecipeCommit", ["Temperature", "Enable", "Recipe"]));
+plc.TagDatabase = database;
+var valid = plc.ValidateTagDatabase();
+if (!valid.IsSucceed) throw new InvalidOperationException(valid.Err);
 
-tags.AddGroup(new MitsubishiTagGroupDefinition("Overview", ["MotorSpeed", "PumpRunning"]));
-tags.Save("plc-tags.yaml");
+var temperature = await plc.ReadFloatByTagAsync("Temperature", CancellationToken.None);
+var enabled = await plc.ReadBitsByTagAsync("Enable", 1, CancellationToken.None);
+var recipe = await plc.ReadStringByTagAsync("Recipe", CancellationToken.None);
 ```
 
-### Schema validation, reload, diff, and rollout APIs
-
-| API | Signature | Purpose |
-|---|---|---|
-| `ValidateTagDatabase` | `Responce ValidateTagDatabase()` | Validates configured tag addresses, string lengths, and group membership. |
-| `LoadAndValidateTagDatabase` | `Responce<MitsubishiTagDatabase> LoadAndValidateTagDatabase(string path)` | Loads, validates, applies on success using `AllowAll`. |
-| `LoadAndValidateTagDatabase` | `Responce<MitsubishiTagDatabase> LoadAndValidateTagDatabase(string path, MitsubishiTagRolloutPolicy policy)` | Loads, validates, diff-checks against policy, applies on success. |
-| `PreviewTagDatabaseDiff` | `Responce<MitsubishiTagDatabaseDiff> PreviewTagDatabaseDiff(string path)` | Loads and validates incoming schema, returns semantic diff without applying. |
-| `PreviewTagDatabaseDiff` | `Responce<MitsubishiTagDatabaseDiff> PreviewTagDatabaseDiff(string path, MitsubishiTagRolloutPolicy policy)` | Preview plus rollout policy enforcement. |
-| `ObserveTagDatabaseReload` | `IObservable<Responce<MitsubishiTagDatabase>> ObserveTagDatabaseReload(string path, TimeSpan pollInterval, bool emitInitial = true)` | Polls schema file and emits valid/invalid reload results. |
-| `ObserveTagDatabaseReload` | `IObservable<Responce<MitsubishiTagDatabase>> ObserveTagDatabaseReload(string path, TimeSpan pollInterval, bool emitInitial, MitsubishiTagRolloutPolicy policy)` | Reload stream gated by rollout policy. |
-| `ObserveTagDatabaseDiff` | `IObservable<Responce<MitsubishiTagDatabaseDiff>> ObserveTagDatabaseDiff(string path, TimeSpan pollInterval, bool emitInitial = true)` | Polls schema file and emits semantic diffs. |
-| `ObserveTagDatabaseDiff` | `IObservable<Responce<MitsubishiTagDatabaseDiff>> ObserveTagDatabaseDiff(string path, TimeSpan pollInterval, bool emitInitial, MitsubishiTagRolloutPolicy policy)` | Diff stream gated by rollout policy. |
-
-Invalid reload/diff emissions do not replace the active `client.TagDatabase`.
-
-### Tag group APIs
-
-| API | Signature | Purpose |
-|---|---|---|
-| `ReadTagGroupSnapshotAsync` | `Task<Responce<MitsubishiTagGroupSnapshot>> ReadTagGroupSnapshotAsync(string groupName, CancellationToken cancellationToken = default)` | Reads every tag in a group and returns a heterogeneous snapshot. |
-| `ValidateTagGroupWrite` | `Responce ValidateTagGroupWrite(string groupName, IReadOnlyDictionary<string, object?> values)` | Validates provided write values against group membership and tag data types. |
-| `WriteTagGroupValuesAsync` | `Task<Responce> WriteTagGroupValuesAsync(string groupName, IReadOnlyDictionary<string, object?> values, CancellationToken cancellationToken = default)` | Writes only supplied group values in configured group order. |
-| `WriteTagGroupSnapshotAsync` | `Task<Responce> WriteTagGroupSnapshotAsync(MitsubishiTagGroupSnapshot snapshot, CancellationToken cancellationToken = default)` | Writes a complete snapshot back to its group. |
-| Snapshot accessor | `snapshot.GetRequired<T>(tagName)` | Gets a typed value or throws when missing/wrong type. |
-| Snapshot optional accessor | `snapshot.GetOptional<T>(tagName)` | Gets a typed value or default when missing/wrong type. |
+The typed families are `Read`/`WriteWordsByTagAsync`, `Bits`, `Int16`, `UInt16`, `Int32`, `DWord`/`UInt32`, `Float`, `ScaledDouble`, and `String`; `ReadTagAsync`/`WriteTagAsync` dispatch by metadata. Use a typed method when the schema is known at compile time, and the generic method only for an editor/importer. String calls have overloads for explicit length where required. `RandomReadWordsByTagAsync`/`RandomWriteWordsByTagAsync` resolve names before the sparse protocol operation.
 
 ```csharp
-var snapshot = await client.ReadTagGroupSnapshotAsync("Overview");
+var setTemperature = await plc.WriteFloatByTagAsync("Temperature", 21.5f, CancellationToken.None);
+var setRecipe = await plc.WriteStringByTagAsync("Recipe", "Batch-07", CancellationToken.None);
+var engineering = await plc.ReadScaledDoubleByTagAsync("Flow", CancellationToken.None);
+var arbitrary = await plc.ReadTagAsync("Temperature", CancellationToken.None);
+```
+
+Groups provide an explicit, validated write boundary. `ReadTagGroupSnapshotAsync` returns `MitsubishiTagGroupSnapshot`; `ValidateTagGroupWrite` checks names/types before any remote write; `WriteTagGroupValuesAsync` writes the supplied members; and `WriteTagGroupSnapshotAsync` replays a snapshot. A group operation is sequential rather than a transactional PLC instruction, so use the PLC program's commit/handshake bit if atomic process visibility is required.
+
+```csharp
+var staged = new Dictionary<string, object?> { ["Temperature"] = 22.0f, ["Enable"] = true };
+var check = plc.ValidateTagGroupWrite("RecipeCommit", staged);
+if (check.IsSucceed)
+    await plc.WriteTagGroupValuesAsync("RecipeCommit", staged, CancellationToken.None);
+
+var snapshot = await plc.ReadTagGroupSnapshotAsync("RecipeCommit", CancellationToken.None);
 if (snapshot.IsSucceed)
+    await plc.WriteTagGroupSnapshotAsync(snapshot.Value!, CancellationToken.None);
+```
+
+For controlled configuration change, use `LoadAndValidateTagDatabase`, `PreviewTagDatabaseDiff`, `ObserveTagDatabaseDiff`, and `ObserveTagDatabaseReload`. `MitsubishiTagDatabaseDiff`, `MitsubishiTagChange`, `MitsubishiTagGroupChange`, and `MitsubishiSchemaChangeKind` tell which entries change. Apply a `MitsubishiTagRolloutPolicy` only after a preview has been reviewed; do not hot-reload a safety-critical mapping without an operations change process.
+
+```csharp
+var preview = plc.PreviewTagDatabaseDiff("tags.yaml", MitsubishiTagRolloutPolicy.AllowAll);
+if (preview.IsSucceed && preview.Value!.IsEmpty)
+    Console.WriteLine("No mapping change");
+using var reload = plc.ObserveTagDatabaseReload("tags.yaml", TimeSpan.FromSeconds(5), emitInitial: true)
+    .Subscribe(result => Console.WriteLine(result.IsSucceed ? "Reloaded" : result.Err));
+```
+
+### Logical tags, bulk operations, and source generation
+
+`CreateLogicalTagClient` composes the common `ILogicalTagCatalog` with the Mitsubishi transport and optional `LogicalTagSqliteStore`. `MitsubishiLogicalTagClient` supports registration, read/write one or many tags, observable and async-enumerable observation, persistence and operation metrics. It is the appropriate boundary when several protocols share a logical-tag catalog. Dispose it before disposing the native Mitsubishi client.
+
+```csharp
+using IoT.DriverCore.Core;
+
+using var catalog = new LogicalTagCatalog();
+var store = new LogicalTagSqliteStore("Data Source=logical-tags.db");
+using var logical = plc.CreateLogicalTagClient(catalog, TimeSpan.FromSeconds(1), store);
+var result = await logical.ReadAsync("Line1.Temperature", CancellationToken.None);
+await foreach (var update in logical.ObserveAsync("Line1.Temperature", CancellationToken.None))
+    Console.WriteLine(update.Value);
+```
+
+The `MitsubishiTagClientGenerator` recognizes `MitsubishiTagClientAttribute`, `MitsubishiTagAttribute`, and `MitsubishiTagClientSchemaAttribute`. It generates a typed client, `GeneratedMitsubishiTagClient` entrypoint, extension/`GroupsClient` surfaces and per-group `TagsClient` accessors. The runtime packages embed this analyzer; `MitsubishiRx.Generators` is a standalone optional analyzer package for a project that intentionally supplies/pins it separately. Do not install duplicate versions in one project. The generator validates supported scalar/tag metadata at compile time, so use attributes for a stable, source-controlled schema and the runtime database for imported/operational schemas.
+
+```csharp
+using IoT.DriverCore.MitsubishiRx;
+
+[MitsubishiTagClient(nameof(LogicalTags))]
+public sealed partial class FurnaceTags
 {
-    float speed = snapshot.Value!.GetRequired<float>("MotorSpeed");
-    bool pump = snapshot.Value.GetRequired<bool>("PumpRunning");
+    public MitsubishiLogicalTagClient LogicalTags { get; init; } = null!;
+
+    [MitsubishiTag("Furnace.Temperature")]
+    public float Temperature { get; set; }
+
+    [MitsubishiTag("Furnace.Enabled")]
+    public bool Enabled { get; set; }
+}
+// The generated client binds the declared members to MitsubishiRx; inspect obj/Generated
+// or the generator diagnostics when an attribute is malformed.
+```
+
+### Test transports and two combined workflows
+
+The client selects its built-in TCP/UDP or serial transport from `MitsubishiClientOptions`; those transport implementations are intentionally internal. `IMitsubishiTransport` is the public contract for a custom transport. `MitsubishiSimulatorMemory` offers direct word/bit state, while `MitsubishiSimulatorTransport` records requests, queues responses/connect/exchange faults, or uses stateful memory. Use the simulator in unit tests rather than a production PLC.
+
+```csharp
+var memory = new MitsubishiSimulatorMemory();
+memory.WriteWords("D100", [10, 20]);
+await using var simulated = new MitsubishiRx(
+    options, new MitsubishiSimulatorTransport(memory), scheduler: null);
+await simulated.OpenAsync(CancellationToken.None);
+var result = await simulated.ReadWordsAsync("D100", 2, CancellationToken.None);
+```
+
+**Workflow 1 - production telemetry with freshness and safe setpoints.** Validate/load the tag database, open the client, observe a tag group with `ObserveReactiveTagGroup` or `ObserveTagGroupStale`, inhibit UI changes when quality is stale/error, validate a group write, write the staged values through a latest-only pipeline, and record `OperationLogs`. This combines configuration validation, polling, quality, grouped writes and audit telemetry without assuming a successful network response is a process-safe outcome.
+
+```csharp
+await using var production = new MitsubishiRx(options, transport: null, scheduler: null);
+production.TagDatabase = MitsubishiTagDatabase.Load("line-a-tags.yaml");
+var schema = production.ValidateTagDatabase();
+if (!schema.IsSucceed) throw new InvalidOperationException(schema.Err);
+
+using var logs = production.OperationLogs.Subscribe(log => Audit(log.Description, log.Success));
+using var fresh = production.ObserveTagGroupStale("Setpoints", TimeSpan.FromMilliseconds(250),
+    TimeSpan.FromSeconds(2), minimumUpdateSpacing: null)
+    .Subscribe(sample => SetControlsEnabled(!sample.IsStale && sample.Value.IsSucceed));
+
+var open = await production.OpenAsync(CancellationToken.None);
+if (!open.IsSucceed) throw new InvalidOperationException(open.Err);
+var staged = new Dictionary<string, object?> { ["TargetTemperature"] = 70.0f, ["Enabled"] = true };
+var accepted = production.ValidateTagGroupWrite("Setpoints", staged);
+if (accepted.IsSucceed && await OperatorInterlockAllowsAsync())
+{
+    var written = await production.WriteTagGroupValuesAsync("Setpoints", staged, CancellationToken.None);
+    if (!written.IsSucceed) ReportWriteFailure(written.Err);
+}
+await production.CloseAsync(CancellationToken.None);
+```
+
+**Workflow 2 - commissioning with sparse diagnostics.** Open a simulator first, use `ReadTypeNameAsync`, batch-read contiguous regions, random-read sparse registers, register/execute a monitor for repeated inspection, then move the same options to a live isolated PLC. Keep remote-control and raw commands behind an explicit operator authorization, capture operation logs, and close/dispose when the session ends.
+
+```csharp
+var memory = new MitsubishiSimulatorMemory();
+memory.WriteWords("D100", new ushort[] { 100, 101, 102, 103 });
+memory.WriteWords("D200", new ushort[] { 200 });
+await using var bench = new MitsubishiRx(
+    options, new MitsubishiSimulatorTransport(memory), scheduler: null);
+using var diagnostics = bench.OperationLogs.Subscribe(log => Console.WriteLine(log.Description));
+if (!(await bench.OpenAsync(CancellationToken.None)).IsSucceed) return;
+
+var identity = await bench.ReadTypeNameAsync(CancellationToken.None);
+var contiguous = await bench.ReadWordsAsync("D100", 4, CancellationToken.None);
+var sparse = await bench.RandomReadWordsAsync(new[] { "D100", "D200" }, CancellationToken.None);
+var registered = await bench.RegisterMonitorAsync(new[] { "D100", "D200" }, CancellationToken.None);
+Responce<byte[]> monitor = registered.IsSucceed
+    ? await bench.ExecuteMonitorAsync(CancellationToken.None)
+    : new Responce<byte[]>(registered);
+if (!identity.IsSucceed || !contiguous.IsSucceed || !sparse.IsSucceed || !monitor.IsSucceed)
+    throw new InvalidOperationException("Commissioning diagnostic did not succeed.");
+await bench.CloseAsync(CancellationToken.None);
+```
+
+### Device operations and monitoring
+
+`ReadWordsAsync`, `WriteWordsAsync`, `ReadBitsAsync`, and `WriteBitsAsync` operate on direct addresses. `RandomReadWordsAsync` / `RandomWriteWordsAsync` issue random-device requests; `RegisterMonitorAsync` then `ExecuteMonitorAsync` use PLC monitor registration; `ReadBlocksAsync` / `WriteBlocksAsync` use `MitsubishiWordBlock` and `MitsubishiBitBlock` requests. Use a cancellation token on every asynchronous call.
+
+```csharp
+var bits = await plc.ReadBitsAsync("M100", 8, CancellationToken.None);
+var random = await plc.RandomReadWordsAsync(new[] { "D100", "D200" }, CancellationToken.None);
+var monitor = await plc.RegisterMonitorAsync(new[] { "D100", "D101" }, CancellationToken.None);
+var data = monitor.IsSucceed
+    ? await plc.ExecuteMonitorAsync(CancellationToken.None)
+    : new Responce<byte[]>(monitor);
+```
+
+The protocol/control surface is `ReadTypeNameAsync`, `RemoteRunAsync`, `RemoteStopAsync`, `RemotePauseAsync`, `RemoteLatchClearAsync`, `RemoteResetAsync`, `UnlockAsync`, `LockAsync`, `ClearErrorAsync`, `LoopbackAsync`, `ReadMemoryAsync`, `WriteMemoryAsync`, and `ExecuteRawAsync(MitsubishiRawCommandRequest, ...)`. Guard the control methods more strictly than normal reads.
+
+```csharp
+// This belongs behind a site authorization and an independently verified safe state.
+if (operatorApproved && await IsPlantSafeAsync())
+{
+    var unlocked = await plc.UnlockAsync(passwordFromSecureStore, CancellationToken.None);
+    if (!unlocked.IsSucceed) throw new InvalidOperationException(unlocked.Err);
+    var running = await plc.RemoteRunAsync(force: false, clearMode: false,
+        cancellationToken: CancellationToken.None);
+    if (!running.IsSucceed) ReportWriteFailure(running.Err);
+    var locked = await plc.LockAsync(passwordFromSecureStore, CancellationToken.None);
 }
 ```
 
-### Reactive polling APIs
+### Polling, health, and queued writes
 
-| API | Signature | Purpose |
-|---|---|---|
-| `ObserveWords` | `IObservable<Responce<ushort[]>> ObserveWords(string address, int points, TimeSpan pollInterval, TimeSpan? minimumUpdateSpacing = null, TimeSpan? pollTimeout = null)` | Polls words. |
-| `ObserveBits` | `IObservable<Responce<bool[]>> ObserveBits(string address, int points, TimeSpan pollInterval, TimeSpan? minimumUpdateSpacing = null)` | Polls bits. |
-| `ObserveWordsHeartbeat` | `IObservable<Heartbeat<Responce<ushort[]>>> ObserveWordsHeartbeat(string address, int points, TimeSpan pollInterval, TimeSpan heartbeatAfter, TimeSpan? minimumUpdateSpacing = null, TimeSpan? pollTimeout = null)` | Word polling with heartbeat envelopes. |
-| `ObserveWordsStale` | `IObservable<Stale<Responce<ushort[]>>> ObserveWordsStale(string address, int points, TimeSpan pollInterval, TimeSpan staleAfter, TimeSpan? minimumUpdateSpacing = null)` | Word polling with stale markers. |
-| `ObserveWordsLatest` | `IObservable<Responce<ushort[]>> ObserveWordsLatest(string address, int points, IObservable<Unit> trigger)` | Latest-only triggered read. |
-| `ObserveTagGroup` | `IObservable<Responce<MitsubishiTagGroupSnapshot>> ObserveTagGroup(string groupName, TimeSpan pollInterval, TimeSpan? minimumUpdateSpacing = null)` | Polls a tag group. |
-| `ObserveTagGroupHeartbeat` | `IObservable<Heartbeat<Responce<MitsubishiTagGroupSnapshot>>> ObserveTagGroupHeartbeat(string groupName, TimeSpan pollInterval, TimeSpan heartbeatAfter, TimeSpan? minimumUpdateSpacing = null)` | Group polling with heartbeat envelopes. |
-| `ObserveTagGroupStale` | `IObservable<Stale<Responce<MitsubishiTagGroupSnapshot>>> ObserveTagGroupStale(string groupName, TimeSpan pollInterval, TimeSpan staleAfter, TimeSpan? minimumUpdateSpacing = null)` | Group polling with stale markers. |
-| `ObserveTagGroupLatest` | `IObservable<Responce<MitsubishiTagGroupSnapshot>> ObserveTagGroupLatest(string groupName, IObservable<Unit> trigger)` | Latest-only triggered group read. |
-| `SampleDiagnostics` | `IObservable<MitsubishiOperationLog> SampleDiagnostics(IObservable<object> trigger)` | Samples latest operation diagnostics on trigger. |
-| `ObserveConnectionHealth` | `IObservable<Stale<MitsubishiConnectionState>> ObserveConnectionHealth(TimeSpan staleAfter)` | Detects stale connection-state updates. |
+`ObserveWords`, `ObserveBits`, `ObserveWordsHeartbeat`, `ObserveWordsStale`, and `ObserveWordsLatest` turn a scan interval or trigger into streams. Tag groups have equivalent `ObserveTagGroup*` methods. `ConnectionStates`, `OperationLogs`, `SampleDiagnostics`, and `ObserveConnectionHealth` expose lifecycle and operational observations. `ObserveReactiveWords` / `ObserveReactiveTagGroup` add `MitsubishiReactiveValue<T>` quality metadata. `CreateReactiveWordWritePipeline` serializes/coalesces word writes and returns `MitsubishiReactiveWritePipeline<IReadOnlyList<ushort>>`.
 
 ```csharp
-using var sub = client.ObserveWords("D100", 2, TimeSpan.FromSeconds(1))
-    .Subscribe(result => Console.WriteLine(result.IsSucceed ? string.Join(",", result.Value!) : result.Err));
-```
-
-### Hot reactive value APIs
-
-Hot reactive APIs share scan work between equivalent subscribers and emit `MitsubishiReactiveValue<T>` quality envelopes.
-
-| API | Signature | Purpose |
-|---|---|---|
-| `ObserveReactiveWords` | `IObservable<MitsubishiReactiveValue<ushort[]>> ObserveReactiveWords(string address, int points, TimeSpan pollInterval, TimeSpan? minimumUpdateSpacing = null)` | Shared hot word scan. |
-| `ObserveReactiveTag<T>` | `IObservable<MitsubishiReactiveValue<T>> ObserveReactiveTag<T>(string tagName, TimeSpan pollInterval, TimeSpan? minimumUpdateSpacing = null)` | Shared typed tag projection. |
-| `ObserveReactiveTagGroup` | `IObservable<MitsubishiReactiveValue<MitsubishiTagGroupSnapshot>> ObserveReactiveTagGroup(string groupName, TimeSpan pollInterval, TimeSpan? minimumUpdateSpacing = null)` | Shared grouped snapshot scan. |
-| `SharedReactiveStream<T>` | `SharedReactiveStream(Func<bool, IObservable<MitsubishiReactiveValue<T>>> streamFactory)` with `Stream` and `Dispose()` | Internal shared-stream primitive exposed by the assembly; application code normally uses the three `ObserveReactive...` methods instead. |
-
-`MitsubishiReactiveValue<T>` fields: `Value`, `TimestampUtc`, `Quality`, `IsHeartbeat`, `IsStale`, `Source`, `Error`, `ErrorCode`, `Exception`.
-
-`MitsubishiReactiveQuality` values: `Good`, `Bad`, `Stale`, `Heartbeat`, `Error`.
-
-Factory helpers:
-
-| API | Signature | Purpose |
-|---|---|---|
-| `MitsubishiReactiveValue.FromResponse` | `static MitsubishiReactiveValue<T> FromResponse<T>(Responce<T> response, DateTimeOffset timestampUtc, string source)` | Wraps a normal response. |
-| `MitsubishiReactiveValue.Heartbeat` | `static MitsubishiReactiveValue<T> Heartbeat<T>(MitsubishiReactiveValue<T> value, DateTimeOffset timestampUtc)` | Creates a heartbeat envelope. |
-| `MitsubishiReactiveValue.Stale` | `static MitsubishiReactiveValue<T> Stale<T>(MitsubishiReactiveValue<T> value, DateTimeOffset timestampUtc)` | Creates a stale envelope. |
-
-Base package example:
-
-```csharp
-using MitsubishiRx;
-
-using var speed = client.ObserveReactiveTag<float>("MotorSpeed", TimeSpan.FromMilliseconds(500))
-    .Subscribe(value =>
+using var subscription = plc.ObserveWords("D100", 2, TimeSpan.FromMilliseconds(250),
+    minimumUpdateSpacing: null, pollTimeout: null)
+    .Subscribe(reply =>
     {
-        if (value.Quality == MitsubishiReactiveQuality.Good)
-        {
-            Console.WriteLine($"MotorSpeed={value.Value}");
-        }
+        if (reply.IsSucceed) Console.WriteLine(reply.Value![0]);
     });
 ```
 
-Reactive package example:
+For externally triggered refreshes, use a caller-owned `Signal<Unit>` and the latest-only overload. The same scope can observe bit changes; dispose all three subscriptions/signals before disposing the client.
 
 ```csharp
-using MitsubishiRx.Reactive;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Signals;
 
-using var overview = client.ObserveReactiveTagGroup("Line1Overview", TimeSpan.FromSeconds(1))
-    .Subscribe(value =>
+using var refresh = new Signal<Unit>();
+using var bits = plc.ObserveBits("M100", 8, TimeSpan.FromMilliseconds(250), minimumUpdateSpacing: null)
+    .Subscribe(reply =>
     {
-        if (value.Quality == MitsubishiReactiveQuality.Good && value.Value is not null)
-        {
-            Console.WriteLine(value.Value.GetRequired<float>("MotorSpeed"));
-        }
+        if (reply.IsSucceed) Console.WriteLine(string.Join(',', reply.Value!));
     });
-```
-
-### Reactive write pipeline APIs
-
-| API | Signature | Purpose |
-|---|---|---|
-| `CreateReactiveWordWritePipeline` | `MitsubishiReactiveWritePipeline<IReadOnlyList<ushort>> CreateReactiveWordWritePipeline(string address, MitsubishiReactiveWriteMode mode, TimeSpan? coalescingWindow = null)` | Creates a word write pipeline for raw address writes. |
-| `CreateReactiveTagWritePipeline<T>` | `MitsubishiReactiveWritePipeline<T> CreateReactiveTagWritePipeline<T>(string tagName, MitsubishiReactiveWriteMode mode, TimeSpan? coalescingWindow = null)` | Creates a typed tag write pipeline. |
-| `MitsubishiReactiveWritePipeline<TPayload>.Post` | `void Post(TPayload payload)` | Queues/posts a payload according to the configured mode. |
-| `MitsubishiReactiveWritePipeline<TPayload>.Results` | `IObservable<MitsubishiReactiveWriteResult> Results { get; }` | Completion result stream. |
-| `MitsubishiReactiveWritePipeline<TPayload>.Mode` | `MitsubishiReactiveWriteMode Mode { get; }` | Configured behavior. |
-| `Dispose` | `void Dispose()` | Stops the pipeline and releases subscriptions. |
-
-`MitsubishiReactiveWriteMode` values:
-
-| Value | Behavior |
-|---|---|
-| `Queued` | Preserve every posted write in order. |
-| `LatestWins` | Collapse bursts to the latest posted value. |
-| `Coalescing` | Delay within `coalescingWindow` and write the latest value when the window closes. |
-
-`MitsubishiReactiveWriteResult` fields: `Target`, `TimestampUtc`, `Mode`, `Success`, `Error`, `ErrorCode`, `Exception`.
-
-```csharp
-using MitsubishiRx.Reactive;
-
-var writes = client.CreateReactiveWordWritePipeline(
-    "D100",
-    MitsubishiReactiveWriteMode.Queued);
-
-using var results = writes.Results.Subscribe(result =>
-    Console.WriteLine($"{result.Target} success={result.Success} error={result.Error}"));
-
-writes.Post([100, 200, 300]);
-```
-
-### Generated typed client APIs
-
-`MitsubishiRx.Generators` is bundled into the `MitsubishiRx` NuGet package as an analyzer asset at `analyzers/dotnet/cs/MitsubishiRx.Generators.dll`. Consumer projects reference `MitsubishiRx`; they normally do not reference `MitsubishiRx.Generators` directly.
-
-The generator currently emits code under `namespace MitsubishiRx` and references `global::MitsubishiRx.MitsubishiRx`, so generated typed clients are base-package APIs. `MitsubishiRx.Reactive` projects should use the runtime tag and group APIs directly.
-
-Attribute API:
-
-| API | Shape | Purpose |
-|---|---|---|
-| `MitsubishiTagClientSchemaAttribute` | `[AttributeUsage(AttributeTargets.Assembly \| AttributeTargets.Class, AllowMultiple = true, Inherited = false)]` | Marks a compilation with generator schema JSON. |
-| Constructor | `MitsubishiTagClientSchemaAttribute(string schemaJson)` | Accepts compile-time schema JSON. |
-| `SchemaJson` | `string SchemaJson { get; }` | Exposes the supplied schema JSON to the generator. |
-
-Generated root API:
-
-```csharp
-var generated = client.Generated();
-var speed = await generated.Tags.MotorSpeed.ReadAsync();
-await generated.Tags.MotorSpeed.WriteAsync(123.4f);
-
-var line = await generated.Groups.Line1.ReadAsync();
-await generated.Groups.Line1.WriteAsync(line.Value!);
-```
-
-| Generated API | Shape | Purpose |
-|---|---|---|
-| `GeneratedMitsubishiTagClientExtensions.Generated` | `GeneratedMitsubishiTagClient Generated(this global::MitsubishiRx.MitsubishiRx owner)` | Creates the generated facade over an existing client. |
-| `GeneratedMitsubishiTagClient` | `sealed partial class` with `Tags` and `Groups` | Root generated facade. |
-| `TagsClient` | `generated.Tags.<SanitizedTagName>` | Accesses generated per-tag clients. |
-| `GroupsClient` | `generated.Groups.<SanitizedGroupName>` | Accesses generated per-group clients. |
-
-Generated tag clients expose:
-
-| Generated API | Shape | Purpose |
-|---|---|---|
-| `ReadAsync` | `Task<Responce<T>> ReadAsync(CancellationToken cancellationToken = default)` | Reads a typed tag value. |
-| `WriteAsync` | `Task<Responce> WriteAsync(T value, CancellationToken cancellationToken = default)` | Writes a typed tag value. |
-| `Observe` | `IObservable<MitsubishiReactiveValue<T>> Observe(TimeSpan pollInterval, TimeSpan? minimumUpdateSpacing = null)` | Observes a typed tag. |
-
-Generated group clients expose:
-
-| Generated API | Shape | Purpose |
-|---|---|---|
-| `ReadAsync` | `Task<Responce<TSnapshot>> ReadAsync(CancellationToken cancellationToken = default)` | Reads and maps a runtime group snapshot to a generated typed snapshot. |
-| `ReadOptionalAsync` | `Task<Responce<TSnapshot?>> ReadOptionalAsync(CancellationToken cancellationToken = default)` | Returns `null` when the runtime snapshot is incomplete or type-mismatched. |
-| `WriteAsync` | `Task<Responce> WriteAsync(TSnapshot value, CancellationToken cancellationToken = default)` | Writes a generated typed snapshot back through `WriteTagGroupSnapshotAsync`. |
-| `Observe` | `IObservable<MitsubishiReactiveValue<TSnapshot>> Observe(TimeSpan pollInterval, TimeSpan? minimumUpdateSpacing = null)` | Observes a generated typed group snapshot. |
-| `ObserveOptional` | `IObservable<MitsubishiReactiveValue<TSnapshot?>> ObserveOptional(TimeSpan pollInterval, TimeSpan? minimumUpdateSpacing = null)` | Observes an optional generated group snapshot. |
-
-Generated group snapshot helpers expose:
-
-| Generated API | Shape | Purpose |
-|---|---|---|
-| `FromSnapshot` | `static TSnapshot FromSnapshot(MitsubishiTagGroupSnapshot snapshot)` | Required conversion from runtime snapshot to generated record. |
-| `TryFromSnapshot` | `static TSnapshot? TryFromSnapshot(MitsubishiTagGroupSnapshot? snapshot)` | Optional conversion from runtime snapshot to generated record. |
-| `ToSnapshot` | `MitsubishiTagGroupSnapshot ToSnapshot()` | Converts generated record to runtime snapshot for writes. |
-| `MapReactive` | `static MitsubishiReactiveValue<TSnapshot> MapReactive(MitsubishiReactiveValue<MitsubishiTagGroupSnapshot> value)` | Maps reactive runtime snapshots to generated typed envelopes. |
-| `MapReactiveOptional` | `static MitsubishiReactiveValue<TSnapshot?> MapReactiveOptional(MitsubishiReactiveValue<MitsubishiTagGroupSnapshot> value)` | Maps reactive runtime snapshots to optional generated typed envelopes. |
-
-Generated `dataType` mapping:
-
-| `dataType` | Generated type | Read/write helpers |
-|---|---|---|
-| missing / `Word` / `UInt16` | `ushort` | `ReadUInt16ByTagAsync` / `WriteUInt16ByTagAsync` |
-| `Int16` | `short` | `ReadInt16ByTagAsync` / `WriteInt16ByTagAsync` |
-| `Int32` | `int` | `ReadInt32ByTagAsync` / `WriteInt32ByTagAsync` |
-| `DWord` / `UInt32` | `uint` | `ReadDWordByTagAsync` / `WriteDWordByTagAsync` |
-| `Float` | `float` | `ReadFloatByTagAsync` / `WriteFloatByTagAsync` |
-| `String` | `string` | `ReadStringByTagAsync` / `WriteStringByTagAsync` |
-| `Bit` | `bool` | `ReadGeneratedBitTagAsync` / `WriteGeneratedBitTagAsync` |
-
-The implementation types behind this feature are `MitsubishiTagClientGenerator` and `MitsubishiTagClientEmitter`. The source-generator attribute exposes `SchemaJson` from `MitsubishiTagClientSchemaAttribute`; `Initialize(...)` wires the incremental generator. `SchemaModel`, `TagModel`, and `GroupModel` are generator-side schema parse models. Consumers normally only write the attribute and call generated extension methods, not the generator classes directly.
-
-| ID | Meaning |
-|---|---|
-| `MRTXGEN001` | Failed to parse or generate schema client source. |
-| `MRTXGEN002` | Duplicate tag name. |
-| `MRTXGEN003` | Group references unknown tag name. |
-| `MRTXGEN004` | Unsupported generated `dataType`. |
-| `MRTXGEN005` | Sanitized generated identifier collision. |
-| `MRTXGEN006` | Empty tag name. |
-| `MRTXGEN007` | Empty group name. |
-| `MRTXGEN008` | Group has no member tags. |
-| `MRTXGEN009` | Duplicate group name. |
-| `MRTXGEN010` | Empty tag reference inside a group. |
-| `MRTXGEN011` | Duplicate tag reference inside a group. |
-
-### Models, records, enums, and constants
-
-| Type | Members / values | Usage |
-|---|---|---|
-| `MitsubishiClientOptions` | `Host`, `Port`, `FrameType`, `DataCode`, `TransportKind`, `Route`, `MonitoringTimer`, `Timeout`, `CpuType`, `XyNotation`, `LegacyPcNumber`, `SerialNumberProvider`, `Serial`; helper properties `ResolvedTimeout`, `ResolvedRoute`, `ResolvedSerial`; method `GetNextSerialNumber()` | Complete client configuration. |
-| `MitsubishiRoute` | `NetworkNumber`, `StationNumber`, `ModuleIoNumber`, `MultidropStationNumber`, `ExtensionStationNumber`; static `Default` | Ethernet route metadata for 3E/4E. |
-| `MitsubishiSerialOptions` | `PortName`, `BaudRate`, `DataBits`, `Parity`, `StopBits`, `Handshake`, `MessageFormat`, `StationNumber`, `NetworkNumber`, `PcNumber`, `RequestDestinationModuleIoNumber`, `RequestDestinationModuleStationNumber`, `SelfStationNumber`, `MessageWait`, `ReadBufferSize`, `WriteBufferSize`, `NewLine`; property `Route` | Serial port and serial MC protocol settings. |
-| `MitsubishiSerialRoute` | `StationNumber`, `NetworkNumber`, `PcNumber`, `RequestDestinationModuleIoNumber`, `RequestDestinationModuleStationNumber`, `SelfStationNumber` | Derived serial route metadata. |
-| `MitsubishiRawCommandRequest` | `Command`, `Subcommand`, `Body`, `Description`; property `ResolvedBody` | Raw command request for `ExecuteRawAsync`. |
-| `MitsubishiTransportRequest` | `Payload`, `ExpectedResponseLength`, `Description` | Transport-level request passed to custom transports. |
-| `MitsubishiOperationLog` | `TimestampUtc`, `State`, `Description`, `Success`, `RequestPayload`, `ResponsePayload`, `Exception` | Operation diagnostics. |
-| `MitsubishiTypeName` | `ModelName`, `ModelCode` | Return model for `ReadTypeNameAsync`. |
-| `MitsubishiDeviceValue` | `Address`, `Value` | Random-write word pair. |
-| `MitsubishiWordBlock` | `Address`, `Values` | Word block descriptor. |
-| `MitsubishiBitBlock` | `Address`, `Values` | Bit block descriptor. |
-| `MitsubishiBlockRequest` | `WordBlocks`, `BitBlocks`; properties `ResolvedWordBlocks`, `ResolvedBitBlocks` | Multi-block read/write descriptor. |
-| `MitsubishiTagDefinition` | `Name`, `Address`, `DataType`, `Description`, `Scale`, `Offset`, `Length`, `Encoding`, `Units`, `Signed`, `ByteOrder`, `Notes` | Symbolic tag schema row. |
-| `MitsubishiTagGroupDefinition` | `Name`, `TagNames`, `ResolvedTagNames` | Named group/scan class. `ResolvedTagNames` gives a non-null ordered member list. |
-| `MitsubishiTagGroupSnapshot` | `GroupName`, `Values`, `TagNames`; `GetRequired<T>`, `GetOptional<T>` | Typed group result and write payload. |
-| `MitsubishiTagChange` | `Name`, `Previous`, `Current`, `ChangeKinds` | Tag diff item. |
-| `MitsubishiTagGroupChange` | `Name`, `Previous`, `Current`, `ChangeKinds` | Group diff item. |
-| `MitsubishiTagDatabaseDiff` | `AddedTags`, `RemovedTags`, `ChangedTags`, `AddedGroups`, `RemovedGroups`, `ChangedGroups`, `ChangeKinds`, `HasChanges`, `ChangeCount`, static `Empty` | Schema diff result. |
-| `MitsubishiReactiveValue<T>` | `Value`, `TimestampUtc`, `Quality`, `IsHeartbeat`, `IsStale`, `Source`, `Error`, `ErrorCode`, `Exception`; static `FromResponse`, `Heartbeat`, `Stale` | Quality envelope emitted by hot reactive APIs and generated observers. |
-| `MitsubishiReactiveWritePipeline<TPayload>` | `Mode`, `Results`, `Post(TPayload payload)`, `Dispose()` | Reactive write coordinator for raw word and typed tag writes. |
-| `MitsubishiReactiveWriteResult` | `Target`, `TimestampUtc`, `Mode`, `Success`, `Error`, `ErrorCode`, `Exception` | Result emitted after a reactive write pipeline attempts a write. |
-| `Responce` | `IsSucceed`, `Err`, `ErrCode`, `Exception`, `ErrList`, `Request`, `Response`, `Request2`, `Response2`, `TimeConsuming`, `InitialTime`, `SetErrInfo`, `AddErr2List` | Base response envelope. |
-| `Responce<T>` | `Value`; constructors from value/base response; `SetErrInfo` | Typed response envelope. |
-
-Enums:
-
-| Enum | Values |
-|---|---|
-| `CpuType` | `None`, `ASeries`, `QnaSeries`, `QSeries`, `LSeries`, `Fx3`, `Fx5`, `IQR` |
-| `MitsubishiFrameType` | `OneE`, `ThreeE`, `FourE`, `OneC`, `ThreeC`, `FourC` |
-| `CommunicationDataCode` | `Binary`, `Ascii` |
-| `MitsubishiTransportKind` | `Tcp`, `Udp`, `Serial` |
-| `XyAddressNotation` | `Octal`, `Hexadecimal` |
-| `MitsubishiConnectionState` | `Disconnected`, `Connecting`, `Connected`, `Reconnecting`, `Faulted` |
-| `MitsubishiSerialMessageFormat` | `Format1`, `Format4`, `Format5` |
-| `DeviceValueKind` | `Bit`, `Word` |
-| `DeviceNumberFormat` | `Decimal`, `Hexadecimal`, `Octal`, `XyVariable` |
-| `MitsubishiReactiveQuality` | `Good`, `Bad`, `Stale`, `Heartbeat`, `Error` |
-| `MitsubishiReactiveWriteMode` | `Queued`, `LatestWins`, `Coalescing` |
-| `MitsubishiSchemaChangeKind` | `None`, `MetadataOnly`, `AddressChange`, `DataTypeChange`, `GroupMembershipChange`, `StructureChange` |
-| `MitsubishiTagRolloutPolicy` | `AllowAll`, `SafeMetadataAndGroups` |
-
-`MitsubishiCommands` constants:
-
-| Constant | Value | Command |
-|---|---:|---|
-| `DeviceRead` | `0x0401` | Batch read |
-| `DeviceWrite` | `0x1401` | Batch write |
-| `RandomRead` | `0x0403` | Random read |
-| `RandomWrite` | `0x1402` | Random write |
-| `BlockRead` | `0x0406` | Block read |
-| `BlockWrite` | `0x1406` | Block write |
-| `EntryMonitorDevice` | `0x0801` | Monitor registration |
-| `ExecuteMonitor` | `0x0802` | Execute monitor |
-| `ExtendUnitRead` | `0x0601` | Intelligent-module buffer read |
-| `ExtendUnitWrite` | `0x1601` | Intelligent-module buffer write |
-| `MemoryRead` | `0x0613` | Memory read |
-| `MemoryWrite` | `0x1613` | Memory write |
-| `ReadTypeName` | `0x0101` | PLC type-name read |
-| `RemoteRun` | `0x1001` | Remote RUN |
-| `RemoteStop` | `0x1002` | Remote STOP |
-| `RemotePause` | `0x1003` | Remote PAUSE |
-| `RemoteLatchClear` | `0x1005` | Remote latch clear |
-| `RemoteReset` | `0x1006` | Remote RESET |
-| `Unlock` | `0x1630` | Remote password unlock |
-| `Lock` | `0x1631` | Remote password lock |
-| `LoopbackTest` | `0x0619` | Loopback |
-| `ClearError` | `0x1617` | Clear error |
-
-### Device addressing reference
-
-`MitsubishiDeviceAddress.Parse(value, xyNotation)` validates and normalizes device addresses. `MitsubishiDeviceAddress.Metadata` exposes supported device families. A parsed address exposes `Descriptor`, whose `MitsubishiDeviceMetadata` contains `Symbol`, `BinaryCode`, `AsciiCode`, `Kind`, and `NumberFormat`; call `GetRadix(xyNotation)` when building custom tooling that needs the effective address base.
-
-| Device | Kind | Number format |
-|---|---|---|
-| `X` | Bit | Octal or hexadecimal via `XyAddressNotation` |
-| `Y` | Bit | Octal or hexadecimal via `XyAddressNotation` |
-| `M` | Bit | Decimal |
-| `L` | Bit | Decimal |
-| `B` | Bit | Hexadecimal |
-| `D` | Word | Decimal |
-| `W` | Word | Hexadecimal |
-| `R` | Word | Decimal |
-| `ZR` | Word | Hexadecimal |
-| `TN` | Word | Decimal |
-| `TS` | Bit | Decimal |
-| `TC` | Bit | Decimal |
-| `CN` | Word | Decimal |
-| `CS` | Bit | Decimal |
-| `CC` | Bit | Decimal |
-| `SM` | Bit | Decimal |
-| `SD` | Word | Decimal |
-
-```csharp
-var xOctal = MitsubishiDeviceAddress.Parse("X20", XyAddressNotation.Octal);
-var xHex = MitsubishiDeviceAddress.Parse("X20", XyAddressNotation.Hexadecimal);
-Console.WriteLine($"octal={xOctal.Number}, hex={xHex.Number}");
-```
-
-### Advanced protocol and transport extension points
-
-Most applications should use `MitsubishiRx` high-level APIs. The following public helpers are available for advanced testing, custom tooling, protocol inspection, and custom transports.
-
-| API | Purpose |
-|---|---|
-| `IMitsubishiTransport` | Implement `ConnectAsync`, `DisconnectAsync`, `ExchangeAsync`, `IsConnected`, `Dispose`, and `DisposeAsync` for custom transport backends. |
-| `SocketMitsubishiTransport` | Built-in TCP/UDP transport. |
-| `ReactiveSerialMitsubishiTransport` | Built-in SerialPortRx-backed serial transport. |
-| `ReactiveSerialPortAdapter` | Adapter around `SerialPortRx`; exposes `IsOpen`, `ReceivedBytes`, `WrittenBytes`, `Open`, `Close`, `Write`, `DiscardInBuffer`, `DiscardOutBuffer`, and `Dispose`. |
-| `MitsubishiProtocolEncoding.Encode(...)` / `Decode(...)` | Ethernet raw request encoding and response decoding. |
-| `MitsubishiProtocolEncoding.GetFixedResponseLength(...)` | Calculates fixed receive sizes where the frame supports it. |
-| `MitsubishiProtocolEncoding.EncodeDeviceBatchRead(...)` / `EncodeDeviceBatchWrite(...)` | Ethernet batch device operation builders. |
-| `MitsubishiProtocolEncoding.EncodeRandomRead(...)` / `EncodeRandomWrite(...)` | Ethernet random operation builders. |
-| `MitsubishiProtocolEncoding.EncodeMonitorRegistration(...)` / `EncodeExecuteMonitor(...)` | Ethernet monitor builders. |
-| `MitsubishiProtocolEncoding.EncodeBlockRead(...)` / `EncodeBlockWrite(...)` | Ethernet block operation builders. |
-| `MitsubishiProtocolEncoding.EncodeReadTypeName(...)`, `EncodeRemoteOperation(...)`, `EncodeLoopback(...)`, `EncodeRemotePassword(...)`, `EncodeMemoryAccess(...)` | Ethernet specialized command builders. |
-| `MitsubishiSerialProtocolEncoding.EncodeWordReadRequest(...)`, `EncodeWordWriteRequest(...)`, `EncodeBitReadRequest(...)`, `EncodeBitWriteRequest(...)` | Serial batch operation builders. |
-| `MitsubishiSerialProtocolEncoding.EncodeRandomReadRequest(...)`, `EncodeRandomWriteRequest(...)`, `EncodeBlockReadRequest(...)`, `EncodeBlockWriteRequest(...)` | Serial random/block builders. |
-| `MitsubishiSerialProtocolEncoding.EncodeMonitorRegistrationRequest(...)`, `EncodeExecuteMonitorRequest(...)`, `EncodeRemoteOperationRequest(...)`, `EncodeReadTypeNameRequest(...)`, `EncodeLoopbackRequest(...)`, `EncodeMemoryAccessRequest(...)`, `EncodeRawRequest(...)` | Serial specialized command builders. |
-| `MitsubishiSerialProtocolEncoding.Decode(...)` | Serial response decoding. |
-| `MitsubishiSerialProtocolEncoding.IsExpectedFrameComplete(...)` | Serial frame-completion predicate used by the serial transport. |
-| `ResponceExtensions.Fail(...)` | Converts a response to failed state with error metadata. |
-| `ResponceExtensions.ToBaseResponse(...)` | Converts a typed response into a base `Responce`. |
-| `Mixins.SafeClose(...)` | Compatibility socket close helper. |
-
-Custom transport example:
-
-```csharp
-public sealed class AuditedTransport : IMitsubishiTransport
-{
-    private readonly IMitsubishiTransport _inner;
-
-    public AuditedTransport(IMitsubishiTransport inner) => _inner = inner;
-    public bool IsConnected => _inner.IsConnected;
-    public ValueTask ConnectAsync(MitsubishiClientOptions options, CancellationToken cancellationToken = default)
-        => _inner.ConnectAsync(options, cancellationToken);
-    public ValueTask DisconnectAsync(CancellationToken cancellationToken = default)
-        => _inner.DisconnectAsync(cancellationToken);
-    public async ValueTask<byte[]> ExchangeAsync(MitsubishiTransportRequest request, CancellationToken cancellationToken = default)
+using var latest = plc.ObserveWordsLatest("D100", 2, refresh)
+    .Subscribe(reply =>
     {
-        Console.WriteLine(request.Description);
-        return await _inner.ExchangeAsync(request, cancellationToken);
-    }
-    public void Dispose() => _inner.Dispose();
-    public ValueTask DisposeAsync() => _inner.DisposeAsync();
-}
-
-await using var client = new MitsubishiRx.MitsubishiRx(options, new AuditedTransport(new SocketMitsubishiTransport()));
+        if (reply.IsSucceed) Console.WriteLine(string.Join(',', reply.Value!));
+    });
+refresh.OnNext(Unit.Default); // a UI refresh or a configuration-change trigger
 ```
 
----
+`ObserveReactiveTag<T>` and `CreateReactiveTagWritePipeline<T>` use the validated `TagDatabase` metadata. A typed key prevents an accidental value-shape mismatch, while the write pipeline serializes/coalesces desired values.
 
-## Troubleshooting notes
+```csharp
+using IoT.DriverCore.Core;
 
-### Tag name not found
+var temperatureKey = new LogicalTagKey<float>("Temperature");
+using var quality = plc.ObserveReactiveTag(temperatureKey, TimeSpan.FromMilliseconds(250), null)
+    .Subscribe(sample =>
+    {
+        if (sample.Quality == MitsubishiReactiveQuality.Good && sample.Value is float value)
+            Console.WriteLine($"Temperature = {value}");
+    });
+using var setpointWriter = plc.CreateReactiveTagWritePipeline(
+    temperatureKey, MitsubishiReactiveWriteMode.LatestWins, TimeSpan.FromMilliseconds(100));
+using var writes = setpointWriter.Results.Subscribe(result => Console.WriteLine($"{result.Target}: {result.Success}"));
+setpointWriter.Post(22.5f);
+```
 
-If tag-based reads fail, verify:
-- `client.TagDatabase` has been assigned
-- `Name` matches the CSV/configured value
-- the tag’s `Address` is a valid Mitsubishi address string
+Group streams provide the equivalent heartbeat and latest-only forms. A group must exist in the assigned tag database before subscribing.
 
-### Wrong X / Y values
+```csharp
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Signals;
 
-If `X` or `Y` values do not match the PLC documentation:
-- switch `XyNotation` between `Octal` and `Hexadecimal`
-- confirm the expected addressing rule for the installed Ethernet module/path
+using var groupHeartbeats = plc.ObserveTagGroupHeartbeat(
+    "RecipeCommit", TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3), minimumUpdateSpacing: null)
+    .Subscribe(sample => Console.WriteLine($"Heartbeat={sample.IsHeartbeat}, success={sample.Value.IsSucceed}"));
+using var groupRefresh = new Signal<Unit>();
+using var latestGroup = plc.ObserveTagGroupLatest("RecipeCommit", groupRefresh)
+    .Subscribe(reply =>
+    {
+        if (reply.IsSucceed) Console.WriteLine($"Recipe values: {reply.Value!.Values.Count}");
+    });
+groupRefresh.OnNext(Unit.Default);
+```
 
-### ASCII vs binary mismatch
+### Tags and logical tags
 
-If communication succeeds on one endpoint but not another:
-- verify whether the PLC/module is configured for `Binary` or `Ascii`
-- verify frame family (`OneE`, `ThreeE`, `FourE`, `OneC`, `ThreeC`, `FourC`)
-- verify TCP vs UDP vs serial configuration on the PLC/module side
-- for serial, also verify `MitsubishiSerialMessageFormat` (`Format1`, `Format4`, `Format5`) and serial-port settings such as baud rate, parity, stop bits, and handshake
+`MitsubishiTagDatabase.Load`, `FromCsv`, `FromJson`, and `FromYaml` create a database. Assign it to `TagDatabase`, then use `ReadWordsByTagAsync`, `ReadBitsByTagAsync`, `WriteWordsByTagAsync`, `WriteBitsByTagAsync`, random tag methods, and typed tag methods for `Int16`, `UInt16`, `Int32`, `DWord`, `Float`, scaled `Double`, and strings. `ValidateTagDatabase`, `LoadAndValidateTagDatabase`, `PreviewTagDatabaseDiff`, and `ObserveTagDatabaseDiff` / `ObserveTagDatabaseReload` support controlled schema rollout. `ReadTagGroupSnapshotAsync`, `ValidateTagGroupWrite`, and `WriteTagGroupValuesAsync` / `WriteTagGroupSnapshotAsync` operate on defined groups.
 
-### Serial support coverage
+```csharp
+var tags = MitsubishiTagDatabase.FromCsv("Name,Address,DataType\nTemperature,D100,UInt16");
+plc.TagDatabase = tags;
+var temperature = await plc.ReadUInt16ByTagAsync("Temperature", CancellationToken.None);
+if (temperature.IsSucceed) Console.WriteLine(temperature.Value);
+```
 
-Current serial implementation is verified for:
-- reactive SerialPortRx-based transport
-- serial batch word reads through `ReadWordsAsync(address, points)`
-- serial batch word writes through `WriteWordsAsync(address, values)`
-- serial batch bit reads through `ReadBitsAsync(address, points)`
-- serial batch bit writes through `WriteBitsAsync(address, values)`
-- serial random word reads through `RandomReadWordsAsync(addresses)` for `1C`, `3C`, and `4C`
-- serial random word writes through `RandomWriteWordsAsync(values)` for `1C`, `3C`, and `4C`
-- serial block reads through `ReadBlocksAsync(request)` for `1C`, `3C`, and `4C`
-- serial block writes through `WriteBlocksAsync(request)` for `1C`, `3C`, and `4C`
-- serial monitor registration through `RegisterMonitorAsync(addresses)` for `1C`, `3C`, and `4C`
-- serial monitor execution through `ExecuteMonitorAsync()` for `1C`, `3C`, and `4C`
-- serial remote RUN/STOP/PAUSE/LATCH CLEAR/RESET through `RemoteRunAsync(...)`, `RemoteStopAsync()`, `RemotePauseAsync()`, `RemoteLatchClearAsync()`, and `RemoteResetAsync()` for `1C`, `3C`, and `4C`
-- serial type-name read through `ReadTypeNameAsync()` for `1C`, tested `3C` ASCII, and `4C` format 5
-- serial loopback through `LoopbackAsync(data)` for `1C`, tested `3C` ASCII, and `4C` format 5
-- serial memory and extend-unit access through `ReadMemoryAsync(...)` / `WriteMemoryAsync(...)` for `1C`, tested `3C` ASCII, and `4C` format 5
-- raw serial command execution through `ExecuteRawAsync(request)` for `1C`, tested `3C` ASCII, and `4C` format 5
-- `1C`, `3C`, and `4C` frame selection
-- serial ASCII format 1/4 and 4C binary format 5 decode paths
+`CreateLogicalTagClient` composes the shared `ILogicalTagCatalog` and optional SQLite store with the Mitsubishi transport. Use it where tag definitions, persistence, batch reads/writes, and `IObservable` / `IAsyncEnumerable` observation are required.
 
-`1C` random, block, and monitor operations are implemented by composing the verified 1C batch read/write requests. This keeps legacy computer-link paths usable even when the target does not provide native multi-device command forms.
+### Transports and test doubles
 
-### Remote operations do not execute
+Implement `IMitsubishiTransport` only for a custom endpoint. The normal built-in TCP/UDP and serial transports are selected automatically from the configured `TransportKind`. `MitsubishiSimulatorMemory` and `MitsubishiSimulatorTransport` provide deterministic in-process test behavior, including queued responses/faults and stateful memory.
 
-Remote operations are target-dependent. Check:
-- CPU mode and permissions
-- Ethernet module settings
-- remote password/lock state
-- target family support and documented operational constraints
+## Complete public API inventory
 
----
+This is the public type inventory from `src/MitsubishiRx`; the reactive package publishes the same types in its `.Reactive` namespace.
 
-## License
+| Area | Public types / members |
+| --- | --- |
+| Client construction and state | `MitsubishiRx(CpuType, ip, port, timeout)`, `MitsubishiRx(MitsubishiClientOptions, IMitsubishiTransport?, scheduler?)`, `Options`, `TagDatabase`, `Connected`, `ConnectionStates`, `OperationLogs`, `Open`/`OpenAsync`, `Close`/`CloseAsync`, `Dispose`/`DisposeAsync`. `Open*` creates the configured transport session; `Close*` disconnects it without discarding the options. |
+| Raw and direct protocol | Legacy `SendPackage`, `SendPackageSingle`, `SendPackageReliable`; `ExecuteRawAsync(MitsubishiRawCommandRequest, token)`; `ReadWordsAsync`, `WriteWordsAsync`, `ReadBitsAsync`, `WriteBitsAsync`; all direct operation overloads take a device address plus point count/value list and cancellation token. `Read*` returns `Responce<T>`; writes return `Responce`. |
+| Sparse, monitor, and block protocol | `RandomReadWordsAsync(IEnumerable<string>, token)`, `RandomWriteWordsAsync(IEnumerable<KeyValuePair<string, ushort>>, token)`, `RegisterMonitorAsync`, `ExecuteMonitorAsync`, `ReadBlocksAsync(MitsubishiBlockRequest, token)`, `WriteBlocksAsync(MitsubishiBlockRequest, token)`. Random and monitor requests return raw/word results in address order; block responses are raw and must be interpreted in request order. |
+| Diagnostics and controller state | `ReadTypeNameAsync`, `RemoteRunAsync(force, clearMode, token)`, `RemoteStopAsync`, `RemotePauseAsync`, `RemoteLatchClearAsync`, `RemoteResetAsync`, `UnlockAsync(password, token)`, `LockAsync(password, token)`, `ClearErrorAsync`, `LoopbackAsync`, `ReadMemoryAsync(command,address,length,token)`, `WriteMemoryAsync(command,address,values,token)`. The remote and protection family must be protected by an application interlock. |
+| Polling and health | `ObserveWords`, `ObserveBits`, `ObserveWordsHeartbeat`, `ObserveWordsStale`, `ObserveWordsLatest`, `ObserveTagGroup`, `ObserveTagGroupHeartbeat`, `ObserveTagGroupStale`, `ObserveTagGroupLatest`, `SampleDiagnostics`, `ObserveConnectionHealth`. Interval overloads schedule reads; trigger/latest overloads coalesce trigger bursts. Dispose the returned subscription. |
+| Reactive quality and writes | `ObserveReactiveWords`, `ObserveReactiveTag<T>`, `ObserveReactiveTagGroup`, `CreateReactiveWordWritePipeline`, `CreateReactiveTagWritePipeline<T>`. `MitsubishiReactiveValue<T>` carries `Value`, `Quality`, timestamp and response/error context; `MitsubishiReactiveWritePipeline<TPayload>` exposes the write-result stream and is disposable. |
+| Tag read/write methods | `ReadWordsByTagAsync`/`WriteWordsByTagAsync`, `ReadBitsByTagAsync`/`WriteBitsByTagAsync`, random by-tag methods, `Read`/`WriteInt16ByTagAsync`, `UInt16`, `Int32`, `DWord`, `Float`, `ScaledDouble`, `String`, plus metadata-dispatched `ReadTagAsync`/`WriteTagAsync`. Every member resolves the name through `TagDatabase`; typed pairs convert wire words using definition metadata. |
+| Tag database and group methods | `ValidateTagDatabase`, `LoadAndValidateTagDatabase`, `PreviewTagDatabaseDiff`, `ObserveTagDatabaseDiff`, `ObserveTagDatabaseReload`, `ReadTagGroupSnapshotAsync`, `ValidateTagGroupWrite`, `WriteTagGroupValuesAsync`, `WriteTagGroupSnapshotAsync`, `CreateLogicalTagClient`. The validation/preview methods are synchronous configuration checks; observation methods return disposables. |
+| Options, routes, and protocol values | `MitsubishiClientOptions`, `MitsubishiSerialOptions`, `MitsubishiRoute`, `MitsubishiSerialRoute`, `MitsubishiTransportRequest`, `MitsubishiRawCommandRequest`, `MitsubishiBlockRequest`, `MitsubishiCommands`; enums `CpuType`, `MitsubishiFrameType`, `CommunicationDataCode`, `MitsubishiTransportKind`, `MitsubishiSerialMessageFormat`, `XyAddressNotation`, `DeviceNumberFormat`, `DeviceValueKind`, `MitsubishiConnectionState`. They are value/configuration types; set a route/format explicitly rather than relying on a CPU guess. |
+| Address, response, blocks, and logging | `Responce`, `Responce<T>`, `MitsubishiDeviceAddress`, `MitsubishiDeviceMetadata`, `MitsubishiDeviceValue`, `MitsubishiTypeName`, `MitsubishiWordBlock`, `MitsubishiBitBlock`, `MitsubishiOperationLog`. `Responce` owns success/error/timing data; the block/device records describe request payloads and parsed addresses. |
+| Tag schema values | `MitsubishiTagDatabase`, `MitsubishiTagDefinition`, `MitsubishiTagGroupDefinition`, `MitsubishiTagDatabaseDiff`, `MitsubishiTagChange`, `MitsubishiTagGroupChange`, `MitsubishiTagGroupSnapshot`, `MitsubishiTagRolloutPolicy`, `MitsubishiSchemaChangeKind`, `MitsubishiTagValueConverter`. `Load`/`From*`/`To*`/`Save`, `Add`, `TryGet`, `GetRequired`, group equivalents, and `CompareWith` are the database member families. Serialization documents and schema-format selectors are internal implementation details. |
+| Logical-tag and bulk metrics | `MitsubishiLogicalTagRegistration`, `MitsubishiLogicalTagClient`, `MitsubishiLogicalTagBulkReadRequest`, `MitsubishiLogicalTagBulkWriteRequest`, `MitsubishiLogicalTagBulkDirectionMetrics`, `MitsubishiLogicalTagBulkOperationMetrics`. The client follows the shared logical-tag contracts for catalog/store CRUD, single/bulk operations and observation. |
+| Transport and simulation | `IMitsubishiTransport` (`ConnectAsync`, `DisconnectAsync`, `ExchangeAsync`, disposal), `MitsubishiSimulatorTransport`, `MitsubishiSimulatorMemory`, `MitsubishiSimulatorDeviceValue`. The built-in TCP/UDP and serial transports are selected automatically from `MitsubishiClientOptions`; simulator members include request/connect counts, response/fault queues, `Snapshot`, word/bit read/write and `Clear`; use them for deterministic tests. |
+| Generation | `MitsubishiTagAttribute`, `MitsubishiTagClientAttribute`, `MitsubishiTagClientSchemaAttribute`, and the embedded `MitsubishiTagClientGenerator` analyzer define generated typed tag-client surfaces. The generated model exposes `GeneratedMitsubishiTagClient`, `GeneratedMitsubishiTagClientExtensions`, `GroupsClient`, and per-group `TagsClient` accessors; attributes are compile-time schema, not runtime PLC discovery. |
 
-MIT
+## Operational guidance
 
----
+Keep one client per endpoint and dispose it at shutdown. Prefer bounded, contiguous reads; select a scan interval that the PLC, network, and downstream consumer can sustain. Serialize application-level writes and make retries idempotent. Log `OperationLogs` with endpoint, command, result, and correlation information, but never log passwords. Treat tag database changes as versioned configuration: validate and preview the diff before applying it.
 
-**MitsubishiRx** - Empowering Industrial Automation with Reactive Technology ⚡🏭
+## Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| Open or request timeout | Host/port, firewall, selected TCP/UDP path, `Timeout`, and whether the PLC is configured for the selected frame. |
+| Protocol error | 1E/3E/4E or 1C/3C/4C, binary/ASCII, route, monitoring timer, and `XyNotation`. |
+| Serial failures | Port ownership, baud/data/parity/stop/handshake, station/routing values, and serial message format. |
+| Tag lookup/type failure | Validate the database, address, point count, declared type, and string/scaling metadata before reading. |
+| Polling overload | Increase scan interval, group contiguous values, unsubscribe unused streams, and avoid overlapping writes. |
+
+## AI skill
+
+For source-grounded implementation assistance, use [skills/mitsubishi-rx/SKILL.md](../../skills/mitsubishi-rx/SKILL.md). It directs an agent to inspect this README and the current source before proposing protocol, tag, or safety-sensitive code.
+
+<!-- BEGIN GENERATED PUBLIC API -->
+
+## Exhaustive public API reference
+
+This catalogue is generated from the packaged runtime assemblies and their XML documentation. It includes exported public types and their declared public members; inherited members and non-public implementation details are intentionally omitted.
+
+### `MitsubishiRx`
+
+Exported public types: 54; declared public members: 670.
+
+#### `T:IoT.DriverCore.MitsubishiRx.CommunicationDataCode`
+
+```csharp
+public enum IoT.DriverCore.MitsubishiRx.CommunicationDataCode
+```
+Defines the CommunicationDataCode values.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.MitsubishiRx.CommunicationDataCode.Ascii`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.CommunicationDataCode Ascii
+```
+Represents the Ascii option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.CommunicationDataCode.Binary`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.CommunicationDataCode Binary
+```
+Represents the Binary option.
+
+#### `T:IoT.DriverCore.MitsubishiRx.CpuType`
+
+```csharp
+public enum IoT.DriverCore.MitsubishiRx.CpuType
+```
+Defines the CpuType values.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.MitsubishiRx.CpuType.ASeries`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.CpuType ASeries
+```
+Represents the ASeries option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.CpuType.Fx3`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.CpuType Fx3
+```
+Represents the Fx3 option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.CpuType.Fx5`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.CpuType Fx5
+```
+Represents the Fx5 option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.CpuType.IQR`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.CpuType IQR
+```
+Represents the IQR option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.CpuType.LSeries`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.CpuType LSeries
+```
+Represents the LSeries option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.CpuType.None`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.CpuType None
+```
+Represents the None option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.CpuType.QSeries`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.CpuType QSeries
+```
+Represents the QSeries option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.CpuType.QnaSeries`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.CpuType QnaSeries
+```
+Represents the QnaSeries option.
+
+#### `T:IoT.DriverCore.MitsubishiRx.DeviceNumberFormat`
+
+```csharp
+public enum IoT.DriverCore.MitsubishiRx.DeviceNumberFormat
+```
+Defines the DeviceNumberFormat values.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.MitsubishiRx.DeviceNumberFormat.Decimal`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.DeviceNumberFormat Decimal
+```
+Represents the Decimal option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.DeviceNumberFormat.Hexadecimal`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.DeviceNumberFormat Hexadecimal
+```
+Represents the Hexadecimal option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.DeviceNumberFormat.Octal`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.DeviceNumberFormat Octal
+```
+Represents the Octal option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.DeviceNumberFormat.XyVariable`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.DeviceNumberFormat XyVariable
+```
+Represents the XyVariable option.
+
+#### `T:IoT.DriverCore.MitsubishiRx.DeviceValueKind`
+
+```csharp
+public enum IoT.DriverCore.MitsubishiRx.DeviceValueKind
+```
+Defines the DeviceValueKind values.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.MitsubishiRx.DeviceValueKind.Bit`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.DeviceValueKind Bit
+```
+Represents the Bit option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.DeviceValueKind.Word`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.DeviceValueKind Word
+```
+Represents the Word option.
+
+#### `T:IoT.DriverCore.MitsubishiRx.IMitsubishiTransport`
+
+```csharp
+public interface IoT.DriverCore.MitsubishiRx.IMitsubishiTransport
+```
+Provides the IMitsubishiTransport contract.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.IMitsubishiTransport.ConnectAsync(IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.ValueTask ConnectAsync(IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions options, System.Threading.CancellationToken cancellationToken)
+```
+Executes the ConnectAsync operation.
+
+- Parameter `options`: The options parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ConnectAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.IMitsubishiTransport.DisconnectAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.ValueTask DisconnectAsync(System.Threading.CancellationToken cancellationToken)
+```
+Executes the DisconnectAsync operation.
+
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The DisconnectAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.IMitsubishiTransport.ExchangeAsync(IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.ValueTask<byte[]> ExchangeAsync(IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest request, System.Threading.CancellationToken cancellationToken)
+```
+Executes the ExchangeAsync operation.
+
+- Parameter `request`: The request parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ExchangeAsync operation result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.IMitsubishiTransport.IsConnected`
+
+```csharp
+public bool IsConnected { get; }
+```
+Gets or sets the IsConnected property.
+
+- Value: The `IsConnected` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock
+```
+Provides the MitsubishiBitBlock record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock.#ctor(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress,System.ReadOnlyMemory`1{System.Boolean})`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress Address, System.ReadOnlyMemory<bool> Values)
+```
+Initializes a new instance of `IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock`.
+
+- Parameter `Address`: The `Address` value.
+- Parameter `Values`: The `Values` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock.Deconstruct(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress@,System.ReadOnlyMemory`1{System.Boolean}@)`
+
+```csharp
+public void Deconstruct(out IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress Address, out System.ReadOnlyMemory<bool> Values)
+```
+Deconstructs the value into its component values.
+
+- Parameter `Address`: The `Address` value.
+- Parameter `Values`: The `Values` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock,IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock left, IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock,IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock left, IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock.Address`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress Address { get; set; }
+```
+The Address parameter.
+
+- Value: The `Address` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock.Values`
+
+```csharp
+public System.ReadOnlyMemory<bool> Values { get; set; }
+```
+The Values parameter.
+
+- Value: The `Values` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest
+```
+Provides the MitsubishiBlockRequest record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest.#ctor(System.Collections.Generic.IReadOnlyList`1{IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock},System.Collections.Generic.IReadOnlyList`1{IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock})`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest(System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock> WordBlocks, System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock> BitBlocks)
+```
+Initializes a new instance of `IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest`.
+
+- Parameter `WordBlocks`: The `WordBlocks` value.
+- Parameter `BitBlocks`: The `BitBlocks` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest.Deconstruct(System.Collections.Generic.IReadOnlyList`1{IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock}@,System.Collections.Generic.IReadOnlyList`1{IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock}@)`
+
+```csharp
+public void Deconstruct(out System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock> WordBlocks, out System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock> BitBlocks)
+```
+Deconstructs the value into its component values.
+
+- Parameter `WordBlocks`: The `WordBlocks` value.
+- Parameter `BitBlocks`: The `BitBlocks` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest,IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest left, IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest,IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest left, IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest.BitBlocks`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock> BitBlocks { get; set; }
+```
+The BitBlocks parameter.
+
+- Value: The `BitBlocks` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest.ResolvedBitBlocks`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiBitBlock> ResolvedBitBlocks { get; }
+```
+Gets or sets the ResolvedBitBlocks property.
+
+- Value: The `ResolvedBitBlocks` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest.ResolvedWordBlocks`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock> ResolvedWordBlocks { get; }
+```
+Gets or sets the ResolvedWordBlocks property.
+
+- Value: The `ResolvedWordBlocks` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest.WordBlocks`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock> WordBlocks { get; set; }
+```
+The WordBlocks parameter.
+
+- Value: The `WordBlocks` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions
+```
+Provides the MitsubishiClientOptions record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.#ctor(System.String,System.Int32,IoT.DriverCore.MitsubishiRx.MitsubishiFrameType,IoT.DriverCore.MitsubishiRx.CommunicationDataCode,IoT.DriverCore.MitsubishiRx.MitsubishiTransportKind,IoT.DriverCore.MitsubishiRx.MitsubishiRoute,System.UInt16,System.Nullable`1{System.TimeSpan},IoT.DriverCore.MitsubishiRx.CpuType,IoT.DriverCore.MitsubishiRx.XyAddressNotation,System.Byte,System.Func`1{System.UInt16},IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions(string Host, int Port, IoT.DriverCore.MitsubishiRx.MitsubishiFrameType FrameType, IoT.DriverCore.MitsubishiRx.CommunicationDataCode DataCode, IoT.DriverCore.MitsubishiRx.MitsubishiTransportKind TransportKind, IoT.DriverCore.MitsubishiRx.MitsubishiRoute Route, ushort MonitoringTimer, System.Nullable<System.TimeSpan> Timeout, IoT.DriverCore.MitsubishiRx.CpuType CpuType, IoT.DriverCore.MitsubishiRx.XyAddressNotation XyNotation, byte LegacyPcNumber, System.Func<ushort> SerialNumberProvider, IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions Serial)
+```
+Initializes a new instance of `IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions`.
+
+- Parameter `Host`: The `Host` value.
+- Parameter `Port`: The `Port` value.
+- Parameter `FrameType`: The `FrameType` value.
+- Parameter `DataCode`: The `DataCode` value.
+- Parameter `TransportKind`: The `TransportKind` value.
+- Parameter `Route`: The `Route` value.
+- Parameter `MonitoringTimer`: The `MonitoringTimer` value.
+- Parameter `Timeout`: The `Timeout` value.
+- Parameter `CpuType`: The `CpuType` value.
+- Parameter `XyNotation`: The `XyNotation` value.
+- Parameter `LegacyPcNumber`: The `LegacyPcNumber` value.
+- Parameter `SerialNumberProvider`: The `SerialNumberProvider` value.
+- Parameter `Serial`: The `Serial` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.Deconstruct(System.String@,System.Int32@,IoT.DriverCore.MitsubishiRx.MitsubishiFrameType@,IoT.DriverCore.MitsubishiRx.CommunicationDataCode@,IoT.DriverCore.MitsubishiRx.MitsubishiTransportKind@,IoT.DriverCore.MitsubishiRx.MitsubishiRoute@,System.UInt16@,System.Nullable`1{System.TimeSpan}@,IoT.DriverCore.MitsubishiRx.CpuType@,IoT.DriverCore.MitsubishiRx.XyAddressNotation@,System.Byte@,System.Func`1{System.UInt16}@,IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions@)`
+
+```csharp
+public void Deconstruct(out string Host, out int Port, out IoT.DriverCore.MitsubishiRx.MitsubishiFrameType FrameType, out IoT.DriverCore.MitsubishiRx.CommunicationDataCode DataCode, out IoT.DriverCore.MitsubishiRx.MitsubishiTransportKind TransportKind, out IoT.DriverCore.MitsubishiRx.MitsubishiRoute Route, out ushort MonitoringTimer, out System.Nullable<System.TimeSpan> Timeout, out IoT.DriverCore.MitsubishiRx.CpuType CpuType, out IoT.DriverCore.MitsubishiRx.XyAddressNotation XyNotation, out byte LegacyPcNumber, out System.Func<ushort> SerialNumberProvider, out IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions Serial)
+```
+Deconstructs the value into its component values.
+
+- Parameter `Host`: The `Host` value.
+- Parameter `Port`: The `Port` value.
+- Parameter `FrameType`: The `FrameType` value.
+- Parameter `DataCode`: The `DataCode` value.
+- Parameter `TransportKind`: The `TransportKind` value.
+- Parameter `Route`: The `Route` value.
+- Parameter `MonitoringTimer`: The `MonitoringTimer` value.
+- Parameter `Timeout`: The `Timeout` value.
+- Parameter `CpuType`: The `CpuType` value.
+- Parameter `XyNotation`: The `XyNotation` value.
+- Parameter `LegacyPcNumber`: The `LegacyPcNumber` value.
+- Parameter `SerialNumberProvider`: The `SerialNumberProvider` value.
+- Parameter `Serial`: The `Serial` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.GetNextSerialNumber`
+
+```csharp
+public ushort GetNextSerialNumber()
+```
+Executes the GetNextSerialNumber operation.
+
+- Returns: The GetNextSerialNumber operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions,IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions left, IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions,IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions left, IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.CpuType`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.CpuType CpuType { get; set; }
+```
+The CpuType parameter.
+
+- Value: The `CpuType` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.DataCode`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.CommunicationDataCode DataCode { get; set; }
+```
+The DataCode parameter.
+
+- Value: The `DataCode` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.FrameType`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiFrameType FrameType { get; set; }
+```
+The FrameType parameter.
+
+- Value: The `FrameType` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.Host`
+
+```csharp
+public string Host { get; set; }
+```
+The Host parameter.
+
+- Value: The `Host` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.LegacyPcNumber`
+
+```csharp
+public byte LegacyPcNumber { get; set; }
+```
+The LegacyPcNumber parameter.
+
+- Value: The `LegacyPcNumber` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.MonitoringTimer`
+
+```csharp
+public ushort MonitoringTimer { get; set; }
+```
+The MonitoringTimer parameter.
+
+- Value: The `MonitoringTimer` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.Port`
+
+```csharp
+public int Port { get; set; }
+```
+The Port parameter.
+
+- Value: The `Port` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.ResolvedRoute`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiRoute ResolvedRoute { get; }
+```
+Gets or sets the ResolvedRoute property.
+
+- Value: The `ResolvedRoute` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.ResolvedSerial`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions ResolvedSerial { get; }
+```
+Gets or sets the ResolvedSerial property.
+
+- Value: The `ResolvedSerial` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.ResolvedTimeout`
+
+```csharp
+public System.TimeSpan ResolvedTimeout { get; }
+```
+Gets or sets the ResolvedTimeout property.
+
+- Value: The `ResolvedTimeout` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.Route`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiRoute Route { get; set; }
+```
+The Route parameter.
+
+- Value: The `Route` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.Serial`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions Serial { get; set; }
+```
+The Serial parameter.
+
+- Value: The `Serial` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.SerialNumberProvider`
+
+```csharp
+public System.Func<ushort> SerialNumberProvider { get; set; }
+```
+The SerialNumberProvider parameter.
+
+- Value: The `SerialNumberProvider` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.Timeout`
+
+```csharp
+public System.Nullable<System.TimeSpan> Timeout { get; set; }
+```
+The Timeout parameter.
+
+- Value: The `Timeout` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.TransportKind`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTransportKind TransportKind { get; set; }
+```
+The TransportKind parameter.
+
+- Value: The `TransportKind` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions.XyNotation`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.XyAddressNotation XyNotation { get; set; }
+```
+The XYNotation parameter.
+
+- Value: The `XyNotation` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiCommands`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiCommands
+```
+Provides the MitsubishiCommands type.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.BlockRead`
+
+```csharp
+public static ushort BlockRead
+```
+Stores the BlockRead field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.BlockWrite`
+
+```csharp
+public static ushort BlockWrite
+```
+Stores the BlockWrite field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.ClearError`
+
+```csharp
+public static ushort ClearError
+```
+Stores the ClearError field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.DeviceRead`
+
+```csharp
+public static ushort DeviceRead
+```
+Stores the DeviceRead field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.DeviceWrite`
+
+```csharp
+public static ushort DeviceWrite
+```
+Stores the DeviceWrite field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.EntryMonitorDevice`
+
+```csharp
+public static ushort EntryMonitorDevice
+```
+Stores the EntryMonitorDevice field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.ExecuteMonitor`
+
+```csharp
+public static ushort ExecuteMonitor
+```
+Stores the ExecuteMonitor field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.ExtendUnitRead`
+
+```csharp
+public static ushort ExtendUnitRead
+```
+Stores the ExtendUnitRead field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.ExtendUnitWrite`
+
+```csharp
+public static ushort ExtendUnitWrite
+```
+Stores the ExtendUnitWrite field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.Lock`
+
+```csharp
+public static ushort Lock
+```
+Stores the Lock field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.LoopbackTest`
+
+```csharp
+public static ushort LoopbackTest
+```
+Stores the LoopbackTest field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.MemoryRead`
+
+```csharp
+public static ushort MemoryRead
+```
+Stores the MemoryRead field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.MemoryWrite`
+
+```csharp
+public static ushort MemoryWrite
+```
+Stores the MemoryWrite field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.RandomRead`
+
+```csharp
+public static ushort RandomRead
+```
+Stores the RandomRead field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.RandomWrite`
+
+```csharp
+public static ushort RandomWrite
+```
+Stores the RandomWrite field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.ReadTypeName`
+
+```csharp
+public static ushort ReadTypeName
+```
+Stores the ReadTypeName field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.RemoteLatchClear`
+
+```csharp
+public static ushort RemoteLatchClear
+```
+Stores the RemoteLatchClear field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.RemotePause`
+
+```csharp
+public static ushort RemotePause
+```
+Stores the RemotePause field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.RemoteReset`
+
+```csharp
+public static ushort RemoteReset
+```
+Stores the RemoteReset field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.RemoteRun`
+
+```csharp
+public static ushort RemoteRun
+```
+Stores the RemoteRun field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.RemoteStop`
+
+```csharp
+public static ushort RemoteStop
+```
+Stores the RemoteStop field.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiCommands.Unlock`
+
+```csharp
+public static ushort Unlock
+```
+Stores the Unlock field.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiConnectionState`
+
+```csharp
+public enum IoT.DriverCore.MitsubishiRx.MitsubishiConnectionState
+```
+Defines the MitsubishiConnectionState values.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiConnectionState.Connected`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiConnectionState Connected
+```
+Represents the Connected option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiConnectionState.Connecting`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiConnectionState Connecting
+```
+Represents the Connecting option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiConnectionState.Disconnected`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiConnectionState Disconnected
+```
+Represents the Disconnected option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiConnectionState.Faulted`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiConnectionState Faulted
+```
+Represents the Faulted option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiConnectionState.Reconnecting`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiConnectionState Reconnecting
+```
+Represents the Reconnecting option.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress
+```
+Provides the MitsubishiDeviceAddress record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress.#ctor(System.String,System.Int32,IoT.DriverCore.MitsubishiRx.XyAddressNotation,System.String)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress(string Symbol, int Number, IoT.DriverCore.MitsubishiRx.XyAddressNotation Notation, string Original)
+```
+Provides the MitsubishiDeviceAddress record.
+
+- Parameter `Symbol`: The Symbol parameter.
+- Parameter `Number`: The Number parameter.
+- Parameter `Notation`: The Notation parameter.
+- Parameter `Original`: The Original parameter.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress.Deconstruct(System.String@,System.Int32@,IoT.DriverCore.MitsubishiRx.XyAddressNotation@,System.String@)`
+
+```csharp
+public void Deconstruct(out string Symbol, out int Number, out IoT.DriverCore.MitsubishiRx.XyAddressNotation Notation, out string Original)
+```
+Deconstructs the value into its component values.
+
+- Parameter `Symbol`: The `Symbol` value.
+- Parameter `Number`: The `Number` value.
+- Parameter `Notation`: The `Notation` value.
+- Parameter `Original`: The `Original` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress.Parse(System.String,IoT.DriverCore.MitsubishiRx.XyAddressNotation)`
+
+```csharp
+public static IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress Parse(string value, IoT.DriverCore.MitsubishiRx.XyAddressNotation addressNotation)
+```
+Executes the Parse operation.
+
+- Parameter `value`: The value parameter.
+- Parameter `addressNotation`: The addressNotation parameter.
+- Returns: The Parse operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress,IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress left, IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress,IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress left, IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress.Descriptor`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata Descriptor { get; }
+```
+Gets or sets the Descriptor property.
+
+- Value: The `Descriptor` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress.Metadata`
+
+```csharp
+public System.Collections.Generic.IReadOnlyDictionary<string, IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata> Metadata { get; }
+```
+Gets or sets the Metadata property.
+
+- Value: The `Metadata` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress.Notation`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.XyAddressNotation Notation { get; set; }
+```
+The Notation parameter.
+
+- Value: The `Notation` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress.Number`
+
+```csharp
+public int Number { get; set; }
+```
+The Number parameter.
+
+- Value: The `Number` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress.Original`
+
+```csharp
+public string Original { get; set; }
+```
+The Original parameter.
+
+- Value: The `Original` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress.Symbol`
+
+```csharp
+public string Symbol { get; set; }
+```
+The Symbol parameter.
+
+- Value: The `Symbol` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata
+```
+Provides the MitsubishiDeviceMetadata record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata.#ctor(System.String,System.UInt16,System.UInt16,IoT.DriverCore.MitsubishiRx.DeviceValueKind,IoT.DriverCore.MitsubishiRx.DeviceNumberFormat)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata(string Symbol, ushort BinaryCode, ushort AsciiCode, IoT.DriverCore.MitsubishiRx.DeviceValueKind Kind, IoT.DriverCore.MitsubishiRx.DeviceNumberFormat NumberFormat)
+```
+Provides the MitsubishiDeviceMetadata record.
+
+- Parameter `Symbol`: The Symbol parameter.
+- Parameter `BinaryCode`: The BinaryCode parameter.
+- Parameter `AsciiCode`: The AsciiCode parameter.
+- Parameter `Kind`: The Kind parameter.
+- Parameter `NumberFormat`: The NumberFormat parameter.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata.Deconstruct(System.String@,System.UInt16@,System.UInt16@,IoT.DriverCore.MitsubishiRx.DeviceValueKind@,IoT.DriverCore.MitsubishiRx.DeviceNumberFormat@)`
+
+```csharp
+public void Deconstruct(out string Symbol, out ushort BinaryCode, out ushort AsciiCode, out IoT.DriverCore.MitsubishiRx.DeviceValueKind Kind, out IoT.DriverCore.MitsubishiRx.DeviceNumberFormat NumberFormat)
+```
+Deconstructs the value into its component values.
+
+- Parameter `Symbol`: The `Symbol` value.
+- Parameter `BinaryCode`: The `BinaryCode` value.
+- Parameter `AsciiCode`: The `AsciiCode` value.
+- Parameter `Kind`: The `Kind` value.
+- Parameter `NumberFormat`: The `NumberFormat` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata.GetRadix(IoT.DriverCore.MitsubishiRx.XyAddressNotation)`
+
+```csharp
+public int GetRadix(IoT.DriverCore.MitsubishiRx.XyAddressNotation addressNotation)
+```
+Executes the GetRadix operation.
+
+- Parameter `addressNotation`: The addressNotation parameter.
+- Returns: The GetRadix operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata,IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata left, IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata,IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata left, IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata.AsciiCode`
+
+```csharp
+public ushort AsciiCode { get; set; }
+```
+The AsciiCode parameter.
+
+- Value: The `AsciiCode` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata.BinaryCode`
+
+```csharp
+public ushort BinaryCode { get; set; }
+```
+The BinaryCode parameter.
+
+- Value: The `BinaryCode` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata.Kind`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.DeviceValueKind Kind { get; set; }
+```
+The Kind parameter.
+
+- Value: The `Kind` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata.NumberFormat`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.DeviceNumberFormat NumberFormat { get; set; }
+```
+The NumberFormat parameter.
+
+- Value: The `NumberFormat` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceMetadata.Symbol`
+
+```csharp
+public string Symbol { get; set; }
+```
+The Symbol parameter.
+
+- Value: The `Symbol` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue
+```
+Provides the MitsubishiDeviceValue record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue.#ctor(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress,System.UInt16)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress Address, ushort Value)
+```
+Provides the MitsubishiDeviceValue record.
+
+- Parameter `Address`: The Address parameter.
+- Parameter `Value`: The Value parameter.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue.Deconstruct(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress@,System.UInt16@)`
+
+```csharp
+public void Deconstruct(out IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress Address, out ushort Value)
+```
+Deconstructs the value into its component values.
+
+- Parameter `Address`: The `Address` value.
+- Parameter `Value`: The `Value` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue,IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue left, IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue,IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue left, IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue.Address`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress Address { get; set; }
+```
+The Address parameter.
+
+- Value: The `Address` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiDeviceValue.Value`
+
+```csharp
+public ushort Value { get; set; }
+```
+The Value parameter.
+
+- Value: The `Value` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiFrameType`
+
+```csharp
+public enum IoT.DriverCore.MitsubishiRx.MitsubishiFrameType
+```
+Defines the MitsubishiFrameType values.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiFrameType.FourC`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiFrameType FourC
+```
+Represents the FourC option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiFrameType.FourE`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiFrameType FourE
+```
+Represents the FourE option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiFrameType.OneC`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiFrameType OneC
+```
+Represents the OneC option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiFrameType.OneE`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiFrameType OneE
+```
+Represents the OneE option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiFrameType.ThreeC`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiFrameType ThreeC
+```
+Represents the ThreeC option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiFrameType.ThreeE`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiFrameType ThreeE
+```
+Represents the ThreeE option.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkDirectionMetrics`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkDirectionMetrics
+```
+Provides an immutable deterministic snapshot for one bulk transfer direction.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkDirectionMetrics.#ctor(System.Int64,System.Int64,System.Int64,System.Int64)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkDirectionMetrics(long planCount, long itemCount, long rangeCount, long protocolCallCount)
+```
+Initializes a new instance of the `T:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkDirectionMetrics` class.
+
+- Parameter `planCount`: The number of eligible plans created.
+- Parameter `itemCount`: The number of eligible word operations planned.
+- Parameter `rangeCount`: The number of contiguous ranges produced by the planner.
+- Parameter `protocolCallCount`: The number of grouped protocol calls issued.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkDirectionMetrics.ItemCount`
+
+```csharp
+public long ItemCount { get; }
+```
+Gets the number of eligible word operations planned.
+
+- Value: The `ItemCount` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkDirectionMetrics.PlanCount`
+
+```csharp
+public long PlanCount { get; }
+```
+Gets the number of eligible plans created.
+
+- Value: The `PlanCount` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkDirectionMetrics.ProtocolCallCount`
+
+```csharp
+public long ProtocolCallCount { get; }
+```
+Gets the number of grouped protocol calls issued.
+
+- Value: The `ProtocolCallCount` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkDirectionMetrics.RangeCount`
+
+```csharp
+public long RangeCount { get; }
+```
+Gets the number of contiguous ranges produced by the planner.
+
+- Value: The `RangeCount` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkOperationMetrics`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkOperationMetrics
+```
+Provides immutable deterministic snapshots of logical-tag bulk planning and protocol dispatch activity.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkOperationMetrics.#ctor(IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkDirectionMetrics,IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkDirectionMetrics)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkOperationMetrics(IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkDirectionMetrics read, IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkDirectionMetrics write)
+```
+Initializes a new instance of the `T:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkOperationMetrics` class.
+
+- Parameter `read`: The read planning and dispatch snapshot.
+- Parameter `write`: The write planning and dispatch snapshot.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkOperationMetrics.Read`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkDirectionMetrics Read { get; }
+```
+Gets the read planning and dispatch snapshot.
+
+- Value: The `Read` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkOperationMetrics.Write`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkDirectionMetrics Write { get; }
+```
+Gets the write planning and dispatch snapshot.
+
+- Value: The `Write` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient
+```
+Composes common logical-tag operations with Mitsubishi protocol transports.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.#ctor(IoT.DriverCore.MitsubishiRx.MitsubishiRx,IoT.DriverCore.Core.ILogicalTagCatalog,System.Nullable`1{System.TimeSpan},IoT.DriverCore.Core.LogicalTagSqliteStore)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient(IoT.DriverCore.MitsubishiRx.MitsubishiRx owner, IoT.DriverCore.Core.ILogicalTagCatalog catalog, System.Nullable<System.TimeSpan> defaultScanInterval, IoT.DriverCore.Core.LogicalTagSqliteStore store)
+```
+Initializes a new instance of `IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient`.
+
+- Parameter `owner`: The `owner` value.
+- Parameter `catalog`: The `catalog` value.
+- Parameter `defaultScanInterval`: The `defaultScanInterval` value.
+- Parameter `store`: The `store` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.#ctor(IoT.DriverCore.MitsubishiRx.MitsubishiRx,IoT.DriverCore.Core.ILogicalTagCatalog,System.Nullable`1{System.TimeSpan},IoT.DriverCore.Core.LogicalTagSqliteStore,System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient(IoT.DriverCore.MitsubishiRx.MitsubishiRx owner, IoT.DriverCore.Core.ILogicalTagCatalog catalog, System.Nullable<System.TimeSpan> defaultScanInterval, IoT.DriverCore.Core.LogicalTagSqliteStore store, System.TimeProvider timeProvider)
+```
+Initializes a new instance of `IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient`.
+
+- Parameter `owner`: The `owner` value.
+- Parameter `catalog`: The `catalog` value.
+- Parameter `defaultScanInterval`: The `defaultScanInterval` value.
+- Parameter `store`: The `store` value.
+- Parameter `timeProvider`: The `timeProvider` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.CreateTag(IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration)`
+
+```csharp
+public IoT.DriverCore.Core.LogicalTag CreateTag(IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration registration)
+```
+Creates and registers a logical Mitsubishi tag.
+
+- Parameter `registration`: The logical tag registration.
+- Returns: The registered immutable tag.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.DeleteGroupAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> DeleteGroupAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `name`: The `name` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<bool>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.DeleteTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> DeleteTagAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Deletes a persisted tag from the configured SQLite store and catalog.
+
+- Parameter `name`: The logical name.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: when the persisted tag existed.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.Dispose`
+
+```csharp
+public void Dispose()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.EditTagAsync(IoT.DriverCore.Core.LogicalTag,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> EditTagAsync(IoT.DriverCore.Core.LogicalTag tag, System.Threading.CancellationToken cancellationToken)
+```
+Edits a persisted tag in the configured SQLite store.
+
+- Parameter `tag`: The replacement tag.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: when the persisted tag existed.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.ExportCsvAsync(System.IO.TextWriter,System.Char,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task ExportCsvAsync(System.IO.TextWriter writer, char delimiter, System.Threading.CancellationToken cancellationToken)
+```
+Exports the current catalog using the shared RFC 4180 CSV format.
+
+- Parameter `writer`: The CSV writer.
+- Parameter `delimiter`: The field delimiter.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: A task that completes when the catalog is written.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.GetGroupAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.LogicalTagGroup> GetGroupAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `name`: The `name` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.Core.LogicalTagGroup>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.GetTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.LogicalTag> GetTagAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Gets a persisted tag from the configured SQLite store.
+
+- Parameter `name`: The logical name.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The persisted tag, if found.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.ImportCsvAsync(System.IO.TextReader,System.Char,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> ImportCsvAsync(System.IO.TextReader reader, char delimiter, System.Threading.CancellationToken cancellationToken)
+```
+Imports the shared RFC 4180 CSV format and registers every tag.
+
+- Parameter `reader`: The CSV reader.
+- Parameter `delimiter`: The field delimiter.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The imported tags.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.InitializeStoreAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task InitializeStoreAsync(System.Threading.CancellationToken cancellationToken)
+```
+Initializes the configured common SQLite store.
+
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: A task that completes when the schema exists.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.ListGroupsAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTagGroup>> ListGroupsAsync(System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTagGroup>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.ListTagsAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> ListTagsAsync(System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.LoadFromSqliteAsync(IoT.DriverCore.Core.LogicalTagSqliteStore,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> LoadFromSqliteAsync(IoT.DriverCore.Core.LogicalTagSqliteStore store, System.Threading.CancellationToken cancellationToken)
+```
+Loads and registers all tags from the common SQLite store.
+
+- Parameter `store`: The initialized or uninitialized store.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The loaded tags.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.LoadTagsAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> LoadTagsAsync(System.Threading.CancellationToken cancellationToken)
+```
+Loads the configured common SQLite store into this client.
+
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The loaded tags.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.Observe(System.String)`
+
+```csharp
+public System.IObservable<IoT.DriverCore.Core.LogicalTagValue> Observe(string tagName)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Returns: A `System.IObservable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.ObserveAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue> ObserveAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.ObserveAsync``1(IoT.DriverCore.Core.LogicalTagKey`1{``0},System.Threading.CancellationToken)`
+
+```csharp
+public System.Collections.Generic.IAsyncEnumerable<T> ObserveAsync<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ObserveAsync` operation.
+
+- Parameter `tag`: The `tag` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Collections.Generic.IAsyncEnumerable<T>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.ObserveMany(System.Collections.Generic.IReadOnlyCollection`1{System.String})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.Core.LogicalTagValue> ObserveMany(System.Collections.Generic.IReadOnlyCollection<string> tagNames)
+```
+Executes the `ObserveMany` operation.
+
+- Parameter `tagNames`: The `tagNames` value.
+- Returns: A `System.IObservable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.ObserveManyAsync(System.Collections.Generic.IReadOnlyCollection`1{System.String},System.Threading.CancellationToken)`
+
+```csharp
+public System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue> ObserveManyAsync(System.Collections.Generic.IReadOnlyCollection<string> tagNames, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ObserveManyAsync` operation.
+
+- Parameter `tagNames`: The `tagNames` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.Observe``1(IoT.DriverCore.Core.LogicalTagKey`1{``0})`
+
+```csharp
+public System.IObservable<T> Observe<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag)
+```
+Executes the `Observe` operation.
+
+- Parameter `tag`: The `tag` value.
+- Returns: A `System.IObservable<T>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.ReadAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>> ReadAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.ReadAsync``1(IoT.DriverCore.Core.LogicalTagKey`1{``0},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<T>> ReadAsync<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ReadAsync` operation.
+
+- Parameter `tag`: The `tag` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<T>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.ReadManyAsync(System.Collections.Generic.IReadOnlyCollection`1{System.String},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>> ReadManyAsync(System.Collections.Generic.IReadOnlyCollection<string> tagNames, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ReadManyAsync` operation.
+
+- Parameter `tagNames`: The `tagNames` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.Register(IoT.DriverCore.Core.LogicalTag)`
+
+```csharp
+public void Register(IoT.DriverCore.Core.LogicalTag tag)
+```
+Compatibility alias for `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.RegisterTag(IoT.DriverCore.Core.LogicalTag)` .
+
+- Parameter `tag`: The tag to register.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.RegisterRange(System.Collections.Generic.IEnumerable`1{IoT.DriverCore.Core.LogicalTag})`
+
+```csharp
+public void RegisterRange(System.Collections.Generic.IEnumerable<IoT.DriverCore.Core.LogicalTag> tags)
+```
+Executes the `RegisterRange` operation.
+
+- Parameter `tags`: The `tags` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.RegisterTag(IoT.DriverCore.Core.LogicalTag)`
+
+```csharp
+public void RegisterTag(IoT.DriverCore.Core.LogicalTag tag)
+```
+Adds or replaces a logical tag and makes it available to Mitsubishi typed APIs.
+
+- Parameter `tag`: The tag to register.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.RemoveTag(System.String)`
+
+```csharp
+public bool RemoveTag(string name)
+```
+Removes a tag from the common catalog.
+
+- Parameter `name`: The logical name.
+- Returns: when the tag existed.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.UpsertGroupAsync(IoT.DriverCore.Core.LogicalTagGroup,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task UpsertGroupAsync(IoT.DriverCore.Core.LogicalTagGroup group, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `group`: The `group` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.UpsertTagAsync(IoT.DriverCore.Core.LogicalTag,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task UpsertTagAsync(IoT.DriverCore.Core.LogicalTag tag, System.Threading.CancellationToken cancellationToken)
+```
+Inserts or replaces a persisted tag in the configured SQLite store.
+
+- Parameter `tag`: The tag to persist.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: A task that completes when the tag is persisted.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.WriteAsync(IoT.DriverCore.Core.LogicalTagValue,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>> WriteAsync(IoT.DriverCore.Core.LogicalTagValue value, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `value`: The `value` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.WriteAsync``1(System.String,``0,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<T>> WriteAsync<T>(string tagName, T value, System.Threading.CancellationToken cancellationToken)
+```
+Writes one typed logical tag.
+
+- Parameter `tagName`: The logical name.
+- Parameter `value`: The value to write.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The typed operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.WriteManyAsync(System.Collections.Generic.IReadOnlyCollection`1{IoT.DriverCore.Core.LogicalTagValue},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>> WriteManyAsync(System.Collections.Generic.IReadOnlyCollection<IoT.DriverCore.Core.LogicalTagValue> values, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `WriteManyAsync` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>>` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.BulkOperationMetrics`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagBulkOperationMetrics BulkOperationMetrics { get; }
+```
+Gets an immutable snapshot of deterministic grouped bulk operation counts.
+
+- Value: The `BulkOperationMetrics` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient.Catalog`
+
+```csharp
+public IoT.DriverCore.Core.ILogicalTagCatalog Catalog { get; }
+```
+Gets the shared catalog used for registrations and persistence.
+
+- Value: The `Catalog` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration
+```
+Describes a logical Mitsubishi tag to create and register.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration.#ctor(System.String,System.String,System.String,System.String,System.String,System.Collections.Generic.IReadOnlyDictionary`2{System.String,System.String},IoT.DriverCore.Core.LogicalTagAccessMode,System.Nullable`1{System.TimeSpan})`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration(string Name, string Address, string DataType, string GroupName, string Description, System.Collections.Generic.IReadOnlyDictionary<string, string> Metadata, IoT.DriverCore.Core.LogicalTagAccessMode AccessMode, System.Nullable<System.TimeSpan> ScanInterval)
+```
+Initializes a new instance of `IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration`.
+
+- Parameter `Name`: The `Name` value.
+- Parameter `Address`: The `Address` value.
+- Parameter `DataType`: The `DataType` value.
+- Parameter `GroupName`: The `GroupName` value.
+- Parameter `Description`: The `Description` value.
+- Parameter `Metadata`: The `Metadata` value.
+- Parameter `AccessMode`: The `AccessMode` value.
+- Parameter `ScanInterval`: The `ScanInterval` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration.Deconstruct(System.String@,System.String@,System.String@,System.String@,System.String@,System.Collections.Generic.IReadOnlyDictionary`2{System.String,System.String}@,IoT.DriverCore.Core.LogicalTagAccessMode@,System.Nullable`1{System.TimeSpan}@)`
+
+```csharp
+public void Deconstruct(out string Name, out string Address, out string DataType, out string GroupName, out string Description, out System.Collections.Generic.IReadOnlyDictionary<string, string> Metadata, out IoT.DriverCore.Core.LogicalTagAccessMode AccessMode, out System.Nullable<System.TimeSpan> ScanInterval)
+```
+Deconstructs the value into its component values.
+
+- Parameter `Name`: The `Name` value.
+- Parameter `Address`: The `Address` value.
+- Parameter `DataType`: The `DataType` value.
+- Parameter `GroupName`: The `GroupName` value.
+- Parameter `Description`: The `Description` value.
+- Parameter `Metadata`: The `Metadata` value.
+- Parameter `AccessMode`: The `AccessMode` value.
+- Parameter `ScanInterval`: The `ScanInterval` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration.ToLogicalTag`
+
+```csharp
+public IoT.DriverCore.Core.LogicalTag ToLogicalTag()
+```
+Creates the common immutable tag model.
+
+- Returns: The common logical tag.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration,IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration left, IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration,IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration left, IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration.AccessMode`
+
+```csharp
+public IoT.DriverCore.Core.LogicalTagAccessMode AccessMode { get; set; }
+```
+The tag access mode.
+
+- Value: The `AccessMode` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration.Address`
+
+```csharp
+public string Address { get; set; }
+```
+The Mitsubishi device address.
+
+- Value: The `Address` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration.DataType`
+
+```csharp
+public string DataType { get; set; }
+```
+The declared data type.
+
+- Value: The `DataType` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration.Description`
+
+```csharp
+public string Description { get; set; }
+```
+The optional description.
+
+- Value: The `Description` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration.GroupName`
+
+```csharp
+public string GroupName { get; set; }
+```
+The optional primary group.
+
+- Value: The `GroupName` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration.Metadata`
+
+```csharp
+public System.Collections.Generic.IReadOnlyDictionary<string, string> Metadata { get; set; }
+```
+The driver-specific metadata.
+
+- Value: The `Metadata` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration.Name`
+
+```csharp
+public string Name { get; set; }
+```
+The logical tag name.
+
+- Value: The `Name` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagRegistration.ScanInterval`
+
+```csharp
+public System.Nullable<System.TimeSpan> ScanInterval { get; set; }
+```
+The optional scan interval.
+
+- Value: The `ScanInterval` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog
+```
+Provides the MitsubishiOperationLog record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog.#ctor(System.DateTimeOffset,IoT.DriverCore.MitsubishiRx.MitsubishiConnectionState,System.String,System.Boolean,System.ReadOnlyMemory`1{System.Byte},System.ReadOnlyMemory`1{System.Byte},System.Exception)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog(System.DateTimeOffset TimestampUtc, IoT.DriverCore.MitsubishiRx.MitsubishiConnectionState State, string Description, bool Success, System.ReadOnlyMemory<byte> RequestPayload, System.ReadOnlyMemory<byte> ResponsePayload, System.Exception Exception)
+```
+Initializes a new instance of `IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog`.
+
+- Parameter `TimestampUtc`: The `TimestampUtc` value.
+- Parameter `State`: The `State` value.
+- Parameter `Description`: The `Description` value.
+- Parameter `Success`: The `Success` value.
+- Parameter `RequestPayload`: The `RequestPayload` value.
+- Parameter `ResponsePayload`: The `ResponsePayload` value.
+- Parameter `Exception`: The `Exception` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog.Deconstruct(System.DateTimeOffset@,IoT.DriverCore.MitsubishiRx.MitsubishiConnectionState@,System.String@,System.Boolean@,System.ReadOnlyMemory`1{System.Byte}@,System.ReadOnlyMemory`1{System.Byte}@,System.Exception@)`
+
+```csharp
+public void Deconstruct(out System.DateTimeOffset TimestampUtc, out IoT.DriverCore.MitsubishiRx.MitsubishiConnectionState State, out string Description, out bool Success, out System.ReadOnlyMemory<byte> RequestPayload, out System.ReadOnlyMemory<byte> ResponsePayload, out System.Exception Exception)
+```
+Deconstructs the value into its component values.
+
+- Parameter `TimestampUtc`: The `TimestampUtc` value.
+- Parameter `State`: The `State` value.
+- Parameter `Description`: The `Description` value.
+- Parameter `Success`: The `Success` value.
+- Parameter `RequestPayload`: The `RequestPayload` value.
+- Parameter `ResponsePayload`: The `ResponsePayload` value.
+- Parameter `Exception`: The `Exception` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog,IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog left, IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog,IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog left, IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog.Description`
+
+```csharp
+public string Description { get; set; }
+```
+The Description parameter.
+
+- Value: The `Description` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog.Exception`
+
+```csharp
+public System.Exception Exception { get; set; }
+```
+The Exception parameter.
+
+- Value: The `Exception` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog.RequestPayload`
+
+```csharp
+public System.ReadOnlyMemory<byte> RequestPayload { get; set; }
+```
+The RequestPayload parameter.
+
+- Value: The `RequestPayload` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog.ResponsePayload`
+
+```csharp
+public System.ReadOnlyMemory<byte> ResponsePayload { get; set; }
+```
+The ResponsePayload parameter.
+
+- Value: The `ResponsePayload` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog.State`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiConnectionState State { get; set; }
+```
+The State parameter.
+
+- Value: The `State` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog.Success`
+
+```csharp
+public bool Success { get; set; }
+```
+The Success parameter.
+
+- Value: The `Success` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog.TimestampUtc`
+
+```csharp
+public System.DateTimeOffset TimestampUtc { get; set; }
+```
+The TimestampUtc parameter.
+
+- Value: The `TimestampUtc` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest
+```
+Provides the MitsubishiRawCommandRequest record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest.#ctor(System.UInt16,System.UInt16,System.Collections.Generic.IReadOnlyList`1{System.Byte},System.String)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest(ushort Command, ushort Subcommand, System.Collections.Generic.IReadOnlyList<byte> Body, string Description)
+```
+Initializes a new instance of `IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest`.
+
+- Parameter `Command`: The `Command` value.
+- Parameter `Subcommand`: The `Subcommand` value.
+- Parameter `Body`: The `Body` value.
+- Parameter `Description`: The `Description` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest.Deconstruct(System.UInt16@,System.UInt16@,System.Collections.Generic.IReadOnlyList`1{System.Byte}@,System.String@)`
+
+```csharp
+public void Deconstruct(out ushort Command, out ushort Subcommand, out System.Collections.Generic.IReadOnlyList<byte> Body, out string Description)
+```
+Deconstructs the value into its component values.
+
+- Parameter `Command`: The `Command` value.
+- Parameter `Subcommand`: The `Subcommand` value.
+- Parameter `Body`: The `Body` value.
+- Parameter `Description`: The `Description` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest,IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest left, IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest,IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest left, IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest.Body`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<byte> Body { get; set; }
+```
+The Body parameter.
+
+- Value: The `Body` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest.Command`
+
+```csharp
+public ushort Command { get; set; }
+```
+The Command parameter.
+
+- Value: The `Command` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest.Description`
+
+```csharp
+public string Description { get; set; }
+```
+The Description parameter.
+
+- Value: The `Description` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest.ResolvedBody`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<byte> ResolvedBody { get; }
+```
+Gets or sets the ResolvedBody property.
+
+- Value: The `ResolvedBody` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest.Subcommand`
+
+```csharp
+public ushort Subcommand { get; set; }
+```
+The Subcommand parameter.
+
+- Value: The `Subcommand` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveQuality`
+
+```csharp
+public enum IoT.DriverCore.MitsubishiRx.MitsubishiReactiveQuality
+```
+Defines the MitsubishiReactiveQuality values.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveQuality.Bad`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiReactiveQuality Bad
+```
+Represents the Bad option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveQuality.Error`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiReactiveQuality Error
+```
+Represents the Error option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveQuality.Good`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiReactiveQuality Good
+```
+Represents the Good option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveQuality.Heartbeat`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiReactiveQuality Heartbeat
+```
+Represents the Heartbeat option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveQuality.Stale`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiReactiveQuality Stale
+```
+Represents the Stale option.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue
+```
+Provides the MitsubishiReactiveValue type.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue.FromResponse``1(IoT.DriverCore.MitsubishiRx.Responce`1{``0},System.DateTimeOffset,System.String)`
+
+```csharp
+public static IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue<T> FromResponse<T>(IoT.DriverCore.MitsubishiRx.Responce<T> response, System.DateTimeOffset timestampUtc, string source)
+```
+Executes the `FromResponse` operation.
+
+- Parameter `response`: The `response` value.
+- Parameter `timestampUtc`: The `timestampUtc` value.
+- Parameter `source`: The `source` value.
+- Returns: A `IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue<T>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue.Heartbeat``1(IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1{``0},System.DateTimeOffset)`
+
+```csharp
+public static IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue<T> Heartbeat<T>(IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue<T> value, System.DateTimeOffset timestampUtc)
+```
+Executes the `Heartbeat` operation.
+
+- Parameter `value`: The `value` value.
+- Parameter `timestampUtc`: The `timestampUtc` value.
+- Returns: A `IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue<T>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue.Stale``1(IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1{``0},System.DateTimeOffset)`
+
+```csharp
+public static IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue<T> Stale<T>(IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue<T> value, System.DateTimeOffset timestampUtc)
+```
+Executes the `Stale` operation.
+
+- Parameter `value`: The `value` value.
+- Parameter `timestampUtc`: The `timestampUtc` value.
+- Returns: A `IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue<T>` result.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1
+```
+Provides the MitsubishiReactiveValue record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1.#ctor(`0,System.DateTimeOffset,IoT.DriverCore.MitsubishiRx.MitsubishiReactiveQuality,System.Boolean,System.Boolean,System.String,System.String,System.Int32,System.Exception)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue<T>(T Value, System.DateTimeOffset TimestampUtc, IoT.DriverCore.MitsubishiRx.MitsubishiReactiveQuality Quality, bool IsHeartbeat, bool IsStale, string Source, string Error, int ErrorCode, System.Exception Exception)
+```
+Provides the MitsubishiReactiveValue record.
+
+- Parameter `Value`: The Value parameter.
+- Parameter `TimestampUtc`: The TimestampUtc parameter.
+- Parameter `Quality`: The Quality parameter.
+- Parameter `IsHeartbeat`: The IsHeartbeat parameter.
+- Parameter `IsStale`: The IsStale parameter.
+- Parameter `Source`: The Source parameter.
+- Parameter `Error`: The Error parameter.
+- Parameter `ErrorCode`: The ErrorCode parameter.
+- Parameter `Exception`: The Exception parameter.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1.Deconstruct(`0@,System.DateTimeOffset@,IoT.DriverCore.MitsubishiRx.MitsubishiReactiveQuality@,System.Boolean@,System.Boolean@,System.String@,System.String@,System.Int32@,System.Exception@)`
+
+```csharp
+public void Deconstruct(out T Value, out System.DateTimeOffset TimestampUtc, out IoT.DriverCore.MitsubishiRx.MitsubishiReactiveQuality Quality, out bool IsHeartbeat, out bool IsStale, out string Source, out string Error, out int ErrorCode, out System.Exception Exception)
+```
+Deconstructs the value into its component values.
+
+- Parameter `Value`: The `Value` value.
+- Parameter `TimestampUtc`: The `TimestampUtc` value.
+- Parameter `Quality`: The `Quality` value.
+- Parameter `IsHeartbeat`: The `IsHeartbeat` value.
+- Parameter `IsStale`: The `IsStale` value.
+- Parameter `Source`: The `Source` value.
+- Parameter `Error`: The `Error` value.
+- Parameter `ErrorCode`: The `ErrorCode` value.
+- Parameter `Exception`: The `Exception` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1{`0})`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue<T> other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1{`0},IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1{`0})`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue<T> left, IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue<T> right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1{`0},IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1{`0})`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue<T> left, IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue<T> right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1.Error`
+
+```csharp
+public string Error { get; set; }
+```
+The Error parameter.
+
+- Value: The `Error` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1.ErrorCode`
+
+```csharp
+public int ErrorCode { get; set; }
+```
+The ErrorCode parameter.
+
+- Value: The `ErrorCode` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1.Exception`
+
+```csharp
+public System.Exception Exception { get; set; }
+```
+The Exception parameter.
+
+- Value: The `Exception` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1.IsHeartbeat`
+
+```csharp
+public bool IsHeartbeat { get; set; }
+```
+The IsHeartbeat parameter.
+
+- Value: The `IsHeartbeat` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1.IsStale`
+
+```csharp
+public bool IsStale { get; set; }
+```
+The IsStale parameter.
+
+- Value: The `IsStale` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1.Quality`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiReactiveQuality Quality { get; set; }
+```
+The Quality parameter.
+
+- Value: The `Quality` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1.Source`
+
+```csharp
+public string Source { get; set; }
+```
+The Source parameter.
+
+- Value: The `Source` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1.TimestampUtc`
+
+```csharp
+public System.DateTimeOffset TimestampUtc { get; set; }
+```
+The TimestampUtc parameter.
+
+- Value: The `TimestampUtc` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue`1.Value`
+
+```csharp
+public T Value { get; set; }
+```
+The Value parameter.
+
+- Value: The `Value` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteMode`
+
+```csharp
+public enum IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteMode
+```
+Defines the MitsubishiReactiveWriteMode values.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteMode.Coalescing`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteMode Coalescing
+```
+Represents the Coalescing option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteMode.LatestWins`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteMode LatestWins
+```
+Represents the LatestWins option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteMode.Queued`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteMode Queued
+```
+Represents the Queued option.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWritePipeline`1`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWritePipeline`1
+```
+Provides the MitsubishiReactiveWritePipeline type.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWritePipeline`1.Dispose`
+
+```csharp
+public void Dispose()
+```
+Executes the Dispose operation.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWritePipeline`1.Post(`0)`
+
+```csharp
+public void Post(TPayload payload)
+```
+Executes the Post operation.
+
+- Parameter `payload`: The payload parameter.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWritePipeline`1.Mode`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteMode Mode { get; }
+```
+Gets or sets the Mode property.
+
+- Value: The `Mode` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWritePipeline`1.Results`
+
+```csharp
+public System.IObservable<IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult> Results { get; }
+```
+Gets or sets the Results property.
+
+- Value: The `Results` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult
+```
+Provides the MitsubishiReactiveWriteResult record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult.#ctor(System.String,System.DateTimeOffset,IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteMode,System.Boolean,System.String,System.Int32,System.Exception)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult(string Target, System.DateTimeOffset TimestampUtc, IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteMode Mode, bool Success, string Error, int ErrorCode, System.Exception Exception)
+```
+Provides the MitsubishiReactiveWriteResult record.
+
+- Parameter `Target`: The Target parameter.
+- Parameter `TimestampUtc`: The TimestampUtc parameter.
+- Parameter `Mode`: The Mode parameter.
+- Parameter `Success`: The Success parameter.
+- Parameter `Error`: The Error parameter.
+- Parameter `ErrorCode`: The ErrorCode parameter.
+- Parameter `Exception`: The Exception parameter.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult.Deconstruct(System.String@,System.DateTimeOffset@,IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteMode@,System.Boolean@,System.String@,System.Int32@,System.Exception@)`
+
+```csharp
+public void Deconstruct(out string Target, out System.DateTimeOffset TimestampUtc, out IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteMode Mode, out bool Success, out string Error, out int ErrorCode, out System.Exception Exception)
+```
+Deconstructs the value into its component values.
+
+- Parameter `Target`: The `Target` value.
+- Parameter `TimestampUtc`: The `TimestampUtc` value.
+- Parameter `Mode`: The `Mode` value.
+- Parameter `Success`: The `Success` value.
+- Parameter `Error`: The `Error` value.
+- Parameter `ErrorCode`: The `ErrorCode` value.
+- Parameter `Exception`: The `Exception` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult,IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult left, IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult,IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult left, IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult.Error`
+
+```csharp
+public string Error { get; set; }
+```
+The Error parameter.
+
+- Value: The `Error` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult.ErrorCode`
+
+```csharp
+public int ErrorCode { get; set; }
+```
+The ErrorCode parameter.
+
+- Value: The `ErrorCode` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult.Exception`
+
+```csharp
+public System.Exception Exception { get; set; }
+```
+The Exception parameter.
+
+- Value: The `Exception` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult.Mode`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteMode Mode { get; set; }
+```
+The Mode parameter.
+
+- Value: The `Mode` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult.Success`
+
+```csharp
+public bool Success { get; set; }
+```
+The Success parameter.
+
+- Value: The `Success` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult.Target`
+
+```csharp
+public string Target { get; set; }
+```
+The Target parameter.
+
+- Value: The `Target` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteResult.TimestampUtc`
+
+```csharp
+public System.DateTimeOffset TimestampUtc { get; set; }
+```
+The TimestampUtc parameter.
+
+- Value: The `TimestampUtc` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiRoute`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiRoute
+```
+Provides the MitsubishiRoute record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRoute.#ctor(System.Byte,System.Byte,System.UInt16,System.Byte,System.Nullable`1{System.UInt16})`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiRoute(byte NetworkNumber, byte StationNumber, ushort ModuleIoNumber, byte MultidropStationNumber, System.Nullable<ushort> ExtensionStationNumber)
+```
+Initializes a new instance of `IoT.DriverCore.MitsubishiRx.MitsubishiRoute`.
+
+- Parameter `NetworkNumber`: The `NetworkNumber` value.
+- Parameter `StationNumber`: The `StationNumber` value.
+- Parameter `ModuleIoNumber`: The `ModuleIoNumber` value.
+- Parameter `MultidropStationNumber`: The `MultidropStationNumber` value.
+- Parameter `ExtensionStationNumber`: The `ExtensionStationNumber` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRoute.Deconstruct(System.Byte@,System.Byte@,System.UInt16@,System.Byte@,System.Nullable`1{System.UInt16}@)`
+
+```csharp
+public void Deconstruct(out byte NetworkNumber, out byte StationNumber, out ushort ModuleIoNumber, out byte MultidropStationNumber, out System.Nullable<ushort> ExtensionStationNumber)
+```
+Deconstructs the value into its component values.
+
+- Parameter `NetworkNumber`: The `NetworkNumber` value.
+- Parameter `StationNumber`: The `StationNumber` value.
+- Parameter `ModuleIoNumber`: The `ModuleIoNumber` value.
+- Parameter `MultidropStationNumber`: The `MultidropStationNumber` value.
+- Parameter `ExtensionStationNumber`: The `ExtensionStationNumber` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRoute.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiRoute)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiRoute other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRoute.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRoute.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRoute.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRoute.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiRoute,IoT.DriverCore.MitsubishiRx.MitsubishiRoute)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiRoute left, IoT.DriverCore.MitsubishiRx.MitsubishiRoute right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRoute.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiRoute,IoT.DriverCore.MitsubishiRx.MitsubishiRoute)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiRoute left, IoT.DriverCore.MitsubishiRx.MitsubishiRoute right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiRoute.Default`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiRoute Default { get; }
+```
+Gets or sets the Default property.
+
+- Value: The `Default` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiRoute.ExtensionStationNumber`
+
+```csharp
+public System.Nullable<ushort> ExtensionStationNumber { get; set; }
+```
+The ExtensionStationNumber parameter.
+
+- Value: The `ExtensionStationNumber` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiRoute.ModuleIoNumber`
+
+```csharp
+public ushort ModuleIoNumber { get; set; }
+```
+The ModuleIoNumber parameter.
+
+- Value: The `ModuleIoNumber` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiRoute.MultidropStationNumber`
+
+```csharp
+public byte MultidropStationNumber { get; set; }
+```
+The MultidropStationNumber parameter.
+
+- Value: The `MultidropStationNumber` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiRoute.NetworkNumber`
+
+```csharp
+public byte NetworkNumber { get; set; }
+```
+The NetworkNumber parameter.
+
+- Value: The `NetworkNumber` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiRoute.StationNumber`
+
+```csharp
+public byte StationNumber { get; set; }
+```
+The StationNumber parameter.
+
+- Value: The `StationNumber` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiRx`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiRx
+```
+Provides the MitsubishiRx type.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.#ctor(IoT.DriverCore.MitsubishiRx.CpuType,System.String,System.Int32,System.Int32)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiRx(IoT.DriverCore.MitsubishiRx.CpuType cpuType, string ip, int port, int timeout)
+```
+Initializes a new instance of the MitsubishiRx class.
+
+- Parameter `cpuType`: The cpuType parameter.
+- Parameter `ip`: The ip parameter.
+- Parameter `port`: The port parameter.
+- Parameter `timeout`: The timeout parameter.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.#ctor(IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions,IoT.DriverCore.MitsubishiRx.IMitsubishiTransport,ReactiveUI.Primitives.Concurrency.ISequencer)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiRx(IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions options, IoT.DriverCore.MitsubishiRx.IMitsubishiTransport transport, ReactiveUI.Primitives.Concurrency.ISequencer scheduler)
+```
+Initializes a new instance of the MitsubishiRx class.
+
+- Parameter `options`: The options parameter.
+- Parameter `transport`: The transport parameter.
+- Parameter `scheduler`: The scheduler parameter.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.#ctor(IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions,IoT.DriverCore.MitsubishiRx.IMitsubishiTransport,ReactiveUI.Primitives.Concurrency.ISequencer,System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiRx(IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions options, IoT.DriverCore.MitsubishiRx.IMitsubishiTransport transport, ReactiveUI.Primitives.Concurrency.ISequencer scheduler, System.TimeProvider timeProvider)
+```
+Initializes a new instance of the MitsubishiRx class.
+
+- Parameter `options`: The options parameter.
+- Parameter `transport`: The transport parameter.
+- Parameter `scheduler`: The scheduler parameter.
+- Parameter `timeProvider`: The time provider.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ClearErrorAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> ClearErrorAsync(System.Threading.CancellationToken cancellationToken)
+```
+Executes the ClearErrorAsync operation.
+
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ClearErrorAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.Close`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.Responce Close()
+```
+Executes the Close operation.
+
+- Returns: The Close operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.CloseAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> CloseAsync(System.Threading.CancellationToken cancellationToken)
+```
+Executes the CloseAsync operation.
+
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The CloseAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.CreateLogicalTagClient(IoT.DriverCore.Core.ILogicalTagCatalog,System.Nullable`1{System.TimeSpan},IoT.DriverCore.Core.LogicalTagSqliteStore)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient CreateLogicalTagClient(IoT.DriverCore.Core.ILogicalTagCatalog catalog, System.Nullable<System.TimeSpan> defaultScanInterval, IoT.DriverCore.Core.LogicalTagSqliteStore store)
+```
+Executes the `CreateLogicalTagClient` operation.
+
+- Parameter `catalog`: The `catalog` value.
+- Parameter `defaultScanInterval`: The `defaultScanInterval` value.
+- Parameter `store`: The `store` value.
+- Returns: A `IoT.DriverCore.MitsubishiRx.MitsubishiLogicalTagClient` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.CreateReactiveTagWritePipeline``1(IoT.DriverCore.Core.LogicalTagKey`1{``0},IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteMode,System.Nullable`1{System.TimeSpan})`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWritePipeline<T> CreateReactiveTagWritePipeline<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag, IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteMode mode, System.Nullable<System.TimeSpan> coalescingWindow)
+```
+Executes the `CreateReactiveTagWritePipeline` operation.
+
+- Parameter `tag`: The `tag` value.
+- Parameter `mode`: The `mode` value.
+- Parameter `coalescingWindow`: The `coalescingWindow` value.
+- Returns: A `IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWritePipeline<T>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.CreateReactiveWordWritePipeline(System.String,IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteMode,System.Nullable`1{System.TimeSpan})`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWritePipeline<System.Collections.Generic.IReadOnlyList<ushort>> CreateReactiveWordWritePipeline(string address, IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWriteMode mode, System.Nullable<System.TimeSpan> coalescingWindow)
+```
+Executes the `CreateReactiveWordWritePipeline` operation.
+
+- Parameter `address`: The `address` value.
+- Parameter `mode`: The `mode` value.
+- Parameter `coalescingWindow`: The `coalescingWindow` value.
+- Returns: A `IoT.DriverCore.MitsubishiRx.MitsubishiReactiveWritePipeline<System.Collections.Generic.IReadOnlyList<ushort>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.Dispose`
+
+```csharp
+public void Dispose()
+```
+Executes the Dispose operation.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.DisposeAsync`
+
+```csharp
+public System.Threading.Tasks.ValueTask DisposeAsync()
+```
+Executes the DisposeAsync operation.
+
+- Returns: The DisposeAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ExecuteMonitorAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<byte[]>> ExecuteMonitorAsync(System.Threading.CancellationToken cancellationToken)
+```
+Executes the ExecuteMonitorAsync operation.
+
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ExecuteMonitorAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ExecuteRawAsync(IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<byte[]>> ExecuteRawAsync(IoT.DriverCore.MitsubishiRx.MitsubishiRawCommandRequest request, System.Threading.CancellationToken cancellationToken)
+```
+Executes the ExecuteRawAsync operation.
+
+- Parameter `request`: The request parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ExecuteRawAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.LoadAndValidateTagDatabase(System.String)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.Responce<IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase> LoadAndValidateTagDatabase(string path)
+```
+Executes the LoadAndValidateTagDatabase operation.
+
+- Parameter `path`: The path parameter.
+- Returns: The LoadAndValidateTagDatabase operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.LoadAndValidateTagDatabase(System.String,IoT.DriverCore.MitsubishiRx.MitsubishiTagRolloutPolicy)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.Responce<IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase> LoadAndValidateTagDatabase(string path, IoT.DriverCore.MitsubishiRx.MitsubishiTagRolloutPolicy policy)
+```
+Executes the LoadAndValidateTagDatabase operation.
+
+- Parameter `path`: The path parameter.
+- Parameter `policy`: The policy parameter.
+- Returns: The LoadAndValidateTagDatabase operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.LockAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> LockAsync(string password, System.Threading.CancellationToken cancellationToken)
+```
+Executes the LockAsync operation.
+
+- Parameter `password`: The password parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The LockAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.LoopbackAsync(System.Byte[],System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<byte[]>> LoopbackAsync(byte[] data, System.Threading.CancellationToken cancellationToken)
+```
+Executes the LoopbackAsync operation.
+
+- Parameter `data`: The data parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The LoopbackAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ObserveBits(System.String,System.Int32,System.TimeSpan,System.Nullable`1{System.TimeSpan})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.MitsubishiRx.Responce<bool[]>> ObserveBits(string address, int points, System.TimeSpan pollInterval, System.Nullable<System.TimeSpan> minimumUpdateSpacing)
+```
+Executes the `ObserveBits` operation.
+
+- Parameter `address`: The `address` value.
+- Parameter `points`: The `points` value.
+- Parameter `pollInterval`: The `pollInterval` value.
+- Parameter `minimumUpdateSpacing`: The `minimumUpdateSpacing` value.
+- Returns: A `System.IObservable<IoT.DriverCore.MitsubishiRx.Responce<bool[]>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ObserveConnectionHealth(System.TimeSpan)`
+
+```csharp
+public System.IObservable<ReactiveUI.Primitives.Extensions.Stale<IoT.DriverCore.MitsubishiRx.MitsubishiConnectionState>> ObserveConnectionHealth(System.TimeSpan staleAfter)
+```
+Executes the ObserveConnectionHealth operation.
+
+- Parameter `staleAfter`: The staleAfter parameter.
+- Returns: The ObserveConnectionHealth operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ObserveReactiveTagGroup(System.String,System.TimeSpan,System.Nullable`1{System.TimeSpan})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot>> ObserveReactiveTagGroup(string groupName, System.TimeSpan pollInterval, System.Nullable<System.TimeSpan> minimumUpdateSpacing)
+```
+Executes the `ObserveReactiveTagGroup` operation.
+
+- Parameter `groupName`: The `groupName` value.
+- Parameter `pollInterval`: The `pollInterval` value.
+- Parameter `minimumUpdateSpacing`: The `minimumUpdateSpacing` value.
+- Returns: A `System.IObservable<IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ObserveReactiveTag``1(IoT.DriverCore.Core.LogicalTagKey`1{``0},System.TimeSpan,System.Nullable`1{System.TimeSpan})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue<T>> ObserveReactiveTag<T>(IoT.DriverCore.Core.LogicalTagKey<T> tagKey, System.TimeSpan pollInterval, System.Nullable<System.TimeSpan> minimumUpdateSpacing)
+```
+Executes the `ObserveReactiveTag` operation.
+
+- Parameter `tagKey`: The `tagKey` value.
+- Parameter `pollInterval`: The `pollInterval` value.
+- Parameter `minimumUpdateSpacing`: The `minimumUpdateSpacing` value.
+- Returns: A `System.IObservable<IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue<T>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ObserveReactiveWords(System.String,System.Int32,System.TimeSpan,System.Nullable`1{System.TimeSpan})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue<ushort[]>> ObserveReactiveWords(string address, int points, System.TimeSpan pollInterval, System.Nullable<System.TimeSpan> minimumUpdateSpacing)
+```
+Executes the `ObserveReactiveWords` operation.
+
+- Parameter `address`: The `address` value.
+- Parameter `points`: The `points` value.
+- Parameter `pollInterval`: The `pollInterval` value.
+- Parameter `minimumUpdateSpacing`: The `minimumUpdateSpacing` value.
+- Returns: A `System.IObservable<IoT.DriverCore.MitsubishiRx.MitsubishiReactiveValue<ushort[]>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ObserveTagDatabaseDiff(System.String,System.TimeSpan,System.Boolean)`
+
+```csharp
+public System.IObservable<IoT.DriverCore.MitsubishiRx.Responce<IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff>> ObserveTagDatabaseDiff(string path, System.TimeSpan pollInterval, bool emitInitial)
+```
+Executes the ObserveTagDatabaseDiff operation.
+
+- Parameter `path`: The path parameter.
+- Parameter `pollInterval`: The pollInterval parameter.
+- Parameter `emitInitial`: The emitInitial parameter.
+- Returns: The ObserveTagDatabaseDiff operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ObserveTagDatabaseDiff(System.String,System.TimeSpan,System.Boolean,IoT.DriverCore.MitsubishiRx.MitsubishiTagRolloutPolicy)`
+
+```csharp
+public System.IObservable<IoT.DriverCore.MitsubishiRx.Responce<IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff>> ObserveTagDatabaseDiff(string path, System.TimeSpan pollInterval, bool emitInitial, IoT.DriverCore.MitsubishiRx.MitsubishiTagRolloutPolicy policy)
+```
+Executes the ObserveTagDatabaseDiff operation.
+
+- Parameter `path`: The path parameter.
+- Parameter `pollInterval`: The pollInterval parameter.
+- Parameter `emitInitial`: The emitInitial parameter.
+- Parameter `policy`: The policy parameter.
+- Returns: The ObserveTagDatabaseDiff operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ObserveTagDatabaseReload(System.String,System.TimeSpan,System.Boolean)`
+
+```csharp
+public System.IObservable<IoT.DriverCore.MitsubishiRx.Responce<IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase>> ObserveTagDatabaseReload(string path, System.TimeSpan pollInterval, bool emitInitial)
+```
+Executes the ObserveTagDatabaseReload operation.
+
+- Parameter `path`: The path parameter.
+- Parameter `pollInterval`: The pollInterval parameter.
+- Parameter `emitInitial`: The emitInitial parameter.
+- Returns: The ObserveTagDatabaseReload operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ObserveTagDatabaseReload(System.String,System.TimeSpan,System.Boolean,IoT.DriverCore.MitsubishiRx.MitsubishiTagRolloutPolicy)`
+
+```csharp
+public System.IObservable<IoT.DriverCore.MitsubishiRx.Responce<IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase>> ObserveTagDatabaseReload(string path, System.TimeSpan pollInterval, bool emitInitial, IoT.DriverCore.MitsubishiRx.MitsubishiTagRolloutPolicy policy)
+```
+Executes the ObserveTagDatabaseReload operation.
+
+- Parameter `path`: The path parameter.
+- Parameter `pollInterval`: The pollInterval parameter.
+- Parameter `emitInitial`: The emitInitial parameter.
+- Parameter `policy`: The policy parameter.
+- Returns: The ObserveTagDatabaseReload operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ObserveTagGroup(System.String,System.TimeSpan,System.Nullable`1{System.TimeSpan})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.MitsubishiRx.Responce<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot>> ObserveTagGroup(string groupName, System.TimeSpan pollInterval, System.Nullable<System.TimeSpan> minimumUpdateSpacing)
+```
+Executes the `ObserveTagGroup` operation.
+
+- Parameter `groupName`: The `groupName` value.
+- Parameter `pollInterval`: The `pollInterval` value.
+- Parameter `minimumUpdateSpacing`: The `minimumUpdateSpacing` value.
+- Returns: A `System.IObservable<IoT.DriverCore.MitsubishiRx.Responce<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ObserveTagGroupHeartbeat(System.String,System.TimeSpan,System.TimeSpan,System.Nullable`1{System.TimeSpan})`
+
+```csharp
+public System.IObservable<ReactiveUI.Primitives.Extensions.Heartbeat<IoT.DriverCore.MitsubishiRx.Responce<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot>>> ObserveTagGroupHeartbeat(string groupName, System.TimeSpan pollInterval, System.TimeSpan heartbeatAfter, System.Nullable<System.TimeSpan> minimumUpdateSpacing)
+```
+Executes the `ObserveTagGroupHeartbeat` operation.
+
+- Parameter `groupName`: The `groupName` value.
+- Parameter `pollInterval`: The `pollInterval` value.
+- Parameter `heartbeatAfter`: The `heartbeatAfter` value.
+- Parameter `minimumUpdateSpacing`: The `minimumUpdateSpacing` value.
+- Returns: A `System.IObservable<ReactiveUI.Primitives.Extensions.Heartbeat<IoT.DriverCore.MitsubishiRx.Responce<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot>>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ObserveTagGroupLatest(System.String,System.IObservable`1{ReactiveUI.Primitives.RxVoid})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.MitsubishiRx.Responce<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot>> ObserveTagGroupLatest(string groupName, System.IObservable<ReactiveUI.Primitives.RxVoid> trigger)
+```
+Executes the `ObserveTagGroupLatest` operation.
+
+- Parameter `groupName`: The `groupName` value.
+- Parameter `trigger`: The `trigger` value.
+- Returns: A `System.IObservable<IoT.DriverCore.MitsubishiRx.Responce<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ObserveTagGroupStale(System.String,System.TimeSpan,System.TimeSpan,System.Nullable`1{System.TimeSpan})`
+
+```csharp
+public System.IObservable<ReactiveUI.Primitives.Extensions.Stale<IoT.DriverCore.MitsubishiRx.Responce<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot>>> ObserveTagGroupStale(string groupName, System.TimeSpan pollInterval, System.TimeSpan staleAfter, System.Nullable<System.TimeSpan> minimumUpdateSpacing)
+```
+Executes the `ObserveTagGroupStale` operation.
+
+- Parameter `groupName`: The `groupName` value.
+- Parameter `pollInterval`: The `pollInterval` value.
+- Parameter `staleAfter`: The `staleAfter` value.
+- Parameter `minimumUpdateSpacing`: The `minimumUpdateSpacing` value.
+- Returns: A `System.IObservable<ReactiveUI.Primitives.Extensions.Stale<IoT.DriverCore.MitsubishiRx.Responce<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot>>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ObserveWords(System.String,System.Int32,System.TimeSpan,System.Nullable`1{System.TimeSpan},System.Nullable`1{System.TimeSpan})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.MitsubishiRx.Responce<ushort[]>> ObserveWords(string address, int points, System.TimeSpan pollInterval, System.Nullable<System.TimeSpan> minimumUpdateSpacing, System.Nullable<System.TimeSpan> pollTimeout)
+```
+Executes the `ObserveWords` operation.
+
+- Parameter `address`: The `address` value.
+- Parameter `points`: The `points` value.
+- Parameter `pollInterval`: The `pollInterval` value.
+- Parameter `minimumUpdateSpacing`: The `minimumUpdateSpacing` value.
+- Parameter `pollTimeout`: The `pollTimeout` value.
+- Returns: A `System.IObservable<IoT.DriverCore.MitsubishiRx.Responce<ushort[]>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ObserveWordsHeartbeat(System.String,System.Int32,System.TimeSpan,System.TimeSpan,System.Nullable`1{System.TimeSpan},System.Nullable`1{System.TimeSpan})`
+
+```csharp
+public System.IObservable<ReactiveUI.Primitives.Extensions.Heartbeat<IoT.DriverCore.MitsubishiRx.Responce<ushort[]>>> ObserveWordsHeartbeat(string address, int points, System.TimeSpan pollInterval, System.TimeSpan heartbeatAfter, System.Nullable<System.TimeSpan> minimumUpdateSpacing, System.Nullable<System.TimeSpan> pollTimeout)
+```
+Executes the `ObserveWordsHeartbeat` operation.
+
+- Parameter `address`: The `address` value.
+- Parameter `points`: The `points` value.
+- Parameter `pollInterval`: The `pollInterval` value.
+- Parameter `heartbeatAfter`: The `heartbeatAfter` value.
+- Parameter `minimumUpdateSpacing`: The `minimumUpdateSpacing` value.
+- Parameter `pollTimeout`: The `pollTimeout` value.
+- Returns: A `System.IObservable<ReactiveUI.Primitives.Extensions.Heartbeat<IoT.DriverCore.MitsubishiRx.Responce<ushort[]>>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ObserveWordsLatest(System.String,System.Int32,System.IObservable`1{ReactiveUI.Primitives.RxVoid})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.MitsubishiRx.Responce<ushort[]>> ObserveWordsLatest(string address, int points, System.IObservable<ReactiveUI.Primitives.RxVoid> trigger)
+```
+Executes the `ObserveWordsLatest` operation.
+
+- Parameter `address`: The `address` value.
+- Parameter `points`: The `points` value.
+- Parameter `trigger`: The `trigger` value.
+- Returns: A `System.IObservable<IoT.DriverCore.MitsubishiRx.Responce<ushort[]>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ObserveWordsStale(System.String,System.Int32,System.TimeSpan,System.TimeSpan,System.Nullable`1{System.TimeSpan})`
+
+```csharp
+public System.IObservable<ReactiveUI.Primitives.Extensions.Stale<IoT.DriverCore.MitsubishiRx.Responce<ushort[]>>> ObserveWordsStale(string address, int points, System.TimeSpan pollInterval, System.TimeSpan staleAfter, System.Nullable<System.TimeSpan> minimumUpdateSpacing)
+```
+Executes the `ObserveWordsStale` operation.
+
+- Parameter `address`: The `address` value.
+- Parameter `points`: The `points` value.
+- Parameter `pollInterval`: The `pollInterval` value.
+- Parameter `staleAfter`: The `staleAfter` value.
+- Parameter `minimumUpdateSpacing`: The `minimumUpdateSpacing` value.
+- Returns: A `System.IObservable<ReactiveUI.Primitives.Extensions.Stale<IoT.DriverCore.MitsubishiRx.Responce<ushort[]>>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.Open`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.Responce Open()
+```
+Executes the Open operation.
+
+- Returns: The Open operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.OpenAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> OpenAsync(System.Threading.CancellationToken cancellationToken)
+```
+Executes the OpenAsync operation.
+
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The OpenAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.PreviewTagDatabaseDiff(System.String)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.Responce<IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff> PreviewTagDatabaseDiff(string path)
+```
+Executes the PreviewTagDatabaseDiff operation.
+
+- Parameter `path`: The path parameter.
+- Returns: The PreviewTagDatabaseDiff operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.PreviewTagDatabaseDiff(System.String,IoT.DriverCore.MitsubishiRx.MitsubishiTagRolloutPolicy)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.Responce<IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff> PreviewTagDatabaseDiff(string path, IoT.DriverCore.MitsubishiRx.MitsubishiTagRolloutPolicy policy)
+```
+Executes the PreviewTagDatabaseDiff operation.
+
+- Parameter `path`: The path parameter.
+- Parameter `policy`: The policy parameter.
+- Returns: The PreviewTagDatabaseDiff operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.RandomReadWordsAsync(System.Collections.Generic.IEnumerable`1{System.String},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<ushort[]>> RandomReadWordsAsync(System.Collections.Generic.IEnumerable<string> addresses, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `RandomReadWordsAsync` operation.
+
+- Parameter `addresses`: The `addresses` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<ushort[]>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.RandomReadWordsByTagAsync(System.Collections.Generic.IEnumerable`1{System.String},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<ushort[]>> RandomReadWordsByTagAsync(System.Collections.Generic.IEnumerable<string> tagNames, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `RandomReadWordsByTagAsync` operation.
+
+- Parameter `tagNames`: The `tagNames` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<ushort[]>>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.RandomWriteWordsAsync(System.Collections.Generic.IEnumerable`1{System.Collections.Generic.KeyValuePair`2{System.String,System.UInt16}},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> RandomWriteWordsAsync(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, ushort>> values, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `RandomWriteWordsAsync` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.RandomWriteWordsByTagAsync(System.Collections.Generic.IEnumerable`1{System.Collections.Generic.KeyValuePair`2{System.String,System.UInt16}},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> RandomWriteWordsByTagAsync(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, ushort>> values, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `RandomWriteWordsByTagAsync` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ReadBitsAsync(System.String,System.Int32,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<bool[]>> ReadBitsAsync(string address, int points, System.Threading.CancellationToken cancellationToken)
+```
+Executes the ReadBitsAsync operation.
+
+- Parameter `address`: The address parameter.
+- Parameter `points`: The points parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ReadBitsAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ReadBitsByTagAsync(System.String,System.Int32,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<bool[]>> ReadBitsByTagAsync(string tagName, int points, System.Threading.CancellationToken cancellationToken)
+```
+Executes the ReadBitsByTagAsync operation.
+
+- Parameter `tagName`: The tagName parameter.
+- Parameter `points`: The points parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ReadBitsByTagAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ReadBlocksAsync(IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<byte[]>> ReadBlocksAsync(IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest request, System.Threading.CancellationToken cancellationToken)
+```
+Executes the ReadBlocksAsync operation.
+
+- Parameter `request`: The request parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ReadBlocksAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ReadDWordByTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<uint>> ReadDWordByTagAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Executes the ReadDWordByTagAsync operation.
+
+- Parameter `tagName`: The tagName parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ReadDWordByTagAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ReadFloatByTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<float>> ReadFloatByTagAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Executes the ReadFloatByTagAsync operation.
+
+- Parameter `tagName`: The tagName parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ReadFloatByTagAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ReadGeneratedBitTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<bool>> ReadGeneratedBitTagAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Executes the ReadGeneratedBitTagAsync operation.
+
+- Parameter `tagName`: The tagName parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ReadGeneratedBitTagAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ReadInt16ByTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<short>> ReadInt16ByTagAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Executes the ReadInt16ByTagAsync operation.
+
+- Parameter `tagName`: The tagName parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ReadInt16ByTagAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ReadInt32ByTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<int>> ReadInt32ByTagAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Executes the ReadInt32ByTagAsync operation.
+
+- Parameter `tagName`: The tagName parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ReadInt32ByTagAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ReadMemoryAsync(System.UInt16,System.UInt16,System.Int32,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<ushort[]>> ReadMemoryAsync(ushort command, ushort address, int length, System.Threading.CancellationToken cancellationToken)
+```
+Executes the ReadMemoryAsync operation.
+
+- Parameter `command`: The command parameter.
+- Parameter `address`: The address parameter.
+- Parameter `length`: The length parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ReadMemoryAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ReadScaledDoubleByTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<double>> ReadScaledDoubleByTagAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Executes the ReadScaledDoubleByTagAsync operation.
+
+- Parameter `tagName`: The tagName parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ReadScaledDoubleByTagAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ReadStringByTagAsync(System.String,System.Int32,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<string>> ReadStringByTagAsync(string tagName, int wordLength, System.Threading.CancellationToken cancellationToken)
+```
+Executes the ReadStringByTagAsync operation.
+
+- Parameter `tagName`: The tagName parameter.
+- Parameter `wordLength`: The wordLength parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ReadStringByTagAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ReadStringByTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<string>> ReadStringByTagAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Executes the ReadStringByTagAsync operation.
+
+- Parameter `tagName`: The tagName parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ReadStringByTagAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ReadTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<object>> ReadTagAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Reads a tag using the data type declared in `P:IoT.DriverCore.MitsubishiRx.MitsubishiRx.TagDatabase` .
+
+- Parameter `tagName`: The logical tag name.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The untyped tag value response.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ReadTagGroupSnapshotAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot>> ReadTagGroupSnapshotAsync(string groupName, System.Threading.CancellationToken cancellationToken)
+```
+Executes the ReadTagGroupSnapshotAsync operation.
+
+- Parameter `groupName`: The groupName parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ReadTagGroupSnapshotAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ReadTypeNameAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<IoT.DriverCore.MitsubishiRx.MitsubishiTypeName>> ReadTypeNameAsync(System.Threading.CancellationToken cancellationToken)
+```
+Executes the ReadTypeNameAsync operation.
+
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ReadTypeNameAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ReadUInt16ByTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<ushort>> ReadUInt16ByTagAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Executes the ReadUInt16ByTagAsync operation.
+
+- Parameter `tagName`: The tagName parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ReadUInt16ByTagAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ReadWordsAsync(System.String,System.Int32,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<ushort[]>> ReadWordsAsync(string address, int points, System.Threading.CancellationToken cancellationToken)
+```
+Executes the ReadWordsAsync operation.
+
+- Parameter `address`: The address parameter.
+- Parameter `points`: The points parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ReadWordsAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ReadWordsByTagAsync(System.String,System.Int32,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce<ushort[]>> ReadWordsByTagAsync(string tagName, int points, System.Threading.CancellationToken cancellationToken)
+```
+Executes the ReadWordsByTagAsync operation.
+
+- Parameter `tagName`: The tagName parameter.
+- Parameter `points`: The points parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The ReadWordsByTagAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.RegisterMonitorAsync(System.Collections.Generic.IEnumerable`1{System.String},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> RegisterMonitorAsync(System.Collections.Generic.IEnumerable<string> addresses, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `RegisterMonitorAsync` operation.
+
+- Parameter `addresses`: The `addresses` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.RemoteLatchClearAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> RemoteLatchClearAsync(System.Threading.CancellationToken cancellationToken)
+```
+Executes the RemoteLatchClearAsync operation.
+
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The RemoteLatchClearAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.RemotePauseAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> RemotePauseAsync(System.Threading.CancellationToken cancellationToken)
+```
+Executes the RemotePauseAsync operation.
+
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The RemotePauseAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.RemoteResetAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> RemoteResetAsync(System.Threading.CancellationToken cancellationToken)
+```
+Executes the RemoteResetAsync operation.
+
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The RemoteResetAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.RemoteRunAsync(System.Boolean,System.Boolean,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> RemoteRunAsync(bool force, bool clearMode, System.Threading.CancellationToken cancellationToken)
+```
+Executes the RemoteRunAsync operation.
+
+- Parameter `force`: The force parameter.
+- Parameter `clearMode`: The clearMode parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The RemoteRunAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.RemoteStopAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> RemoteStopAsync(System.Threading.CancellationToken cancellationToken)
+```
+Executes the RemoteStopAsync operation.
+
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The RemoteStopAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.SampleDiagnostics(System.IObservable`1{System.Object})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog> SampleDiagnostics(System.IObservable<object> trigger)
+```
+Executes the `SampleDiagnostics` operation.
+
+- Parameter `trigger`: The `trigger` value.
+- Returns: A `System.IObservable<IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.SendPackage(System.Byte[],System.Int32)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.Responce<byte[]> SendPackage(byte[] command, int receiveCount)
+```
+Executes the SendPackage operation.
+
+- Parameter `command`: The command parameter.
+- Parameter `receiveCount`: The receiveCount parameter.
+- Returns: The SendPackage operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.SendPackageReliable(System.Byte[])`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.Responce<byte[]> SendPackageReliable(byte[] command)
+```
+Executes the SendPackageReliable operation.
+
+- Parameter `command`: The command parameter.
+- Returns: The SendPackageReliable operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.SendPackageSingle(System.Byte[])`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.Responce<byte[]> SendPackageSingle(byte[] command)
+```
+Executes the SendPackageSingle operation.
+
+- Parameter `command`: The command parameter.
+- Returns: The SendPackageSingle operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.UnlockAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> UnlockAsync(string password, System.Threading.CancellationToken cancellationToken)
+```
+Executes the UnlockAsync operation.
+
+- Parameter `password`: The password parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The UnlockAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ValidateTagDatabase`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.Responce ValidateTagDatabase()
+```
+Executes the ValidateTagDatabase operation.
+
+- Returns: The ValidateTagDatabase operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ValidateTagGroupWrite(System.String,System.Collections.Generic.IReadOnlyDictionary`2{System.String,System.Object})`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.Responce ValidateTagGroupWrite(string groupName, System.Collections.Generic.IReadOnlyDictionary<string, object> values)
+```
+Executes the `ValidateTagGroupWrite` operation.
+
+- Parameter `groupName`: The `groupName` value.
+- Parameter `values`: The `values` value.
+- Returns: A `IoT.DriverCore.MitsubishiRx.Responce` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.WriteBitsAsync(System.String,System.Collections.Generic.IReadOnlyList`1{System.Boolean},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> WriteBitsAsync(string address, System.Collections.Generic.IReadOnlyList<bool> values, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `WriteBitsAsync` operation.
+
+- Parameter `address`: The `address` value.
+- Parameter `values`: The `values` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.WriteBitsByTagAsync(System.String,System.Collections.Generic.IReadOnlyList`1{System.Boolean},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> WriteBitsByTagAsync(string tagName, System.Collections.Generic.IReadOnlyList<bool> values, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `WriteBitsByTagAsync` operation.
+
+- Parameter `tagName`: The `tagName` value.
+- Parameter `values`: The `values` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.WriteBlocksAsync(IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> WriteBlocksAsync(IoT.DriverCore.MitsubishiRx.MitsubishiBlockRequest request, System.Threading.CancellationToken cancellationToken)
+```
+Executes the WriteBlocksAsync operation.
+
+- Parameter `request`: The request parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The WriteBlocksAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.WriteDWordByTagAsync(System.String,System.UInt32,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> WriteDWordByTagAsync(string tagName, uint value, System.Threading.CancellationToken cancellationToken)
+```
+Executes the WriteDWordByTagAsync operation.
+
+- Parameter `tagName`: The tagName parameter.
+- Parameter `value`: The value parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The WriteDWordByTagAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.WriteFloatByTagAsync(System.String,System.Single,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> WriteFloatByTagAsync(string tagName, float value, System.Threading.CancellationToken cancellationToken)
+```
+Executes the WriteFloatByTagAsync operation.
+
+- Parameter `tagName`: The tagName parameter.
+- Parameter `value`: The value parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The WriteFloatByTagAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.WriteGeneratedBitTagAsync(System.String,System.Boolean,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> WriteGeneratedBitTagAsync(string tagName, bool value, System.Threading.CancellationToken cancellationToken)
+```
+Executes the WriteGeneratedBitTagAsync operation.
+
+- Parameter `tagName`: The tagName parameter.
+- Parameter `value`: The value parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The WriteGeneratedBitTagAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.WriteInt16ByTagAsync(System.String,System.Int16,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> WriteInt16ByTagAsync(string tagName, short value, System.Threading.CancellationToken cancellationToken)
+```
+Executes the WriteInt16ByTagAsync operation.
+
+- Parameter `tagName`: The tagName parameter.
+- Parameter `value`: The value parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The WriteInt16ByTagAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.WriteInt32ByTagAsync(System.String,System.Int32,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> WriteInt32ByTagAsync(string tagName, int value, System.Threading.CancellationToken cancellationToken)
+```
+Executes the WriteInt32ByTagAsync operation.
+
+- Parameter `tagName`: The tagName parameter.
+- Parameter `value`: The value parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The WriteInt32ByTagAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.WriteMemoryAsync(System.UInt16,System.UInt16,System.Collections.Generic.IReadOnlyList`1{System.UInt16},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> WriteMemoryAsync(ushort command, ushort address, System.Collections.Generic.IReadOnlyList<ushort> values, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `WriteMemoryAsync` operation.
+
+- Parameter `command`: The `command` value.
+- Parameter `address`: The `address` value.
+- Parameter `values`: The `values` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.WriteScaledDoubleByTagAsync(System.String,System.Double,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> WriteScaledDoubleByTagAsync(string tagName, double value, System.Threading.CancellationToken cancellationToken)
+```
+Executes the WriteScaledDoubleByTagAsync operation.
+
+- Parameter `tagName`: The tagName parameter.
+- Parameter `value`: The value parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The WriteScaledDoubleByTagAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.WriteStringByTagAsync(System.String,System.String,System.Int32,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> WriteStringByTagAsync(string tagName, string value, int wordLength, System.Threading.CancellationToken cancellationToken)
+```
+Executes the WriteStringByTagAsync operation.
+
+- Parameter `tagName`: The tagName parameter.
+- Parameter `value`: The value parameter.
+- Parameter `wordLength`: The wordLength parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The WriteStringByTagAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.WriteStringByTagAsync(System.String,System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> WriteStringByTagAsync(string tagName, string value, System.Threading.CancellationToken cancellationToken)
+```
+Executes the WriteStringByTagAsync operation.
+
+- Parameter `tagName`: The tagName parameter.
+- Parameter `value`: The value parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The WriteStringByTagAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.WriteTagAsync(System.String,System.Object,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> WriteTagAsync(string tagName, object value, System.Threading.CancellationToken cancellationToken)
+```
+Writes a tag using the data type declared in `P:IoT.DriverCore.MitsubishiRx.MitsubishiRx.TagDatabase` .
+
+- Parameter `tagName`: The logical tag name.
+- Parameter `value`: The value to write.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The write response.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.WriteTagGroupSnapshotAsync(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> WriteTagGroupSnapshotAsync(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot snapshot, System.Threading.CancellationToken cancellationToken)
+```
+Executes the WriteTagGroupSnapshotAsync operation.
+
+- Parameter `snapshot`: The snapshot parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The WriteTagGroupSnapshotAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.WriteTagGroupValuesAsync(System.String,System.Collections.Generic.IReadOnlyDictionary`2{System.String,System.Object},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> WriteTagGroupValuesAsync(string groupName, System.Collections.Generic.IReadOnlyDictionary<string, object> values, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `WriteTagGroupValuesAsync` operation.
+
+- Parameter `groupName`: The `groupName` value.
+- Parameter `values`: The `values` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.WriteUInt16ByTagAsync(System.String,System.UInt16,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> WriteUInt16ByTagAsync(string tagName, ushort value, System.Threading.CancellationToken cancellationToken)
+```
+Executes the WriteUInt16ByTagAsync operation.
+
+- Parameter `tagName`: The tagName parameter.
+- Parameter `value`: The value parameter.
+- Parameter `cancellationToken`: The cancellationToken parameter.
+- Returns: The WriteUInt16ByTagAsync operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.WriteWordsAsync(System.String,System.Collections.Generic.IReadOnlyList`1{System.UInt16},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> WriteWordsAsync(string address, System.Collections.Generic.IReadOnlyList<ushort> values, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `WriteWordsAsync` operation.
+
+- Parameter `address`: The `address` value.
+- Parameter `values`: The `values` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiRx.WriteWordsByTagAsync(System.String,System.Collections.Generic.IReadOnlyList`1{System.UInt16},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce> WriteWordsByTagAsync(string tagName, System.Collections.Generic.IReadOnlyList<ushort> values, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `WriteWordsByTagAsync` operation.
+
+- Parameter `tagName`: The `tagName` value.
+- Parameter `values`: The `values` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.MitsubishiRx.Responce>` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiRx.Connected`
+
+```csharp
+public bool Connected { get; }
+```
+Gets or sets the Connected property.
+
+- Value: The `Connected` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiRx.ConnectionStates`
+
+```csharp
+public System.IObservable<IoT.DriverCore.MitsubishiRx.MitsubishiConnectionState> ConnectionStates { get; }
+```
+Gets or sets the ConnectionStates property.
+
+- Value: The `ConnectionStates` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiRx.OperationLogs`
+
+```csharp
+public System.IObservable<IoT.DriverCore.MitsubishiRx.MitsubishiOperationLog> OperationLogs { get; }
+```
+Gets or sets the OperationLogs property.
+
+- Value: The `OperationLogs` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiRx.Options`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions Options { get; }
+```
+Gets or sets the Options property.
+
+- Value: The `Options` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiRx.TagDatabase`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase TagDatabase { get; set; }
+```
+Gets or sets the TagDatabase property.
+
+- Value: The `TagDatabase` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiSchemaChangeKind`
+
+```csharp
+public enum IoT.DriverCore.MitsubishiRx.MitsubishiSchemaChangeKind
+```
+Defines the MitsubishiSchemaChangeKind values.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiSchemaChangeKind.AddressChange`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiSchemaChangeKind AddressChange
+```
+Represents the AddressChange option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiSchemaChangeKind.DataTypeChange`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiSchemaChangeKind DataTypeChange
+```
+Represents the DataTypeChange option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiSchemaChangeKind.GroupMembershipChange`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiSchemaChangeKind GroupMembershipChange
+```
+Represents the GroupMembershipChange option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiSchemaChangeKind.MetadataOnly`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiSchemaChangeKind MetadataOnly
+```
+Represents the MetadataOnly option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiSchemaChangeKind.None`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiSchemaChangeKind None
+```
+Represents the None option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiSchemaChangeKind.StructureChange`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiSchemaChangeKind StructureChange
+```
+Represents the StructureChange option.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiSerialMessageFormat`
+
+```csharp
+public enum IoT.DriverCore.MitsubishiRx.MitsubishiSerialMessageFormat
+```
+Defines the MitsubishiSerialMessageFormat values.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiSerialMessageFormat.Format1`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiSerialMessageFormat Format1
+```
+Represents the Format1 option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiSerialMessageFormat.Format4`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiSerialMessageFormat Format4
+```
+Represents the Format4 option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiSerialMessageFormat.Format5`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiSerialMessageFormat Format5
+```
+Represents the Format5 option.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions
+```
+Provides the MitsubishiSerialOptions record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.#ctor(System.String,System.Int32,System.Int32,System.IO.Ports.Parity,System.IO.Ports.StopBits,System.IO.Ports.Handshake,IoT.DriverCore.MitsubishiRx.MitsubishiSerialMessageFormat,System.Byte,System.Byte,System.Byte,System.UInt16,System.Byte,System.Byte,System.Byte,System.Int32,System.Int32,System.String)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions(string PortName, int BaudRate, int DataBits, System.IO.Ports.Parity Parity, System.IO.Ports.StopBits StopBits, System.IO.Ports.Handshake Handshake, IoT.DriverCore.MitsubishiRx.MitsubishiSerialMessageFormat MessageFormat, byte StationNumber, byte NetworkNumber, byte PcNumber, ushort RequestDestinationModuleIoNumber, byte RequestDestinationModuleStationNumber, byte SelfStationNumber, byte MessageWait, int ReadBufferSize, int WriteBufferSize, string NewLine)
+```
+Provides the MitsubishiSerialOptions record.
+
+- Parameter `PortName`: The PortName parameter.
+- Parameter `BaudRate`: The BaudRate parameter.
+- Parameter `DataBits`: The DataBits parameter.
+- Parameter `Parity`: The Parity parameter.
+- Parameter `StopBits`: The StopBits parameter.
+- Parameter `Handshake`: The Handshake parameter.
+- Parameter `MessageFormat`: The MessageFormat parameter.
+- Parameter `StationNumber`: The StationNumber parameter.
+- Parameter `NetworkNumber`: The NetworkNumber parameter.
+- Parameter `PcNumber`: The PcNumber parameter.
+- Parameter `RequestDestinationModuleIoNumber`: The RequestDestinationModuleIoNumber parameter.
+- Parameter `RequestDestinationModuleStationNumber`: The RequestDestinationModuleStationNumber parameter.
+- Parameter `SelfStationNumber`: The SelfStationNumber parameter.
+- Parameter `MessageWait`: The MessageWait parameter.
+- Parameter `ReadBufferSize`: The ReadBufferSize parameter.
+- Parameter `WriteBufferSize`: The WriteBufferSize parameter.
+- Parameter `NewLine`: The NewLine parameter.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.Deconstruct(System.String@,System.Int32@,System.Int32@,System.IO.Ports.Parity@,System.IO.Ports.StopBits@,System.IO.Ports.Handshake@,IoT.DriverCore.MitsubishiRx.MitsubishiSerialMessageFormat@,System.Byte@,System.Byte@,System.Byte@,System.UInt16@,System.Byte@,System.Byte@,System.Byte@,System.Int32@,System.Int32@,System.String@)`
+
+```csharp
+public void Deconstruct(out string PortName, out int BaudRate, out int DataBits, out System.IO.Ports.Parity Parity, out System.IO.Ports.StopBits StopBits, out System.IO.Ports.Handshake Handshake, out IoT.DriverCore.MitsubishiRx.MitsubishiSerialMessageFormat MessageFormat, out byte StationNumber, out byte NetworkNumber, out byte PcNumber, out ushort RequestDestinationModuleIoNumber, out byte RequestDestinationModuleStationNumber, out byte SelfStationNumber, out byte MessageWait, out int ReadBufferSize, out int WriteBufferSize, out string NewLine)
+```
+Deconstructs the value into its component values.
+
+- Parameter `PortName`: The `PortName` value.
+- Parameter `BaudRate`: The `BaudRate` value.
+- Parameter `DataBits`: The `DataBits` value.
+- Parameter `Parity`: The `Parity` value.
+- Parameter `StopBits`: The `StopBits` value.
+- Parameter `Handshake`: The `Handshake` value.
+- Parameter `MessageFormat`: The `MessageFormat` value.
+- Parameter `StationNumber`: The `StationNumber` value.
+- Parameter `NetworkNumber`: The `NetworkNumber` value.
+- Parameter `PcNumber`: The `PcNumber` value.
+- Parameter `RequestDestinationModuleIoNumber`: The `RequestDestinationModuleIoNumber` value.
+- Parameter `RequestDestinationModuleStationNumber`: The `RequestDestinationModuleStationNumber` value.
+- Parameter `SelfStationNumber`: The `SelfStationNumber` value.
+- Parameter `MessageWait`: The `MessageWait` value.
+- Parameter `ReadBufferSize`: The `ReadBufferSize` value.
+- Parameter `WriteBufferSize`: The `WriteBufferSize` value.
+- Parameter `NewLine`: The `NewLine` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions,IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions left, IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions,IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions left, IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.BaudRate`
+
+```csharp
+public int BaudRate { get; set; }
+```
+The BaudRate parameter.
+
+- Value: The `BaudRate` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.DataBits`
+
+```csharp
+public int DataBits { get; set; }
+```
+The DataBits parameter.
+
+- Value: The `DataBits` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.Handshake`
+
+```csharp
+public System.IO.Ports.Handshake Handshake { get; set; }
+```
+The Handshake parameter.
+
+- Value: The `Handshake` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.MessageFormat`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiSerialMessageFormat MessageFormat { get; set; }
+```
+The MessageFormat parameter.
+
+- Value: The `MessageFormat` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.MessageWait`
+
+```csharp
+public byte MessageWait { get; set; }
+```
+The MessageWait parameter.
+
+- Value: The `MessageWait` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.NetworkNumber`
+
+```csharp
+public byte NetworkNumber { get; set; }
+```
+The NetworkNumber parameter.
+
+- Value: The `NetworkNumber` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.NewLine`
+
+```csharp
+public string NewLine { get; set; }
+```
+The NewLine parameter.
+
+- Value: The `NewLine` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.Parity`
+
+```csharp
+public System.IO.Ports.Parity Parity { get; set; }
+```
+The Parity parameter.
+
+- Value: The `Parity` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.PcNumber`
+
+```csharp
+public byte PcNumber { get; set; }
+```
+The PcNumber parameter.
+
+- Value: The `PcNumber` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.PortName`
+
+```csharp
+public string PortName { get; set; }
+```
+The PortName parameter.
+
+- Value: The `PortName` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.ReadBufferSize`
+
+```csharp
+public int ReadBufferSize { get; set; }
+```
+The ReadBufferSize parameter.
+
+- Value: The `ReadBufferSize` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.RequestDestinationModuleIoNumber`
+
+```csharp
+public ushort RequestDestinationModuleIoNumber { get; set; }
+```
+The RequestDestinationModuleIoNumber parameter.
+
+- Value: The `RequestDestinationModuleIoNumber` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.RequestDestinationModuleStationNumber`
+
+```csharp
+public byte RequestDestinationModuleStationNumber { get; set; }
+```
+The RequestDestinationModuleStationNumber parameter.
+
+- Value: The `RequestDestinationModuleStationNumber` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.Route`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute Route { get; }
+```
+Gets or sets the Route property.
+
+- Value: The `Route` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.SelfStationNumber`
+
+```csharp
+public byte SelfStationNumber { get; set; }
+```
+The SelfStationNumber parameter.
+
+- Value: The `SelfStationNumber` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.StationNumber`
+
+```csharp
+public byte StationNumber { get; set; }
+```
+The StationNumber parameter.
+
+- Value: The `StationNumber` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.StopBits`
+
+```csharp
+public System.IO.Ports.StopBits StopBits { get; set; }
+```
+The StopBits parameter.
+
+- Value: The `StopBits` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialOptions.WriteBufferSize`
+
+```csharp
+public int WriteBufferSize { get; set; }
+```
+The WriteBufferSize parameter.
+
+- Value: The `WriteBufferSize` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute
+```
+Provides the MitsubishiSerialRoute record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute.#ctor(System.Byte,System.Byte,System.Byte,System.UInt16,System.Byte,System.Byte)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute(byte StationNumber, byte NetworkNumber, byte PcNumber, ushort RequestDestinationModuleIoNumber, byte RequestDestinationModuleStationNumber, byte SelfStationNumber)
+```
+Provides the MitsubishiSerialRoute record.
+
+- Parameter `StationNumber`: The StationNumber parameter.
+- Parameter `NetworkNumber`: The NetworkNumber parameter.
+- Parameter `PcNumber`: The PcNumber parameter.
+- Parameter `RequestDestinationModuleIoNumber`: The RequestDestinationModuleIoNumber parameter.
+- Parameter `RequestDestinationModuleStationNumber`: The RequestDestinationModuleStationNumber parameter.
+- Parameter `SelfStationNumber`: The SelfStationNumber parameter.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute.Deconstruct(System.Byte@,System.Byte@,System.Byte@,System.UInt16@,System.Byte@,System.Byte@)`
+
+```csharp
+public void Deconstruct(out byte StationNumber, out byte NetworkNumber, out byte PcNumber, out ushort RequestDestinationModuleIoNumber, out byte RequestDestinationModuleStationNumber, out byte SelfStationNumber)
+```
+Deconstructs the value into its component values.
+
+- Parameter `StationNumber`: The `StationNumber` value.
+- Parameter `NetworkNumber`: The `NetworkNumber` value.
+- Parameter `PcNumber`: The `PcNumber` value.
+- Parameter `RequestDestinationModuleIoNumber`: The `RequestDestinationModuleIoNumber` value.
+- Parameter `RequestDestinationModuleStationNumber`: The `RequestDestinationModuleStationNumber` value.
+- Parameter `SelfStationNumber`: The `SelfStationNumber` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute,IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute left, IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute,IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute left, IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute.NetworkNumber`
+
+```csharp
+public byte NetworkNumber { get; set; }
+```
+The NetworkNumber parameter.
+
+- Value: The `NetworkNumber` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute.PcNumber`
+
+```csharp
+public byte PcNumber { get; set; }
+```
+The PcNumber parameter.
+
+- Value: The `PcNumber` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute.RequestDestinationModuleIoNumber`
+
+```csharp
+public ushort RequestDestinationModuleIoNumber { get; set; }
+```
+The RequestDestinationModuleIoNumber parameter.
+
+- Value: The `RequestDestinationModuleIoNumber` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute.RequestDestinationModuleStationNumber`
+
+```csharp
+public byte RequestDestinationModuleStationNumber { get; set; }
+```
+The RequestDestinationModuleStationNumber parameter.
+
+- Value: The `RequestDestinationModuleStationNumber` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute.SelfStationNumber`
+
+```csharp
+public byte SelfStationNumber { get; set; }
+```
+The SelfStationNumber parameter.
+
+- Value: The `SelfStationNumber` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSerialRoute.StationNumber`
+
+```csharp
+public byte StationNumber { get; set; }
+```
+The StationNumber parameter.
+
+- Value: The `StationNumber` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue
+```
+Represents one populated value in a Mitsubishi simulator memory snapshot.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue.#ctor(System.String,System.Int32,IoT.DriverCore.MitsubishiRx.DeviceValueKind,System.UInt16)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue(string Symbol, int Number, IoT.DriverCore.MitsubishiRx.DeviceValueKind Kind, ushort Value)
+```
+Represents one populated value in a Mitsubishi simulator memory snapshot.
+
+- Parameter `Symbol`: The device symbol.
+- Parameter `Number`: The numeric device address.
+- Parameter `Kind`: The device value kind.
+- Parameter `Value`: The stored raw value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue.Deconstruct(System.String@,System.Int32@,IoT.DriverCore.MitsubishiRx.DeviceValueKind@,System.UInt16@)`
+
+```csharp
+public void Deconstruct(out string Symbol, out int Number, out IoT.DriverCore.MitsubishiRx.DeviceValueKind Kind, out ushort Value)
+```
+Deconstructs the value into its component values.
+
+- Parameter `Symbol`: The `Symbol` value.
+- Parameter `Number`: The `Number` value.
+- Parameter `Kind`: The `Kind` value.
+- Parameter `Value`: The `Value` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue,IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue left, IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue,IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue left, IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue.Kind`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.DeviceValueKind Kind { get; set; }
+```
+The device value kind.
+
+- Value: The `Kind` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue.Number`
+
+```csharp
+public int Number { get; set; }
+```
+The numeric device address.
+
+- Value: The `Number` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue.Symbol`
+
+```csharp
+public string Symbol { get; set; }
+```
+The device symbol.
+
+- Value: The `Symbol` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue.Value`
+
+```csharp
+public ushort Value { get; set; }
+```
+The stored raw value.
+
+- Value: The `Value` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory
+```
+Provides a thread-safe, deterministic Mitsubishi device-memory image.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.#ctor`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory()
+```
+Initializes a new instance of `IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory`.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.Clear`
+
+```csharp
+public void Clear()
+```
+Clears all populated devices.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.ReadBit(System.String)`
+
+```csharp
+public bool ReadBit(string address)
+```
+Reads one bit device.
+
+- Parameter `address`: The bit-device address.
+- Returns: The current value, or when the device has not been written.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.ReadBit(System.String,IoT.DriverCore.MitsubishiRx.XyAddressNotation)`
+
+```csharp
+public bool ReadBit(string address, IoT.DriverCore.MitsubishiRx.XyAddressNotation addressNotation)
+```
+Reads one bit device.
+
+- Parameter `address`: The bit-device address.
+- Parameter `addressNotation`: The X/Y address notation.
+- Returns: The current value, or when the device has not been written.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.ReadBits(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress,System.Int32)`
+
+```csharp
+public bool[] ReadBits(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress address, int points)
+```
+Reads consecutive bit devices.
+
+- Parameter `address`: The first bit-device address.
+- Parameter `points`: The number of bits to read.
+- Returns: A detached value snapshot.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.ReadBits(System.String,System.Int32)`
+
+```csharp
+public bool[] ReadBits(string address, int points)
+```
+Reads consecutive bit devices.
+
+- Parameter `address`: The first bit-device address.
+- Parameter `points`: The number of bits to read.
+- Returns: A detached value snapshot.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.ReadBits(System.String,System.Int32,IoT.DriverCore.MitsubishiRx.XyAddressNotation)`
+
+```csharp
+public bool[] ReadBits(string address, int points, IoT.DriverCore.MitsubishiRx.XyAddressNotation addressNotation)
+```
+Reads consecutive bit devices.
+
+- Parameter `address`: The first bit-device address.
+- Parameter `points`: The number of bits to read.
+- Parameter `addressNotation`: The X/Y address notation.
+- Returns: A detached value snapshot.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.ReadWord(System.String)`
+
+```csharp
+public ushort ReadWord(string address)
+```
+Reads one word device.
+
+- Parameter `address`: The word-device address.
+- Returns: The current value, or zero when the device has not been written.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.ReadWord(System.String,IoT.DriverCore.MitsubishiRx.XyAddressNotation)`
+
+```csharp
+public ushort ReadWord(string address, IoT.DriverCore.MitsubishiRx.XyAddressNotation addressNotation)
+```
+Reads one word device.
+
+- Parameter `address`: The word-device address.
+- Parameter `addressNotation`: The X/Y address notation.
+- Returns: The current value, or zero when the device has not been written.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.ReadWords(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress,System.Int32)`
+
+```csharp
+public ushort[] ReadWords(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress address, int points)
+```
+Reads consecutive word devices.
+
+- Parameter `address`: The first word-device address.
+- Parameter `points`: The number of words to read.
+- Returns: A detached value snapshot.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.ReadWords(System.String,System.Int32)`
+
+```csharp
+public ushort[] ReadWords(string address, int points)
+```
+Reads consecutive word devices.
+
+- Parameter `address`: The first word-device address.
+- Parameter `points`: The number of words to read.
+- Returns: A detached value snapshot.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.ReadWords(System.String,System.Int32,IoT.DriverCore.MitsubishiRx.XyAddressNotation)`
+
+```csharp
+public ushort[] ReadWords(string address, int points, IoT.DriverCore.MitsubishiRx.XyAddressNotation addressNotation)
+```
+Reads consecutive word devices.
+
+- Parameter `address`: The first word-device address.
+- Parameter `points`: The number of words to read.
+- Parameter `addressNotation`: The X/Y address notation.
+- Returns: A detached value snapshot.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.Snapshot`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorDeviceValue> Snapshot()
+```
+Gets a deterministic detached snapshot of the populated memory image.
+
+- Returns: Values ordered by device symbol and numeric address.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.WriteBit(System.String,System.Boolean)`
+
+```csharp
+public void WriteBit(string address, bool value)
+```
+Writes one bit device.
+
+- Parameter `address`: The bit-device address.
+- Parameter `value`: The value to write.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.WriteBit(System.String,System.Boolean,IoT.DriverCore.MitsubishiRx.XyAddressNotation)`
+
+```csharp
+public void WriteBit(string address, bool value, IoT.DriverCore.MitsubishiRx.XyAddressNotation addressNotation)
+```
+Writes one bit device.
+
+- Parameter `address`: The bit-device address.
+- Parameter `value`: The value to write.
+- Parameter `addressNotation`: The X/Y address notation.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.WriteBits(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress,System.Collections.Generic.IReadOnlyList`1{System.Boolean})`
+
+```csharp
+public void WriteBits(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress address, System.Collections.Generic.IReadOnlyList<bool> values)
+```
+Executes the `WriteBits` operation.
+
+- Parameter `address`: The `address` value.
+- Parameter `values`: The `values` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.WriteBits(System.String,System.Collections.Generic.IReadOnlyList`1{System.Boolean})`
+
+```csharp
+public void WriteBits(string address, System.Collections.Generic.IReadOnlyList<bool> values)
+```
+Executes the `WriteBits` operation.
+
+- Parameter `address`: The `address` value.
+- Parameter `values`: The `values` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.WriteBits(System.String,System.Collections.Generic.IReadOnlyList`1{System.Boolean},IoT.DriverCore.MitsubishiRx.XyAddressNotation)`
+
+```csharp
+public void WriteBits(string address, System.Collections.Generic.IReadOnlyList<bool> values, IoT.DriverCore.MitsubishiRx.XyAddressNotation addressNotation)
+```
+Executes the `WriteBits` operation.
+
+- Parameter `address`: The `address` value.
+- Parameter `values`: The `values` value.
+- Parameter `addressNotation`: The `addressNotation` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.WriteWord(System.String,System.UInt16)`
+
+```csharp
+public void WriteWord(string address, ushort value)
+```
+Writes one word device.
+
+- Parameter `address`: The word-device address.
+- Parameter `value`: The value to write.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.WriteWord(System.String,System.UInt16,IoT.DriverCore.MitsubishiRx.XyAddressNotation)`
+
+```csharp
+public void WriteWord(string address, ushort value, IoT.DriverCore.MitsubishiRx.XyAddressNotation addressNotation)
+```
+Writes one word device.
+
+- Parameter `address`: The word-device address.
+- Parameter `value`: The value to write.
+- Parameter `addressNotation`: The X/Y address notation.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.WriteWords(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress,System.Collections.Generic.IReadOnlyList`1{System.UInt16})`
+
+```csharp
+public void WriteWords(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress address, System.Collections.Generic.IReadOnlyList<ushort> values)
+```
+Executes the `WriteWords` operation.
+
+- Parameter `address`: The `address` value.
+- Parameter `values`: The `values` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.WriteWords(System.String,System.Collections.Generic.IReadOnlyList`1{System.UInt16})`
+
+```csharp
+public void WriteWords(string address, System.Collections.Generic.IReadOnlyList<ushort> values)
+```
+Executes the `WriteWords` operation.
+
+- Parameter `address`: The `address` value.
+- Parameter `values`: The `values` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.WriteWords(System.String,System.Collections.Generic.IReadOnlyList`1{System.UInt16},IoT.DriverCore.MitsubishiRx.XyAddressNotation)`
+
+```csharp
+public void WriteWords(string address, System.Collections.Generic.IReadOnlyList<ushort> values, IoT.DriverCore.MitsubishiRx.XyAddressNotation addressNotation)
+```
+Executes the `WriteWords` operation.
+
+- Parameter `address`: The `address` value.
+- Parameter `values`: The `values` value.
+- Parameter `addressNotation`: The `addressNotation` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory.Version`
+
+```csharp
+public long Version { get; }
+```
+Gets the monotonically increasing memory version.
+
+- Value: The `Version` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport
+```
+Provides a deterministic, in-memory Mitsubishi transport for simulations, examples, integration tests, and applications that do not have a physical PLC.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.#ctor`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport()
+```
+Initializes a new instance of the `T:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport` class.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.#ctor(IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport(IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory memory)
+```
+Initializes a new instance of the `T:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport` class.
+
+- Parameter `memory`: The stateful device-memory image.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.#ctor(System.Collections.Generic.IEnumerable`1{System.Byte[]})`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport(System.Collections.Generic.IEnumerable<byte[]> responses)
+```
+Initializes a new instance of `IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport`.
+
+- Parameter `responses`: The `responses` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.#ctor(System.Func`2{IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest,System.Byte[]})`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport(System.Func<IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest, byte[]> responseFactory)
+```
+Initializes a new instance of `IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport`.
+
+- Parameter `responseFactory`: The `responseFactory` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.ClearRequests`
+
+```csharp
+public void ClearRequests()
+```
+Clears the captured request history.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.ConnectAsync(IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.ValueTask ConnectAsync(IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions options, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `options`: The `options` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.ValueTask` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.CreateErrorResponse(IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions,System.UInt16)`
+
+```csharp
+public static byte[] CreateErrorResponse(IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions options, ushort endCode)
+```
+Creates a complete protocol response containing a PLC end code.
+
+- Parameter `options`: The client options defining the response framing.
+- Parameter `endCode`: The PLC end code.
+- Returns: The complete wire response.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.CreateSuccessResponse(IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions,System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static byte[] CreateSuccessResponse(IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions options, System.ReadOnlySpan<byte> payload)
+```
+Executes the `CreateSuccessResponse` operation.
+
+- Parameter `options`: The `options` value.
+- Parameter `payload`: The `payload` value.
+- Returns: A `byte[]` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.DisconnectAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.ValueTask DisconnectAsync(System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.ValueTask` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.Dispose`
+
+```csharp
+public void Dispose()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.DisposeAsync`
+
+```csharp
+public System.Threading.Tasks.ValueTask DisposeAsync()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `System.Threading.Tasks.ValueTask` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.EnqueueConnectFault(System.Exception)`
+
+```csharp
+public void EnqueueConnectFault(System.Exception exception)
+```
+Queues a fault to be thrown by the next connection attempt.
+
+- Parameter `exception`: The fault to throw.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.EnqueueFault(System.Exception)`
+
+```csharp
+public void EnqueueFault(System.Exception exception)
+```
+Queues a fault to be thrown by the next exchange.
+
+- Parameter `exception`: The fault to throw.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.EnqueueResponse(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public void EnqueueResponse(System.ReadOnlySpan<byte> response)
+```
+Executes the `EnqueueResponse` operation.
+
+- Parameter `response`: The `response` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.ExchangeAsync(IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.ValueTask<byte[]> ExchangeAsync(IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest request, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `request`: The `request` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.ValueTask<byte[]>` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.ReadBufferMemory(System.UInt16,System.Int32)`
+
+```csharp
+public ushort[] ReadBufferMemory(ushort address, int length)
+```
+Reads consecutive simulated buffer-memory words.
+
+- Parameter `address`: The first buffer-memory address.
+- Parameter `length`: The number of words to read.
+- Returns: A detached word snapshot.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.SetControllerError(System.UInt16)`
+
+```csharp
+public void SetControllerError(ushort errorCode)
+```
+Sets the current simulated controller error code.
+
+- Parameter `errorCode`: The deterministic controller error code.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.WriteBufferMemory(System.UInt16,System.Collections.Generic.IReadOnlyList`1{System.UInt16})`
+
+```csharp
+public void WriteBufferMemory(ushort address, System.Collections.Generic.IReadOnlyList<ushort> values)
+```
+Executes the `WriteBufferMemory` operation.
+
+- Parameter `address`: The `address` value.
+- Parameter `values`: The `values` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.ConnectCount`
+
+```csharp
+public int ConnectCount { get; }
+```
+Gets the number of successful connection attempts.
+
+- Value: The `ConnectCount` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.ConnectedOptions`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiClientOptions ConnectedOptions { get; }
+```
+Gets the options supplied by the most recent successful connection.
+
+- Value: The `ConnectedOptions` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.ControllerError`
+
+```csharp
+public ushort ControllerError { get; }
+```
+Gets the current simulated controller error code.
+
+- Value: The `ControllerError` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.DisconnectCount`
+
+```csharp
+public int DisconnectCount { get; }
+```
+Gets the number of disconnect operations.
+
+- Value: The `DisconnectCount` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.IsConnected`
+
+```csharp
+public bool IsConnected { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `IsConnected` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.IsCpuRunning`
+
+```csharp
+public bool IsCpuRunning { get; }
+```
+Gets whether the simulated controller is in the run state.
+
+- Value: The `IsCpuRunning` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.Memory`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorMemory Memory { get; }
+```
+Gets the stateful device-memory image used by automatic responses.
+
+- Value: The `Memory` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.ModelCode`
+
+```csharp
+public ushort ModelCode { get; set; }
+```
+Gets or sets the simulated controller model code.
+
+- Value: The `ModelCode` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.ModelName`
+
+```csharp
+public string ModelName { get; set; }
+```
+Gets or sets the simulated controller model name.
+
+- Value: The `ModelName` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiSimulatorTransport.Requests`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest> Requests { get; }
+```
+Gets immutable snapshots of requests in their exchange order.
+
+- Value: The `Requests` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiTagAttribute`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiTagAttribute
+```
+Binds a generated property to a logical Mitsubishi tag name.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagAttribute.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTagAttribute(string tagName)
+```
+Initializes a tag binding attribute.
+
+- Parameter `tagName`: The logical tag name.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagAttribute.TagName`
+
+```csharp
+public string TagName { get; }
+```
+Gets the logical tag name.
+
+- Value: The `TagName` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiTagChange`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiTagChange
+```
+Provides the MitsubishiTagChange record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagChange.#ctor(System.String,IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition,IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTagChange(string Name, IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition Previous, IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition Current)
+```
+Provides the MitsubishiTagChange record.
+
+- Parameter `Name`: The Name parameter.
+- Parameter `Previous`: The Previous parameter.
+- Parameter `Current`: The Current parameter.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagChange.Deconstruct(System.String@,IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition@,IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition@)`
+
+```csharp
+public void Deconstruct(out string Name, out IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition Previous, out IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition Current)
+```
+Deconstructs the value into its component values.
+
+- Parameter `Name`: The `Name` value.
+- Parameter `Previous`: The `Previous` value.
+- Parameter `Current`: The `Current` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagChange.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiTagChange)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiTagChange other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagChange.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagChange.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagChange.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagChange.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiTagChange,IoT.DriverCore.MitsubishiRx.MitsubishiTagChange)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiTagChange left, IoT.DriverCore.MitsubishiRx.MitsubishiTagChange right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagChange.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiTagChange,IoT.DriverCore.MitsubishiRx.MitsubishiTagChange)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiTagChange left, IoT.DriverCore.MitsubishiRx.MitsubishiTagChange right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagChange.ChangeKinds`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiSchemaChangeKind ChangeKinds { get; }
+```
+Gets or sets the ChangeKinds property.
+
+- Value: The `ChangeKinds` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagChange.Current`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition Current { get; set; }
+```
+The Current parameter.
+
+- Value: The `Current` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagChange.Name`
+
+```csharp
+public string Name { get; set; }
+```
+The Name parameter.
+
+- Value: The `Name` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagChange.Previous`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition Previous { get; set; }
+```
+The Previous parameter.
+
+- Value: The `Previous` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiTagClientAttribute`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiTagClientAttribute
+```
+Binds generated tag members to a Mitsubishi client member.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagClientAttribute.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTagClientAttribute(string clientMemberName)
+```
+Initializes a client binding attribute.
+
+- Parameter `clientMemberName`: The client field or property name.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagClientAttribute.ClientMemberName`
+
+```csharp
+public string ClientMemberName { get; }
+```
+Gets the client field or property name.
+
+- Value: The `ClientMemberName` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiTagClientSchemaAttribute`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiTagClientSchemaAttribute
+```
+Declares an inline Mitsubishi tag schema.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagClientSchemaAttribute.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTagClientSchemaAttribute(string schemaJson)
+```
+Initializes a schema attribute.
+
+- Parameter `schemaJson`: The JSON tag schema.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagClientSchemaAttribute.SchemaJson`
+
+```csharp
+public string SchemaJson { get; }
+```
+Gets the JSON tag schema.
+
+- Value: The `SchemaJson` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase
+```
+Provides the MitsubishiTagDatabase type.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase.#ctor(System.Collections.Generic.IEnumerable`1{IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition})`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase(System.Collections.Generic.IEnumerable<IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition> tags)
+```
+Initializes a new instance of `IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase`.
+
+- Parameter `tags`: The `tags` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase.Add(IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition)`
+
+```csharp
+public void Add(IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition tag)
+```
+Executes the Add operation.
+
+- Parameter `tag`: The tag parameter.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase.AddGroup(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition)`
+
+```csharp
+public void AddGroup(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition group)
+```
+Executes the AddGroup operation.
+
+- Parameter `group`: The group parameter.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase.CompareWith(IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff CompareWith(IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase other)
+```
+Executes the CompareWith operation.
+
+- Parameter `other`: The other parameter.
+- Returns: The CompareWith operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase.FromCsv(System.String)`
+
+```csharp
+public static IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase FromCsv(string csvContent)
+```
+Executes the FromCsv operation.
+
+- Parameter `csvContent`: The csvContent parameter.
+- Returns: The FromCsv operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase.FromJson(System.String)`
+
+```csharp
+public static IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase FromJson(string json)
+```
+Executes the FromJson operation.
+
+- Parameter `json`: The json parameter.
+- Returns: The FromJson operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase.FromYaml(System.String)`
+
+```csharp
+public static IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase FromYaml(string yaml)
+```
+Executes the FromYaml operation.
+
+- Parameter `yaml`: The yaml parameter.
+- Returns: The FromYaml operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase.GetRequired(System.String)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition GetRequired(string name)
+```
+Executes the GetRequired operation.
+
+- Parameter `name`: The name parameter.
+- Returns: The GetRequired operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase.GetRequiredGroup(System.String)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition GetRequiredGroup(string name)
+```
+Executes the GetRequiredGroup operation.
+
+- Parameter `name`: The name parameter.
+- Returns: The GetRequiredGroup operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase.Load(System.String)`
+
+```csharp
+public static IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase Load(string path)
+```
+Executes the Load operation.
+
+- Parameter `path`: The path parameter.
+- Returns: The Load operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase.Save(System.String)`
+
+```csharp
+public void Save(string path)
+```
+Executes the Save operation.
+
+- Parameter `path`: The path parameter.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase.ToCsv`
+
+```csharp
+public string ToCsv()
+```
+Serializes tags and group membership to CSV.
+
+- Returns: The CSV document.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase.ToJson`
+
+```csharp
+public string ToJson()
+```
+Executes the ToJson operation.
+
+- Returns: The ToJson operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase.ToYaml`
+
+```csharp
+public string ToYaml()
+```
+Executes the ToYaml operation.
+
+- Returns: The ToYaml operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase.TryGet(System.String,IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition@)`
+
+```csharp
+public bool TryGet(string name, out IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition tag)
+```
+Executes the TryGet operation.
+
+- Parameter `name`: The name parameter.
+- Parameter `tag`: The tag parameter.
+- Returns: The TryGet operation result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase.TryGetGroup(System.String,IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition@)`
+
+```csharp
+public bool TryGetGroup(string name, out IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition group)
+```
+Executes the TryGetGroup operation.
+
+- Parameter `name`: The name parameter.
+- Parameter `group`: The group parameter.
+- Returns: The TryGetGroup operation result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase.Count`
+
+```csharp
+public int Count { get; }
+```
+Gets or sets the Count property.
+
+- Value: The `Count` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase.GroupCount`
+
+```csharp
+public int GroupCount { get; }
+```
+Gets or sets the GroupCount property.
+
+- Value: The `GroupCount` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase.Groups`
+
+```csharp
+public System.Collections.Generic.IReadOnlyCollection<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition> Groups { get; }
+```
+Gets or sets the Groups property.
+
+- Value: The `Groups` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabase.Tags`
+
+```csharp
+public System.Collections.Generic.IReadOnlyCollection<IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition> Tags { get; }
+```
+Gets or sets the Tags property.
+
+- Value: The `Tags` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff
+```
+Provides the MitsubishiTagDatabaseDiff record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff.#ctor(System.Collections.Generic.IReadOnlyList`1{IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition},System.Collections.Generic.IReadOnlyList`1{IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition},System.Collections.Generic.IReadOnlyList`1{IoT.DriverCore.MitsubishiRx.MitsubishiTagChange},System.Collections.Generic.IReadOnlyList`1{IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition},System.Collections.Generic.IReadOnlyList`1{IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition},System.Collections.Generic.IReadOnlyList`1{IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange})`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff(System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition> AddedTags, System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition> RemovedTags, System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiTagChange> ChangedTags, System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition> AddedGroups, System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition> RemovedGroups, System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange> ChangedGroups)
+```
+Initializes a new instance of `IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff`.
+
+- Parameter `AddedTags`: The `AddedTags` value.
+- Parameter `RemovedTags`: The `RemovedTags` value.
+- Parameter `ChangedTags`: The `ChangedTags` value.
+- Parameter `AddedGroups`: The `AddedGroups` value.
+- Parameter `RemovedGroups`: The `RemovedGroups` value.
+- Parameter `ChangedGroups`: The `ChangedGroups` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff.Deconstruct(System.Collections.Generic.IReadOnlyList`1{IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition}@,System.Collections.Generic.IReadOnlyList`1{IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition}@,System.Collections.Generic.IReadOnlyList`1{IoT.DriverCore.MitsubishiRx.MitsubishiTagChange}@,System.Collections.Generic.IReadOnlyList`1{IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition}@,System.Collections.Generic.IReadOnlyList`1{IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition}@,System.Collections.Generic.IReadOnlyList`1{IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange}@)`
+
+```csharp
+public void Deconstruct(out System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition> AddedTags, out System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition> RemovedTags, out System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiTagChange> ChangedTags, out System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition> AddedGroups, out System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition> RemovedGroups, out System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange> ChangedGroups)
+```
+Deconstructs the value into its component values.
+
+- Parameter `AddedTags`: The `AddedTags` value.
+- Parameter `RemovedTags`: The `RemovedTags` value.
+- Parameter `ChangedTags`: The `ChangedTags` value.
+- Parameter `AddedGroups`: The `AddedGroups` value.
+- Parameter `RemovedGroups`: The `RemovedGroups` value.
+- Parameter `ChangedGroups`: The `ChangedGroups` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff,IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff left, IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff,IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff left, IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff.AddedGroups`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition> AddedGroups { get; set; }
+```
+The AddedGroups parameter.
+
+- Value: The `AddedGroups` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff.AddedTags`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition> AddedTags { get; set; }
+```
+The AddedTags parameter.
+
+- Value: The `AddedTags` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff.ChangeCount`
+
+```csharp
+public int ChangeCount { get; }
+```
+Gets or sets the ChangeCount property.
+
+- Value: The `ChangeCount` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff.ChangeKinds`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiSchemaChangeKind ChangeKinds { get; }
+```
+Gets or sets the ChangeKinds property.
+
+- Value: The `ChangeKinds` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff.ChangedGroups`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange> ChangedGroups { get; set; }
+```
+The ChangedGroups parameter.
+
+- Value: The `ChangedGroups` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff.ChangedTags`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiTagChange> ChangedTags { get; set; }
+```
+The ChangedTags parameter.
+
+- Value: The `ChangedTags` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff.Empty`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff Empty { get; }
+```
+Gets or sets the Empty property.
+
+- Value: The `Empty` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff.HasChanges`
+
+```csharp
+public bool HasChanges { get; }
+```
+Gets or sets the HasChanges property.
+
+- Value: The `HasChanges` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff.RemovedGroups`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition> RemovedGroups { get; set; }
+```
+The RemovedGroups parameter.
+
+- Value: The `RemovedGroups` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDatabaseDiff.RemovedTags`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition> RemovedTags { get; set; }
+```
+The RemovedTags parameter.
+
+- Value: The `RemovedTags` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition
+```
+Provides the MitsubishiTagDefinition record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition.#ctor(System.String,System.String,System.String,System.String,System.Double,System.Double,System.Nullable`1{System.Int32},System.String,System.String,System.Boolean,System.String,System.String)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition(string Name, string Address, string DataType, string Description, double Scale, double Offset, System.Nullable<int> Length, string Encoding, string Units, bool Signed, string ByteOrder, string Notes)
+```
+Initializes a new instance of `IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition`.
+
+- Parameter `Name`: The `Name` value.
+- Parameter `Address`: The `Address` value.
+- Parameter `DataType`: The `DataType` value.
+- Parameter `Description`: The `Description` value.
+- Parameter `Scale`: The `Scale` value.
+- Parameter `Offset`: The `Offset` value.
+- Parameter `Length`: The `Length` value.
+- Parameter `Encoding`: The `Encoding` value.
+- Parameter `Units`: The `Units` value.
+- Parameter `Signed`: The `Signed` value.
+- Parameter `ByteOrder`: The `ByteOrder` value.
+- Parameter `Notes`: The `Notes` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition.Deconstruct(System.String@,System.String@,System.String@,System.String@,System.Double@,System.Double@,System.Nullable`1{System.Int32}@,System.String@,System.String@,System.Boolean@,System.String@,System.String@)`
+
+```csharp
+public void Deconstruct(out string Name, out string Address, out string DataType, out string Description, out double Scale, out double Offset, out System.Nullable<int> Length, out string Encoding, out string Units, out bool Signed, out string ByteOrder, out string Notes)
+```
+Deconstructs the value into its component values.
+
+- Parameter `Name`: The `Name` value.
+- Parameter `Address`: The `Address` value.
+- Parameter `DataType`: The `DataType` value.
+- Parameter `Description`: The `Description` value.
+- Parameter `Scale`: The `Scale` value.
+- Parameter `Offset`: The `Offset` value.
+- Parameter `Length`: The `Length` value.
+- Parameter `Encoding`: The `Encoding` value.
+- Parameter `Units`: The `Units` value.
+- Parameter `Signed`: The `Signed` value.
+- Parameter `ByteOrder`: The `ByteOrder` value.
+- Parameter `Notes`: The `Notes` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition,IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition left, IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition,IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition left, IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition.Address`
+
+```csharp
+public string Address { get; set; }
+```
+The Address parameter.
+
+- Value: The `Address` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition.ByteOrder`
+
+```csharp
+public string ByteOrder { get; set; }
+```
+The ByteOrder parameter.
+
+- Value: The `ByteOrder` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition.DataType`
+
+```csharp
+public string DataType { get; set; }
+```
+The DataType parameter.
+
+- Value: The `DataType` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition.Description`
+
+```csharp
+public string Description { get; set; }
+```
+The Description parameter.
+
+- Value: The `Description` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition.Encoding`
+
+```csharp
+public string Encoding { get; set; }
+```
+The Encoding parameter.
+
+- Value: The `Encoding` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition.Length`
+
+```csharp
+public System.Nullable<int> Length { get; set; }
+```
+The Length parameter.
+
+- Value: The `Length` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition.Name`
+
+```csharp
+public string Name { get; set; }
+```
+The Name parameter.
+
+- Value: The `Name` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition.Notes`
+
+```csharp
+public string Notes { get; set; }
+```
+The Notes parameter.
+
+- Value: The `Notes` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition.Offset`
+
+```csharp
+public double Offset { get; set; }
+```
+The Offset parameter.
+
+- Value: The `Offset` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition.Scale`
+
+```csharp
+public double Scale { get; set; }
+```
+The Scale parameter.
+
+- Value: The `Scale` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition.Signed`
+
+```csharp
+public bool Signed { get; set; }
+```
+The Signed parameter.
+
+- Value: The `Signed` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagDefinition.Units`
+
+```csharp
+public string Units { get; set; }
+```
+The Units parameter.
+
+- Value: The `Units` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange
+```
+Provides the MitsubishiTagGroupChange record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange.#ctor(System.String,IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition,IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange(string Name, IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition Previous, IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition Current)
+```
+Provides the MitsubishiTagGroupChange record.
+
+- Parameter `Name`: The Name parameter.
+- Parameter `Previous`: The Previous parameter.
+- Parameter `Current`: The Current parameter.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange.Deconstruct(System.String@,IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition@,IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition@)`
+
+```csharp
+public void Deconstruct(out string Name, out IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition Previous, out IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition Current)
+```
+Deconstructs the value into its component values.
+
+- Parameter `Name`: The `Name` value.
+- Parameter `Previous`: The `Previous` value.
+- Parameter `Current`: The `Current` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange,IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange left, IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange,IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange left, IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange.ChangeKinds`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiSchemaChangeKind ChangeKinds { get; }
+```
+Gets or sets the ChangeKinds property.
+
+- Value: The `ChangeKinds` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange.Current`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition Current { get; set; }
+```
+The Current parameter.
+
+- Value: The `Current` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange.Name`
+
+```csharp
+public string Name { get; set; }
+```
+The Name parameter.
+
+- Value: The `Name` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupChange.Previous`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition Previous { get; set; }
+```
+The Previous parameter.
+
+- Value: The `Previous` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition
+```
+Provides the MitsubishiTagGroupDefinition record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition.#ctor(System.String,System.Collections.Generic.IReadOnlyList`1{System.String})`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition(string Name, System.Collections.Generic.IReadOnlyList<string> TagNames)
+```
+Initializes a new instance of `IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition`.
+
+- Parameter `Name`: The `Name` value.
+- Parameter `TagNames`: The `TagNames` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition.Deconstruct(System.String@,System.Collections.Generic.IReadOnlyList`1{System.String}@)`
+
+```csharp
+public void Deconstruct(out string Name, out System.Collections.Generic.IReadOnlyList<string> TagNames)
+```
+Deconstructs the value into its component values.
+
+- Parameter `Name`: The `Name` value.
+- Parameter `TagNames`: The `TagNames` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition,IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition left, IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition,IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition left, IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition.Name`
+
+```csharp
+public string Name { get; set; }
+```
+The Name parameter.
+
+- Value: The `Name` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition.ResolvedTagNames`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<string> ResolvedTagNames { get; }
+```
+Gets or sets the ResolvedTagNames property.
+
+- Value: The `ResolvedTagNames` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupDefinition.TagNames`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<string> TagNames { get; set; }
+```
+The TagNames parameter.
+
+- Value: The `TagNames` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot
+```
+Provides the MitsubishiTagGroupSnapshot record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot.#ctor(System.String,System.Collections.Generic.IReadOnlyDictionary`2{System.String,System.Object})`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot(string GroupName, System.Collections.Generic.IReadOnlyDictionary<string, object> Values)
+```
+Initializes a new instance of `IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot`.
+
+- Parameter `GroupName`: The `GroupName` value.
+- Parameter `Values`: The `Values` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot.Deconstruct(System.String@,System.Collections.Generic.IReadOnlyDictionary`2{System.String,System.Object}@)`
+
+```csharp
+public void Deconstruct(out string GroupName, out System.Collections.Generic.IReadOnlyDictionary<string, object> Values)
+```
+Deconstructs the value into its component values.
+
+- Parameter `GroupName`: The `GroupName` value.
+- Parameter `Values`: The `Values` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot.GetOptional``1(IoT.DriverCore.Core.LogicalTagKey`1{``0})`
+
+```csharp
+public T GetOptional<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag)
+```
+Executes the `GetOptional` operation.
+
+- Parameter `tag`: The `tag` value.
+- Returns: A `T` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot.GetRequired``1(IoT.DriverCore.Core.LogicalTagKey`1{``0})`
+
+```csharp
+public T GetRequired<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag)
+```
+Executes the `GetRequired` operation.
+
+- Parameter `tag`: The `tag` value.
+- Returns: A `T` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot,IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot left, IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot,IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot left, IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot.GroupName`
+
+```csharp
+public string GroupName { get; set; }
+```
+The GroupName parameter.
+
+- Value: The `GroupName` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot.TagNames`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<string> TagNames { get; }
+```
+Gets or sets the TagNames property.
+
+- Value: The `TagNames` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTagGroupSnapshot.Values`
+
+```csharp
+public System.Collections.Generic.IReadOnlyDictionary<string, object> Values { get; set; }
+```
+The Values parameter.
+
+- Value: The `Values` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiTagRolloutPolicy`
+
+```csharp
+public enum IoT.DriverCore.MitsubishiRx.MitsubishiTagRolloutPolicy
+```
+Defines the MitsubishiTagRolloutPolicy values.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiTagRolloutPolicy.AllowAll`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiTagRolloutPolicy AllowAll
+```
+Represents the AllowAll option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiTagRolloutPolicy.SafeMetadataAndGroups`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiTagRolloutPolicy SafeMetadataAndGroups
+```
+Represents the SafeMetadataAndGroups option.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiTagValueConverter`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiTagValueConverter
+```
+Converts dynamically read tag values to declared tag types.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTagValueConverter.Require``1(System.Object,IoT.DriverCore.Core.LogicalTagKey`1{``0})`
+
+```csharp
+public static T Require<T>(object value, IoT.DriverCore.Core.LogicalTagKey<T> tag)
+```
+Executes the `Require` operation.
+
+- Parameter `value`: The `value` value.
+- Parameter `tag`: The `tag` value.
+- Returns: A `T` result.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiTransportKind`
+
+```csharp
+public enum IoT.DriverCore.MitsubishiRx.MitsubishiTransportKind
+```
+Defines the MitsubishiTransportKind values.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiTransportKind.Serial`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiTransportKind Serial
+```
+Represents the Serial option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiTransportKind.Tcp`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiTransportKind Tcp
+```
+Represents the Tcp option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.MitsubishiTransportKind.Udp`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.MitsubishiTransportKind Udp
+```
+Represents the Udp option.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest
+```
+Provides the MitsubishiTransportRequest record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest.#ctor(System.Byte[],System.Nullable`1{System.Int32},System.String)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest(byte[] Payload, System.Nullable<int> ExpectedResponseLength, string Description)
+```
+Initializes a new instance of `IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest`.
+
+- Parameter `Payload`: The `Payload` value.
+- Parameter `ExpectedResponseLength`: The `ExpectedResponseLength` value.
+- Parameter `Description`: The `Description` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest.Deconstruct(System.Byte[]@,System.Nullable`1{System.Int32}@,System.String@)`
+
+```csharp
+public void Deconstruct(out byte[] Payload, out System.Nullable<int> ExpectedResponseLength, out string Description)
+```
+Deconstructs the value into its component values.
+
+- Parameter `Payload`: The `Payload` value.
+- Parameter `ExpectedResponseLength`: The `ExpectedResponseLength` value.
+- Parameter `Description`: The `Description` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest,IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest left, IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest,IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest left, IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest.Description`
+
+```csharp
+public string Description { get; set; }
+```
+The Description parameter.
+
+- Value: The `Description` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest.ExpectedResponseLength`
+
+```csharp
+public System.Nullable<int> ExpectedResponseLength { get; set; }
+```
+The ExpectedResponseLength parameter.
+
+- Value: The `ExpectedResponseLength` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTransportRequest.Payload`
+
+```csharp
+public byte[] Payload { get; set; }
+```
+The Payload parameter.
+
+- Value: The `Payload` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiTypeName`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiTypeName
+```
+Provides the MitsubishiTypeName record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTypeName.#ctor(System.String,System.UInt16)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiTypeName(string ModelName, ushort ModelCode)
+```
+Provides the MitsubishiTypeName record.
+
+- Parameter `ModelName`: The ModelName parameter.
+- Parameter `ModelCode`: The ModelCode parameter.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTypeName.Deconstruct(System.String@,System.UInt16@)`
+
+```csharp
+public void Deconstruct(out string ModelName, out ushort ModelCode)
+```
+Deconstructs the value into its component values.
+
+- Parameter `ModelName`: The `ModelName` value.
+- Parameter `ModelCode`: The `ModelCode` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTypeName.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiTypeName)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiTypeName other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTypeName.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTypeName.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTypeName.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTypeName.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiTypeName,IoT.DriverCore.MitsubishiRx.MitsubishiTypeName)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiTypeName left, IoT.DriverCore.MitsubishiRx.MitsubishiTypeName right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiTypeName.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiTypeName,IoT.DriverCore.MitsubishiRx.MitsubishiTypeName)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiTypeName left, IoT.DriverCore.MitsubishiRx.MitsubishiTypeName right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTypeName.ModelCode`
+
+```csharp
+public ushort ModelCode { get; set; }
+```
+The ModelCode parameter.
+
+- Value: The `ModelCode` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiTypeName.ModelName`
+
+```csharp
+public string ModelName { get; set; }
+```
+The ModelName parameter.
+
+- Value: The `ModelName` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock
+```
+Provides the MitsubishiWordBlock record.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock.#ctor(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress,System.ReadOnlyMemory`1{System.UInt16})`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress Address, System.ReadOnlyMemory<ushort> Values)
+```
+Initializes a new instance of `IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock`.
+
+- Parameter `Address`: The `Address` value.
+- Parameter `Values`: The `Values` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock.Deconstruct(IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress@,System.ReadOnlyMemory`1{System.UInt16}@)`
+
+```csharp
+public void Deconstruct(out IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress Address, out System.ReadOnlyMemory<ushort> Values)
+```
+Deconstructs the value into its component values.
+
+- Parameter `Address`: The `Address` value.
+- Parameter `Values`: The `Values` value.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock.Equals(IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock)`
+
+```csharp
+public bool Equals(IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock.op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock,IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock left, IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock.op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock,IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock left, IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock.Address`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.MitsubishiDeviceAddress Address { get; set; }
+```
+The Address parameter.
+
+- Value: The `Address` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.MitsubishiWordBlock.Values`
+
+```csharp
+public System.ReadOnlyMemory<ushort> Values { get; set; }
+```
+The Values parameter.
+
+- Value: The `Values` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.Responce`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.Responce
+```
+Provides the Responce type.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.Responce.#ctor`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.Responce()
+```
+Initializes a new instance of the `T:IoT.DriverCore.MitsubishiRx.Responce` class using `P:System.TimeProvider.System` .
+
+###### `M:IoT.DriverCore.MitsubishiRx.Responce.#ctor(System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.Responce(System.TimeProvider timeProvider)
+```
+Initializes a new instance of the `T:IoT.DriverCore.MitsubishiRx.Responce` class.
+
+- Parameter `timeProvider`: The time provider used to stamp `P:IoT.DriverCore.MitsubishiRx.Responce.InitialTime` .
+
+###### `M:IoT.DriverCore.MitsubishiRx.Responce.AddErr2List`
+
+```csharp
+public void AddErr2List()
+```
+Executes the AddErr2List operation.
+
+###### `M:IoT.DriverCore.MitsubishiRx.Responce.SetErrInfo(IoT.DriverCore.MitsubishiRx.Responce)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.Responce SetErrInfo(IoT.DriverCore.MitsubishiRx.Responce result)
+```
+Executes the SetErrInfo operation.
+
+- Parameter `result`: The result parameter.
+- Returns: The SetErrInfo operation result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.Responce.Err`
+
+```csharp
+public string Err { get; set; }
+```
+Gets or sets the Err property.
+
+- Value: The `Err` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.Responce.ErrCode`
+
+```csharp
+public int ErrCode { get; set; }
+```
+Gets or sets the ErrCode property.
+
+- Value: The `ErrCode` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.Responce.ErrList`
+
+```csharp
+public System.Collections.Generic.List<string> ErrList { get; }
+```
+Gets or sets the ErrList property.
+
+- Value: The `ErrList` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.Responce.Exception`
+
+```csharp
+public System.Exception Exception { get; set; }
+```
+Gets or sets the Exception property.
+
+- Value: The `Exception` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.Responce.InitialTime`
+
+```csharp
+public System.DateTimeOffset InitialTime { get; }
+```
+Gets the InitialTime property.
+
+- Value: The `InitialTime` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.Responce.IsSucceed`
+
+```csharp
+public bool IsSucceed { get; set; }
+```
+Gets or sets the IsSucceed property.
+
+- Value: The `IsSucceed` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.Responce.Request`
+
+```csharp
+public string Request { get; set; }
+```
+Gets or sets the Request property.
+
+- Value: The `Request` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.Responce.Request2`
+
+```csharp
+public string Request2 { get; set; }
+```
+Gets or sets the Request2 property.
+
+- Value: The `Request2` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.Responce.Response`
+
+```csharp
+public string Response { get; set; }
+```
+Gets or sets the Response property.
+
+- Value: The `Response` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.Responce.Response2`
+
+```csharp
+public string Response2 { get; set; }
+```
+Gets or sets the Response2 property.
+
+- Value: The `Response2` value.
+
+###### `P:IoT.DriverCore.MitsubishiRx.Responce.TimeConsuming`
+
+```csharp
+public System.Nullable<double> TimeConsuming { get; }
+```
+Gets the TimeConsuming property.
+
+- Value: The `TimeConsuming` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.Responce`1`
+
+```csharp
+public class IoT.DriverCore.MitsubishiRx.Responce`1
+```
+Provides the Responce type.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.MitsubishiRx.Responce`1.#ctor`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.Responce<T>()
+```
+Initializes a new instance of the Responce class.
+
+###### `M:IoT.DriverCore.MitsubishiRx.Responce`1.#ctor(IoT.DriverCore.MitsubishiRx.Responce)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.Responce<T>(IoT.DriverCore.MitsubishiRx.Responce result)
+```
+Initializes a new instance of the Responce class.
+
+- Parameter `result`: The result parameter.
+
+###### `M:IoT.DriverCore.MitsubishiRx.Responce`1.#ctor(IoT.DriverCore.MitsubishiRx.Responce,`0)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.Responce<T>(IoT.DriverCore.MitsubishiRx.Responce result, T data)
+```
+Initializes a new instance of the Responce class.
+
+- Parameter `result`: The result parameter.
+- Parameter `data`: The data parameter.
+
+###### `M:IoT.DriverCore.MitsubishiRx.Responce`1.#ctor(`0)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.Responce<T>(T data)
+```
+Initializes a new instance of the Responce class.
+
+- Parameter `data`: The data parameter.
+
+###### `M:IoT.DriverCore.MitsubishiRx.Responce`1.SetErrInfo(IoT.DriverCore.MitsubishiRx.Responce)`
+
+```csharp
+public IoT.DriverCore.MitsubishiRx.Responce<T> SetErrInfo(IoT.DriverCore.MitsubishiRx.Responce result)
+```
+Executes the SetErrInfo operation.
+
+- Parameter `result`: The result parameter.
+- Returns: The SetErrInfo operation result.
+
+###### `P:IoT.DriverCore.MitsubishiRx.Responce`1.Value`
+
+```csharp
+public T Value { get; set; }
+```
+Gets or sets the Value property.
+
+- Value: The `Value` value.
+
+#### `T:IoT.DriverCore.MitsubishiRx.XyAddressNotation`
+
+```csharp
+public enum IoT.DriverCore.MitsubishiRx.XyAddressNotation
+```
+Defines the XyAddressNotation values.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.MitsubishiRx.XyAddressNotation.Hexadecimal`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.XyAddressNotation Hexadecimal
+```
+Represents the Hexadecimal option.
+
+###### `F:IoT.DriverCore.MitsubishiRx.XyAddressNotation.Octal`
+
+```csharp
+public static const IoT.DriverCore.MitsubishiRx.XyAddressNotation Octal
+```
+Represents the Octal option.
+
+<!-- END GENERATED PUBLIC API -->

--- a/packagereadme/ModbusRx/README.md
+++ b/packagereadme/ModbusRx/README.md
@@ -1,1719 +1,7499 @@
-# ModbusRx - A Reactive Modbus Implementation
-
-![License](https://img.shields.io/github/license/ChrisPulman/ModbusRx.svg) [![Build](https://github.com/ChrisPulman/ModbusRx/actions/workflows/BuildOnly.yml/badge.svg)](https://github.com/ChrisPulman/ModbusRx/actions/workflows/BuildOnly.yml) ![Nuget](https://img.shields.io/nuget/dt/ModbusRx?color=pink&style=plastic) [![NuGet](https://img.shields.io/nuget/v/ModbusRx.svg?style=plastic)](https://www.nuget.org/packages/ModbusRx)
-
-![Alt](https://repobeats.axiom.co/api/embed/003b94efc502d37d72af8cc355f4cf4ef95f317a.svg "Repobeats analytics image")
-
-<p align="left">
-  <a href="https://github.com/ChrisPulman/ModbusRx">
-    <img alt="ModbusRx" src="https://github.com/ChrisPulman/ModbusRx/blob/main/Images/ModbusRx.png" width="200"/>
-  </a>
-</p>
+# ModbusRx
 
 ## Overview
 
-ModbusRx is a modern, reactive implementation of the Modbus protocol for .NET applications. Built on the foundation of NModbus4 and ReactiveUI.Primitives, it provides a powerful, observable-based API for industrial communication scenarios with comprehensive support for all major Modbus variants.
+`ModbusRx` is an asynchronous Modbus master, slave/server, simulation, logical-tag, and observable toolkit. It supports Modbus TCP, UDP, RTU, and ASCII through SerialPortRx adapters and exposes core function codes 1, 2, 3, 4, 5, 6, 8, 15, 16, and 23.
 
-### Key Features
+## Safety
 
-- **🔧 Full Modbus Protocol Support**: RTU, ASCII, TCP, and UDP variants
-- **⚡ Reactive Design**: Built with ReactiveUI.Primitives for responsive, event-driven applications
-- **🔁 Async Observables**: `IObservableAsync<T>` bridges through ReactiveUI.Primitives.Async and ReactiveUI.Primitives.Async.Reactive
-- **🧩 Source Generators**: Attribute-driven register maps that expose properties and matching observable streams
-- **🏭 Master/Slave Architecture**: Complete client and server implementations
-- **🚀 High Performance**: Optimized for speed with memory-efficient operations
-- **✅ TUnit Testing**: Unit, integration, and generator tests run on Microsoft Testing Platform
-- **📊 Advanced Simulation**: Built-in simulation capabilities for testing and development
-- **📡 Connection Management**: Automatic reconnection and health monitoring
-- **🔄 Data Type Conversions**: Built-in support for float, double, and custom data types
-- **🛠️ SerialPortRx**: Built on [CP.IO.Ports](https://github.com/ChrisPulman/SerialPortRx) for robust, Reactive serial communication
+Modbus has no intrinsic authorization and write functions can alter a live process. Segment the control network, allow-list endpoints/unit IDs, validate zero-based addresses against the device map, use least privilege, and require an application interlock/audit record for writes. Test against `DataStore`, a simulator, or an isolated device first.
 
-### Supported Protocols & Target Frameworks
+## Package matrix
 
-**Protocols:**
-- ✅ **Modbus RTU Master/Slave** (Serial)
-- ✅ **Modbus ASCII Master/Slave** (Serial)  
-- ✅ **Modbus TCP Master/Slave** (Ethernet)
-- ✅ **Modbus UDP Master/Slave** (Ethernet)
-- ✅ **Modbus TCP/UDP Server** with client aggregation
+| Package | Namespace | Target frameworks | Use it when |
+| --- | --- | --- | --- |
+| `ModbusRx` | `IoT.DriverCore.ModbusRx` | net48, net8.0, net9.0, net10.0, net11.0 | Using ReactiveUI.Primitives.Async and SerialPortRx. |
+| `ModbusRx.Reactive` | `IoT.DriverCore.ModbusRx.Reactive` | net48, net8.0, net9.0, net10.0, net11.0 | Using the reactive bridge and SerialPortRx.Reactive. |
+| `ModbusRx.Generators` | `IoT.DriverCore.ModbusRx.Generators` | netstandard2.0 analyzer | Generating typed reactive device maps; install it alongside one runtime package. |
 
-**Target Frameworks:**
-- `.NET Framework 4.8` (Legacy support)
-- `.NET 8` (Long-term support)
-- `.NET 9`
-- `.NET 10`
-- `.NET 11`
+Both packages compile the same source with namespace aliases. Choose one; do not mix both surfaces accidentally.
 
-## Installation
+## Install
 
 ```bash
 dotnet add package ModbusRx
-```
-
-Use the reactive shim package when you want the shared API emitted under the `ModbusRx.Reactive.*` namespace tree with ReactiveUI.Primitives.Reactive and ReactiveUI.Primitives.Async.Reactive adapters:
-
-```bash
+# or
 dotnet add package ModbusRx.Reactive
+# optional typed reactive device-map generator
+dotnet add package ModbusRx.Generators
 ```
 
-The core package keeps its historical namespaces, including `ModbusRx.Device`, `ModbusRx.Data`, and `ModbusRx.Reactive`. The shim package mirrors those sources under `ModbusRx.Reactive.*`; for example device types are available from `ModbusRx.Reactive.Device`.
+## Quick start
 
-Or via Package Manager Console:
-
-```powershell
-Install-Package ModbusRx
-Install-Package ModbusRx.Reactive
-```
-
-## Quick Start Guide
-
-### 1. Basic TCP Master Operations
-
-#### Simple TCP Master Connection
+Use `ModbusIpMaster.CreateIp` with a connected `TcpClientRx`, `UdpClientRx`, `SerialPortRx`, or an `IStreamResource`. Addresses are zero-based API offsets, not display addresses such as 40001.
 
 ```csharp
-using ModbusRx.Device;
-using CP.IO.Ports;
+using IoT.DriverCore.ModbusRx.Device;
+using IoT.DriverCore.Serial;
 
-// Create a TCP master
-var client = new TcpClientRx("192.168.1.100", 502);
-using var master = ModbusIpMaster.CreateIp(client);
+using var tcp = new TcpClientRx("192.168.0.20", 502);
+using var master = ModbusIpMaster.CreateIp(tcp);
 
-// Read holding registers (Function Code 03)
 var registers = await master.ReadHoldingRegistersAsync(
-    slaveAddress: 1, 
-    startAddress: 0, 
-    numberOfPoints: 10);
-
-Console.WriteLine($"Read {registers.Length} registers: [{string.Join(", ", registers)}]");
-
-// Write a single register (Function Code 06)  
-await master.WriteSingleRegisterAsync(
-    slaveAddress: 1, 
-    registerAddress: 0, 
-    value: 12345);
-
-// Write multiple registers (Function Code 16)
-var dataToWrite = new ushort[] { 100, 200, 300, 400, 500 };
-await master.WriteMultipleRegistersAsync(
-    slaveAddress: 1, 
-    startAddress: 10, 
-    data: dataToWrite);
+    slaveAddress: 1, startAddress: 0, numberOfPoints: 2);
+await master.WriteSingleRegisterAsync(slaveAddress: 1, registerAddress: 0, value: 42);
+Console.WriteLine(registers[0]);
 ```
 
-#### Advanced TCP Master with Error Handling
+`ModbusIpMaster` also has no-unit-id overloads that use the IP default unit ID. For serial devices, use `ModbusSerialMaster.CreateRtu` or `CreateAscii`.
+
+## Configuration
+
+Configure the transport first, then set the transport's timeout/retry properties if needed. Match TCP port, UDP endpoint, or serial baud/data bits/parity/stop bits/handshake exactly to the device. Preserve unit IDs for serial and gateway deployments. Requests validate protocol limits: reads allow up to 2,000 bits or 125 registers; writes allow 1,968 coils, 123 registers, or 121 combined-write registers.
 
 ```csharp
-using ModbusRx.Device;
-using CP.IO.Ports;
-
-try
-{
-    var client = new TcpClientRx("192.168.1.100", 502)
-    {
-        ReadTimeout = 5000,   // 5 second timeout
-        WriteTimeout = 5000
-    };
-    
-    using var master = ModbusIpMaster.CreateIp(client);
-    
-    // Configure transport settings
-    master.Transport!.ReadTimeout = 5000;
-    master.Transport.Retries = 3;
-    master.Transport.WaitToRetryMilliseconds = 1000;
-    
-    // Read all data types
-    var coils = await master.ReadCoilsAsync(1, 0, 16);
-    var discreteInputs = await master.ReadInputsAsync(1, 0, 16);
-    var holdingRegisters = await master.ReadHoldingRegistersAsync(1, 0, 10);
-    var inputRegisters = await master.ReadInputRegistersAsync(1, 0, 10);
-    
-    Console.WriteLine($"Coils: {string.Join("", coils.Select(c => c ? "1" : "0"))}");
-    Console.WriteLine($"Discrete Inputs: {string.Join("", discreteInputs.Select(d => d ? "1" : "0"))}");
-    Console.WriteLine($"Holding Registers: [{string.Join(", ", holdingRegisters)}]");
-    Console.WriteLine($"Input Registers: [{string.Join(", ", inputRegisters)}]");
-}
-catch (ModbusException ex)
-{
-    Console.WriteLine($"Modbus Error: {ex.Message}");
-}
-catch (TimeoutException ex)
-{
-    Console.WriteLine($"Timeout Error: {ex.Message}");
-}
-catch (Exception ex)
-{
-    Console.WriteLine($"General Error: {ex.Message}");
-}
-```
-
-### 2. Reactive Masters with Automatic Connection Management
-
-#### TCP and UDP
-
-```csharp
-using ModbusRx.Reactive;
-using ReactiveUI.Primitives.Reactive;
-
-// Reactive TCP master
-var tcp = Create.TcpIpMaster("192.168.1.100", 502);
-var tcpSub = tcp
-    .ReadHoldingRegisters(startAddress: 0, numberOfPoints: 10, interval: 1000)
-    .Subscribe(result =>
-    {
-        if (result.error == null && result.data != null)
-        {
-            Console.WriteLine($"TCP: [{string.Join(", ", result.data)}]");
-        }
-    });
-
-// Reactive UDP master
-var udp = Create.UdpIpMaster("192.168.1.101", 502);
-var udpSub = udp
-    .ReadHoldingRegisters(startAddress: 0, numberOfPoints: 10, interval: 1000)
-    .Subscribe(result =>
-    {
-        if (result.error == null && result.data != null)
-        {
-            Console.WriteLine($"UDP: [{string.Join(", ", result.data)}]");
-        }
-    });
-```
-
-#### Reactive Serial RTU/ASCII Masters
-
-```csharp
-using ModbusRx.Reactive;
 using System.IO.Ports;
-using ReactiveUI.Primitives.Reactive;
+using IoT.DriverCore.ModbusRx.Device;
+using IoT.DriverCore.Serial;
 
-// Reactive Serial RTU master
-var rtu = Create.SerialRtuMaster("COM3", 19200, 8, Parity.None, StopBits.One);
-var rtuSub = rtu
-    .ReadHoldingRegisters(slaveAddress: 1, startAddress: 0, numberOfPoints: 10, interval: 500)
-    .Subscribe(result =>
-    {
-        if (result.error == null && result.data != null)
-        {
-            Console.WriteLine($"RTU: [{string.Join(", ", result.data)}]");
-        }
-    });
-
-
-// Convenience overload (defaults slave 1)
-var rtuQuickSub = rtu
-    .ReadHoldingRegisters(startAddress: 0, numberOfPoints: 5, interval: 1000)
-    .Subscribe();
-
-// Reactive Serial ASCII master
-var ascii = Create.SerialAsciiMaster("COM4", 9600, 7, Parity.Even, StopBits.One);
-var asciiSub = ascii
-    .ReadCoils(slaveAddress: 1, startAddress: 0, numberOfPoints: 8, interval: 1000)
-    .Subscribe(result =>
-    {
-        if (result.error == null && result.data != null)
-        {
-            Console.WriteLine($"ASCII Coils: {string.Join("", result.data.Select(c => c ? "1" : "0"))}");
-        }
-    });
-```
-
-### 3. UDP Master Operations
-
-```csharp
-using ModbusRx.Device;
-using CP.IO.Ports;
-using System.Net;
-
-// Create UDP master
-var client = new UdpClientRx();
-var endPoint = new IPEndPoint(IPAddress.Parse("192.168.1.100"), 502);
-client.Connect(endPoint);
-
-using var master = ModbusIpMaster.CreateIp(client);
-
-// UDP operations are similar to TCP
-var registers = await master.ReadHoldingRegistersAsync(1, 0, 10);
-Console.WriteLine($"UDP Read: [{string.Join(", ", registers)}]");
-
-// Write coils (Function Code 15)
-var coilData = new bool[] { true, false, true, true, false, false, true, false };
-await master.WriteMultipleCoilsAsync(1, 0, coilData);
-```
-
-### 4. Serial RTU Master
-
-```csharp
-using CP.IO.Ports;
-using ModbusRx.Device;
-using System.IO.Ports;
-
-// Configure serial port
-using var port = new SerialPortRx("COM1")
+using var port = new SerialPortRx("COM3")
 {
-    BaudRate = 9600,
-    DataBits = 8,
-    Parity = Parity.None,
-    StopBits = StopBits.One,
-    Handshake = Handshake.None
+    BaudRate = 9600, DataBits = 8, Parity = Parity.Even,
+    StopBits = StopBits.One, Handshake = Handshake.None,
 };
-
-await port.OpenAsync();
-
-// Create RTU master
 using var master = ModbusSerialMaster.CreateRtu(port);
-
-try
-{
-    // Read coils
-    var coils = await master.ReadCoilsAsync(
-        slaveAddress: 1, 
-        startAddress: 0, 
-        numberOfPoints: 16);
-    
-    Console.WriteLine($"Coils: {string.Join("", coils.Select(c => c ? "1" : "0"))}");
-    
-    // Read/Write multiple registers (Function Code 23)
-    var writeData = new ushort[] { 1000, 2000, 3000 };
-    var readData = await master.ReadWriteMultipleRegistersAsync(
-        slaveAddress: 1,
-        startReadAddress: 0,
-        numberOfPointsToRead: 5,
-        startWriteAddress: 10,
-        writeData: writeData);
-    
-    Console.WriteLine($"Read/Write Result: [{string.Join(", ", readData)}]");
-}
-finally
-{
-    await port.CloseAsync();
-}
+var coils = await master.ReadCoilsAsync(1, 0, 8);
 ```
 
-### 5. Serial ASCII Master
+## Detailed features
+
+### Master requests
+
+`IModbusMaster` / `ModbusMaster` expose `ReadCoilsAsync`, `ReadInputsAsync`, `ReadHoldingRegistersAsync`, `ReadInputRegistersAsync`, `WriteSingleCoilAsync`, `WriteSingleRegisterAsync`, `WriteMultipleCoilsAsync`, `WriteMultipleRegistersAsync`, and `ReadWriteMultipleRegistersAsync`. Each base overload accepts `byte slaveAddress`; `ModbusIpMaster` adds convenience overloads. `ExecuteCustomMessage<TResponse>` supports a custom request/response pair; catch `SlaveException`, `InvalidModbusRequestException`, and `ModbusCommunicationException` explicitly.
 
 ```csharp
-using CP.IO.Ports;
-using ModbusRx.Device;
-using System.IO.Ports;
-
-// Configure serial port for ASCII
-using var port = new SerialPortRx("COM2")
-{
-    BaudRate = 9600,
-    DataBits = 7,           // ASCII typically uses 7 data bits
-    Parity = Parity.Even,   // ASCII typically uses even parity
-    StopBits = StopBits.One
-};
-
-await port.OpenAsync();
-
-// Create ASCII master
-using var master = ModbusSerialMaster.CreateAscii(port);
-
-// ASCII operations are identical to RTU in terms of function calls
-var registers = await master.ReadHoldingRegistersAsync(1, 0, 10);
-Console.WriteLine($"ASCII Read: [{string.Join(", ", registers)}]");
+var current = await master.ReadWriteMultipleRegistersAsync(
+    slaveAddress: 1, startReadAddress: 10, numberOfPointsToRead: 2,
+    startWriteAddress: 20, writeData: new ushort[] { 100, 101 });
 ```
 
-## Advanced Server Implementations
+### Slaves, servers, and test data
 
-### 1. Creating a Comprehensive Modbus Server
-
-```csharp
-using ModbusRx.Device;
-using ModbusRx.Data;
-
-// Create and configure a server
-using var server = new ModbusServer();
-
-// Start multiple protocol endpoints
-var tcpSubscription = server.StartTcpServer(502, unitId: 1);
-var udpSubscription = server.StartUdpServer(503, unitId: 1);
-
-// Enable simulation mode for testing
-server.SimulationMode = true;
-
-// Start the server
-server.Start();
-
-// Load initial test data
-server.LoadSimulationData(
-    holdingRegisters: new ushort[] { 1, 2, 3, 4, 5, 100, 200, 300, 400, 500 },
-    inputRegisters: new ushort[] { 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-    coils: new bool[] { true, false, true, false, true, false, true, false },
-    inputs: new bool[] { false, true, false, true, false, true, false, true }
-);
-
-Console.WriteLine("Server running on TCP:502 and UDP:503");
-Console.WriteLine("Press any key to stop...");
-Console.ReadKey();
-
-// Cleanup
-server.Stop();
-tcpSubscription.Dispose();
-udpSubscription.Dispose();
-```
-
-### 2. TCP Slave Implementation
+`DataStoreFactory.CreateDefaultDataStore` creates the four data areas. `ModbusTcpSlave.CreateTcp`, `ModbusUdpSlave.CreateUdp`, and `ModbusSerialSlave.CreateRtu` / `CreateAscii` create protocol slaves. Call `ListenAsync` for a slave; dispose it to stop it. `ModbusServer` aggregates TCP/UDP slaves and remote clients, exposes `IsRunning`, `DataStore`, and `SimulationMode`, and owns server lifecycle/simulation. Use `DataStoreWrittenTo` / `DataStoreReadFrom` plus `GetOperationMetrics` for observability.
 
 ```csharp
-using ModbusRx.Device;
-using ModbusRx.Data;
+using System.Net;
 using System.Net.Sockets;
+using IoT.DriverCore.ModbusRx.Data;
+using IoT.DriverCore.ModbusRx.Device;
 
-// Create TCP listener
-var tcpListener = new TcpListener(IPAddress.Any, 502);
-
-// Create TCP slave
-using var slave = ModbusTcpSlave.CreateTcp(unitId: 1, tcpListener);
-
-// Configure custom data store
+using var slave = ModbusTcpSlave.CreateTcp(1, new TcpListener(IPAddress.Loopback, 1502));
 slave.DataStore = DataStoreFactory.CreateDefaultDataStore();
-
-// Load test data
-for (ushort i = 1; i <= 100; i++)
-{
-    slave.DataStore.HoldingRegisters[i] = (ushort)(i * 10);
-    slave.DataStore.InputRegisters[i] = (ushort)(i * 5);
-    slave.DataStore.CoilDiscretes[i] = (i % 2) == 0;
-    slave.DataStore.InputDiscretes[i] = (i % 3) == 0;
-}
-
-// Start listening
-var listenTask = Task.Run(async () => await slave.ListenAsync());
-
-Console.WriteLine("TCP Slave listening on port 502...");
-Console.WriteLine("Press any key to stop...");
-Console.ReadKey();
-
-// Stop the slave
-slave.Dispose();
+slave.DataStore.HoldingRegisters[0] = 25;
+var listening = slave.ListenAsync(); // keep task alive until the slave is disposed
 ```
 
-### 3. UDP Slave Implementation
+`ModbusSimulator`, `SimulationDataProvider`, `TestPattern`, and `SimulationType` support deterministic test/scenario data. `ModbusTcpLoopbackEndpoint` supports local end-to-end tests without a physical device.
+
+### Observable operations and connection factories
+
+`Create.TcpIpMaster`, `UdpIpMaster`, `SerialRtuMaster`, and `SerialAsciiMaster` create connection-state observables. Read extensions such as `ReadCoils`, `ReadInputs`, `ReadHoldingRegisters`, and `ReadInputRegisters` poll those streams and emit `(Data, Error)` tuples. `ModbusAsyncObservableExtensions` provides async-observable bridges. `Create.PingInterval` and `CheckConnectionInterval` control factory monitoring; dispose subscriptions to release their masters.
 
 ```csharp
-using ModbusRx.Device;
-using CP.IO.Ports;
+using IoT.DriverCore.ModbusRx;
 
-// Create UDP client for listening
-var udpClient = new UdpClientRx(502);
-
-// Create UDP slave
-using var slave = ModbusUdpSlave.CreateUdp(unitId: 1, udpClient);
-
-// Start listening
-var listenTask = Task.Run(async () => await slave.ListenAsync());
-
-Console.WriteLine("UDP Slave listening on port 502...");
-Console.WriteLine("Press any key to stop...");
-Console.ReadKey();
+using var poll = Create.TcpIpMaster("192.168.0.20", 502)
+    .ReadHoldingRegisters(1, 0, 2, interval: 500)
+    .Subscribe(result =>
+    {
+        if (result.Error is null) Console.WriteLine(result.Data![0]);
+    });
 ```
 
-### 4. Serial RTU Slave
+### Logical tags, conversions, and Enron helpers
+
+`ModbusLogicalTagClient` composes an `IModbusMaster` with a `ModbusTagCatalog`, optional SQLite persistence, grouped reads/writes, and observable/async observation. Build a `ModbusTagConfiguration`, set byte order/access/scan interval as needed, and call `CreateTag`; use `ReadAsync` / `WriteAsync` or batch variants. `ModbusDataExtensions` and `ModbusUtility` convert registers, byte order, CRC/LRC, floats, doubles, ASCII, and network values. `EnronModbusExtensions` adds 32-bit register read/write helpers.
 
 ```csharp
-using ModbusRx.Device;
-using CP.IO.Ports;
-using System.IO.Ports;
+using IoT.DriverCore.ModbusRx.LogicalTags;
 
-// Configure serial port
-using var port = new SerialPortRx("COM1")
+using var tags = new ModbusLogicalTagClient(master, catalog: null, defaultScanInterval: TimeSpan.FromSeconds(1));
+tags.CreateTag(new ModbusTagConfiguration(
+    "Temperature", 1, ModbusDataArea.HoldingRegister, 0, 1, typeof(ushort)));
+var value = await tags.ReadAsync("Temperature");
+if (value.Succeeded) Console.WriteLine(value.Value!.Value);
+```
+
+### Generated reactive device maps
+
+Add `ModbusRx.Generators` when a partial class should expose generated latest-value, observable, async-observable, binding, and optional logical-tag read/write members. The connection member must expose the master stream produced by the `Create` factory.
+
+```csharp
+using IoT.DriverCore.ModbusRx;
+using IoT.DriverCore.ModbusRx.Device;
+using IoT.DriverCore.ModbusRx.Generators;
+
+var map = new BoilerMap
 {
-    BaudRate = 9600,
-    DataBits = 8,
-    Parity = Parity.None,
-    StopBits = StopBits.One
+    MasterStream = Create.TcpIpMaster("192.168.0.20", 502),
 };
+using var binding = map.BindGeneratedModbusStreams();
+using var changes = map.TemperatureObservable.Subscribe(Console.WriteLine);
 
-await port.OpenAsync();
-
-// Create RTU slave
-using var slave = ModbusSerialSlave.CreateRtu(unitId: 1, port);
-
-// Start listening
-var listenTask = Task.Run(async () => await slave.ListenAsync());
-
-Console.WriteLine("RTU Slave listening on COM1...");
-Console.WriteLine("Press any key to stop...");
-Console.ReadKey();
-```
-
-## Data Type Conversions and Utilities
-
-### 1. Working with Float and Double Values
-
-```csharp
-using ModbusRx.Reactive;
-
-// Read registers and convert to float
-var registers = await master.ReadHoldingRegistersAsync(1, 0, 2);
-var floatValue = registers.ToFloat(0); // Convert registers at index 0-1 to float
-Console.WriteLine($"Float value: {floatValue}");
-
-// Read registers and convert to double
-var doubleRegisters = await master.ReadHoldingRegistersAsync(1, 0, 4);
-var doubleValue = doubleRegisters.ToDouble(0); // Convert registers at index 0-3 to double
-Console.WriteLine($"Double value: {doubleValue}");
-
-// Convert values back to registers for writing
-var outputRegisters = new ushort[2];
-123.45f.FromFloat(outputRegisters, 0);
-await master.WriteMultipleRegistersAsync(1, 0, outputRegisters);
-
-var outputDoubleRegisters = new ushort[4];
-987.654321.FromDouble(outputDoubleRegisters, 0);
-await master.WriteMultipleRegistersAsync(1, 10, outputDoubleRegisters);
-
-// Using spans for high-performance operations
-var registerSpan = registers.AsSpan();
-var floatFromSpan = registerSpan.ToFloat(0);
-var doubleFromSpan = registerSpan.ToDouble(2);
-
-var outputSpan = outputRegisters.AsSpan();
-456.78f.FromFloat(outputSpan, 0);
-```
-
-### 2. Working with Different Word Orders
-
-```csharp
-// Handle different byte/word ordering conventions
-var registers = await master.ReadHoldingRegistersAsync(1, 0, 4);
-
-// Standard word order (high word first)
-var floatStandard = registers.ToFloat(0, swapWords: false);
-
-// Swapped word order (low word first) - common with some PLCs
-var floatSwapped = registers.ToFloat(0, swapWords: true);
-
-Console.WriteLine($"Standard: {floatStandard}, Swapped: {floatSwapped}");
-
-// Same applies to double values
-var doubleStandard = registers.ToDouble(0, swapWords: false);
-var doubleSwapped = registers.ToDouble(0, swapWords: true);
-```
-
-## Reactive Programming Features
-
-### 1. Observing Data Changes
-
-```csharp
-using ModbusRx.Reactive;
-using ReactiveUI.Primitives.Reactive;
-
-// Create a server and observe data changes
-using var server = new ModbusServer();
-server.SimulationMode = true;
-server.Start();
-
-// Observe all data changes
-var allDataSubscription = server.ObserveDataChanges(interval: 100)
-    .Subscribe(data =>
-    {
-        Console.WriteLine($"Holding Registers: [{string.Join(", ", data.holdingRegisters.Take(5))}]");
-        Console.WriteLine($"Coils: {string.Join("", data.coils.Take(8).Select(c => c ? "1" : "0"))}");
-    });
-
-// Observe specific holding registers with change detection
-var holdingRegSubscription = server.ObserveHoldingRegisters(
-        startAddress: 0, 
-        count: 10, 
-        interval: 100)
-    .Subscribe(registers =>
-    {
-        Console.WriteLine($"Holding registers changed: [{string.Join(", ", registers)}]");
-    });
-
-// Observe coil changes
-var coilSubscription = server.ObserveCoils(
-        startAddress: 0, 
-        count: 8, 
-        interval: 100)
-    .Subscribe(coils =>
-    {
-        Console.WriteLine($"Coils changed: {string.Join("", coils.Select(c => c ? "1" : "0"))}");
-    });
-
-// Observe input registers
-var inputRegSubscription = server.ObserveInputRegisters(
-        startAddress: 0,
-        count: 5,
-        interval: 200)
-    .Subscribe(registers =>
-    {
-        Console.WriteLine($"Input registers: [{string.Join(", ", registers)}]");
-    });
-
-// Let it run
-await Task.Delay(10000);
-
-// Cleanup
-allDataSubscription.Dispose();
-holdingRegSubscription.Dispose();
-coilSubscription.Dispose();
-inputRegSubscription.Dispose();
-```
-
-### 2. Creating Reactive Servers
-
-```csharp
-using ModbusRx.Reactive;
-
-// Create a reactive server that automatically manages lifecycle
-var serverSubscription = ModbusServerExtensions.CreateReactiveServer(server =>
-{
-    // Configure the server
-    server.StartTcpServer(502, 1);
-    server.StartUdpServer(503, 1);
-    server.SimulationMode = true;
-    
-    // Load initial data
-    server.LoadSimulationData(
-        holdingRegisters: Enumerable.Range(1, 100).Select(i => (ushort)(i * 10)).ToArray(),
-        coils: Enumerable.Range(0, 50).Select(i => i % 2 == 0).ToArray()
-    );
-})
-.Subscribe(
-    server => Console.WriteLine("Server started and configured"),
-    error => Console.WriteLine($"Server error: {error.Message}"),
-    () => Console.WriteLine("Server stopped")
-);
-
-// Server runs automatically while subscribed
-await Task.Delay(30000);
-
-// Dispose to stop server
-serverSubscription.Dispose();
-```
-
-### 3. Advanced Reactive Master Operations
-
-```csharp
-using ModbusRx.Reactive;
-using ReactiveUI.Primitives.Reactive;
-
-// Create reactive master streams
-var tcpMasterStream = Create.TcpIpMaster("192.168.1.100", 502);
-var udpMasterStream = Create.UdpIpMaster("192.168.1.101", 502);
-
-// Combine multiple data sources
-var combinedData = tcpMasterStream.ReadHoldingRegisters(0, 10, 1000)
-    .CombineLatest(
-        udpMasterStream.ReadHoldingRegisters(0, 10, 1000),
-        (tcpData, udpData) => new { TCP = tcpData.data, UDP = udpData.data })
-    .Subscribe(combined =>
-{
-    if (combined.TCP != null && combined.UDP != null)
-    {
-        Console.WriteLine($"TCP: [{string.Join(", ", combined.TCP)}]");
-        Console.WriteLine($"UDP: [{string.Join(", ", combined.UDP)}]");
-    }
-});
-
-// Read different data types reactively
-var multiDataSubscription = tcpMasterStream
-    .ReadHoldingRegisters(0, 5, 1000)
-    .CombineLatest(
-        tcpMasterStream.ReadCoils(0, 8, 1000),
-        tcpMasterStream.ReadInputs(0, 8, 1000),
-        (registers, coils, inputs) => new { Registers = registers.data, Coils = coils.data, Inputs = inputs.data })
-    .Where(data => data.Registers != null && data.Coils != null && data.Inputs != null)
-    .Subscribe(data =>
-    {
-        Console.WriteLine($"Registers: [{string.Join(", ", data.Registers!)}]");
-        Console.WriteLine($"Coils: {string.Join("", data.Coils!.Select(c => c ? "1" : "0"))}");
-        Console.WriteLine($"Inputs: {string.Join("", data.Inputs!.Select(i => i ? "1" : "0"))}");
-    });
-
-await Task.Delay(30000);
-
-// Cleanup
-combinedData.Dispose();
-multiDataSubscription.Dispose();
-```
-
-### 4. Async Observables with ReactiveUI.Primitives
-
-Modern .NET targets include adapters for `IObservableAsync<T>` through ReactiveUI.Primitives.Async and ReactiveUI.Primitives.Async.Reactive. These APIs let ModbusRx streams participate in async-observable pipelines while keeping the classic `IObservable<T>` APIs available.
-
-```csharp
-using ModbusRx.Reactive;
-using ReactiveUI.Primitives.Async;
-
-var masterStream = Create.TcpIpMaster("192.168.1.100", 502);
-
-// Bridge an existing ModbusRx connection stream into IObservableAsync<T>.
-var asyncMasterStream = masterStream.ToModbusObservableAsync();
-
-var holdingRegisters = asyncMasterStream.ReadHoldingRegisters(
-    startAddress: 0,
-    numberOfPoints: 10,
-    interval: 500);
-
-await using var subscription = await holdingRegisters.SubscribeAsync(result =>
-{
-    if (result.error != null)
-    {
-        Console.WriteLine($"Read failed: {result.error.Message}");
-        return;
-    }
-
-    Console.WriteLine($"Holding registers: [{string.Join(", ", result.data ?? Array.Empty<ushort>())}]");
-});
-```
-
-The direct bridge helpers `ReadHoldingRegistersAsyncObservable`, `ReadInputRegistersAsyncObservable`, `ReadCoilsAsyncObservable`, and `ReadInputsAsyncObservable` are available when the source stream is still a classic `IObservable<T>`.
-
-Serial streams keep the slave address explicit:
-
-```csharp
-using ModbusRx.Device;
-using ModbusRx.Reactive;
-using ReactiveUI.Primitives.Async;
-using System.IO.Ports;
-
-var serial = Create.SerialRtuMaster("COM3", 19200, 8, Parity.None, StopBits.One);
-
-var inputs = serial.ReadInputsAsyncObservable(
-    slaveAddress: 2,
-    startAddress: 0,
-    numberOfPoints: 16,
-    interval: 250);
-
-var first = await inputs.FirstAsync(CancellationToken.None);
-```
-
-Server-side streams and write pipelines are also available as async observables:
-
-```csharp
-using ModbusRx.Device;
-using ModbusRx.Reactive;
-using ReactiveUI.Primitives.Async;
-
-using var server = new ModbusServer();
-server.SimulationMode = true;
-server.Start();
-
-var changes = server.ObserveDataChangesAsync(interval: 100);
-await using var subscription = await changes.SubscribeAsync(snapshot =>
-{
-    Console.WriteLine($"Holding[0]: {snapshot.holdingRegisters[0]}");
-});
-```
-
-### 5. Generated Reactive Register Maps
-
-`ModbusRx.Generators` can generate strongly typed register-map members from attributes. The generator updates the annotated property when matching Modbus data is received and exposes both the latest property value and an observable stream for that property.
-
-When referencing the generator from source, add it as an analyzer:
-
-```xml
-<ItemGroup>
-  <ProjectReference Include="..\ModbusRx.Generators\ModbusRx.Generators.csproj"
-                    OutputItemType="Analyzer"
-                    ReferenceOutputAssembly="false"
-                    PrivateAssets="all" />
-</ItemGroup>
-```
-
-Then define a partial map class and partial properties:
-
-```csharp
-using ModbusRx.Device;
-using ModbusRx.Generators;
-using ModbusRx.Reactive;
-
-[ModbusReactiveDevice(ConnectionMember = nameof(MasterStream), DefaultInterval = 500)]
+[ModbusReactiveDevice(ConnectionMember = "MasterStream")]
 public partial class BoilerMap
 {
-    public IObservable<(bool connected, Exception? error, ModbusIpMaster? master)> MasterStream { get; }
+    public IObservable<(bool connected, Exception? error, ModbusIpMaster? master)>
+        MasterStream { get; set; } = default!;
 
     [HoldingRegister(0)]
     public partial ushort? Temperature { get; private set; }
 
-    [Coil(4)]
-    public partial bool? PumpRunning { get; private set; }
-
-    public BoilerMap(IObservable<(bool connected, Exception? error, ModbusIpMaster? master)> masterStream)
-    {
-        MasterStream = masterStream;
-    }
+    [Coil(3)]
+    public partial bool? Enabled { get; private set; }
 }
+```
 
-var map = new BoilerMap(Create.TcpIpMaster("192.168.1.100", 502));
+Supported point attributes are `HoldingRegister`, `InputRegister`, `Coil`, and `DiscreteInput`. Configure `Count`, `DataType`, `SwapWords`, or `TagName` on an attribute when defaults are insufficient. Set `TagClientMember` on `ModbusReactiveDevice` to generate logical-tag `Read<Property>Async` and `Write<Property>Async` helpers.
 
-using var bindings = map.BindGeneratedModbusStreams();
-using var temperatureSub = map.TemperatureObservable.Subscribe(value =>
+## Exhaustive feature guide and worked workflows
+
+All Modbus addresses passed to this library are **zero-based protocol offsets**. Device manuals often display `40001`, `30001`, `00001`, or `10001`; remove the display-area prefix and one-based offset before calling the master (for example holding register `40001` is `0`). Read limits are 2,000 bits or 125 registers; write limits are 1,968 coils, 123 registers, and 121 registers for function 23. The master validates ranges before writing to the transport; PLC/device exceptions are still remote outcomes and must be handled.
+
+### Master construction and all function-code families
+
+`ModbusIpMaster.CreateIp` has `TcpClientRx`, `UdpClientRx`, `SerialPortRx`, and `IStreamResource` overloads. `ModbusSerialMaster.CreateRtu` and `CreateAscii` have matching serial/stream overloads. The base `IModbusMaster`/`ModbusMaster` methods always take a `byte slaveAddress`: reads are coils (FC01), inputs (FC02), holding registers (FC03), and input registers (FC04); writes are single coil/register (FC05/06), multiple coils/registers (FC15/16), and read/write registers (FC23). `ModbusIpMaster` adds no-unit-ID overloads for the IP default. `ModbusSerialMaster.ReturnQueryData` exposes the diagnostic return-query-data operation (FC08).
+
+```csharp
+using IoT.DriverCore.ModbusRx.Device;
+using IoT.DriverCore.Serial;
+
+using var tcp = new TcpClientRx("192.168.0.20", 502);
+using var master = ModbusIpMaster.CreateIp(tcp);
+try
 {
-    Console.WriteLine($"Temperature register changed to {value}");
+    bool[] coils = await master.ReadCoilsAsync(1, 0, 8);
+    bool[] inputs = await master.ReadInputsAsync(1, 0, 8);
+    ushort[] holding = await master.ReadHoldingRegistersAsync(1, 0, 4);
+    ushort[] input = await master.ReadInputRegistersAsync(1, 0, 4);
+
+    await master.WriteSingleCoilAsync(1, 3, true);
+    await master.WriteSingleRegisterAsync(1, 0, 42);
+    await master.WriteMultipleCoilsAsync(1, 8, [true, false, true]);
+    await master.WriteMultipleRegistersAsync(1, 10, [100, 200]);
+    ushort[] response = await master.ReadWriteMultipleRegistersAsync(1, 0, 2, 20, [300, 400]);
+    Console.WriteLine($"Read/write response: {string.Join(',', response)}");
+}
+catch (SlaveException ex) { Console.Error.WriteLine($"Device exception: {ex.Message}"); }
+catch (InvalidModbusRequestException ex) { Console.Error.WriteLine($"Invalid request: {ex.Message}"); }
+catch (ModbusCommunicationException ex) { Console.Error.WriteLine($"Transport failure: {ex.Message}"); }
+```
+
+`ModbusSerialMaster.ReturnQueryData` is the synchronous FC08 **Return Query Data** diagnostic: it returns `true` only when the device echoes the supplied 16-bit value. Run it only against a serial-line device that supports the diagnostic; it is a link check, not a proof that the process program is healthy.
+
+```csharp
+using IoT.DriverCore.ModbusRx.Device;
+using IoT.DriverCore.Serial;
+
+using var port = new SerialPortRx("COM3");
+using var serial = ModbusSerialMaster.CreateRtu(port);
+bool echoed = serial.ReturnQueryData(slaveAddress: 1, data: 0x5AA5);
+if (!echoed) throw new InvalidOperationException("The serial slave did not echo FC08 data.");
+```
+
+Use `ExecuteCustomMessage<TResponse>(IModbusMessage, Func<TResponse>)` only when a standard public message class does not express the operation, or for a proprietary PDU whose complete request/response contract you own. The direct FC08 diagnostics message is not part of the public surface, so the source-verified example below uses the standard FC06 request/response class through the same transport path. The standard `WriteSingleRegisterAsync` method is usually clearer for this operation.
+
+```csharp
+using IoT.DriverCore.ModbusRx.Message;
+
+var request = new WriteSingleRegisterRequestResponse(
+    slaveAddress: 1, startAddress: 10, registerValue: 0x1234);
+WriteSingleRegisterRequestResponse response = master.ExecuteCustomMessage(
+    request,
+    static () => new WriteSingleRegisterRequestResponse());
+
+if (response.Data[0] != 0x1234)
+    throw new InvalidOperationException("FC06 response did not echo the expected value.");
+```
+
+`IModbusMessage` exposes function code, slave address, transaction ID, frame/PDU, and `Initialize`; `IModbusRequest` also validates a response. In this release, the public message base constructors are not consumable outside the package, so vendor PDU types cannot safely be derived by an application. Use the public standard message classes/factories or a dedicated protocol adapter package for a proprietary PDU. Validate function code, unit ID, byte count, and payload before using any reply; do not use a raw/custom path to bypass point-count or process-safety validation.
+
+### TCP, UDP, RTU, ASCII and transport lifetime
+
+TCP and UDP use port 502 by convention but the library accepts any transport endpoint. RTU and ASCII require the exact COM port framing used by the device. Own the `SerialPortRx`/client and master together with `using`; a master disposes its transport resources. Configure timeout, retries, and retry delay on `master.Transport` where applicable before issuing commands. Retries can repeat a write after a lost response, so write only idempotent values or add application-level command/audit protection.
+
+```csharp
+using System.IO.Ports;
+using IoT.DriverCore.ModbusRx.Device;
+using IoT.DriverCore.Serial;
+
+using var port = new SerialPortRx("COM3")
+{
+    BaudRate = 19_200,
+    DataBits = 8,
+    Parity = Parity.Even,
+    StopBits = StopBits.One,
+    Handshake = Handshake.None,
+};
+using var rtu = ModbusSerialMaster.CreateRtu(port);
+rtu.Transport.ReadTimeout = 2_000;
+rtu.Transport.Retries = 1;
+ushort[] setpoint = await rtu.ReadHoldingRegistersAsync(1, 10, 1);
+await rtu.WriteSingleRegisterAsync(1, 10, checked((ushort)(setpoint[0] + 1)));
+```
+
+For Modbus UDP, create a **connected** `UdpClientRx` before passing it to `ModbusIpMaster.CreateIp`. Modbus ASCII can likewise run over a `SerialPortRx`, TCP client, UDP client, or an `IStreamResource`; the framing mode is selected by `CreateAscii`, not by the endpoint type.
+
+```csharp
+using IoT.DriverCore.ModbusRx.Device;
+using IoT.DriverCore.Serial;
+
+using var udp = new UdpClientRx("192.168.0.20", 502);
+using var udpMaster = ModbusIpMaster.CreateIp(udp);
+ushort[] udpValue = await udpMaster.ReadHoldingRegistersAsync(1, 0, 1);
+
+using var asciiPort = new SerialPortRx("COM4");
+using var ascii = ModbusSerialMaster.CreateAscii(asciiPort);
+await ascii.WriteSingleRegisterAsync(1, 10, udpValue[0]);
+```
+
+### Data conversion, byte order, Enron helpers and collections
+
+`RegisterCollection` and `DiscreteCollection` are PDU data containers with byte-count semantics; `DataStore` holds four server areas and exposes `SyncRoot`/`Lock` for safe direct mutation. `ModbusDataExtensions` packs/unpacks booleans and converts 16/32/64-bit values. `CreateExtensions` offers `ToFloat`, `FromFloat`, `ToDouble`, and `FromDouble` helpers for reactive use. `ModbusUtility` owns CRC/LRC and general network conversion helpers. `ModbusByteOrder`, `SwapWords`, and a tag's data type determine word ordering: verify this against the device manual with known test values. `EnronModbusExtensions` provides 32-bit Enron read/write helpers; it does not make a conventional Modbus register map Enron-compatible.
+
+```csharp
+using IoT.DriverCore.ModbusRx.Data;
+using IoT.DriverCore.ModbusRx.Reactive;
+
+ushort[] registers = await master.ReadHoldingRegistersAsync(1, 100, 2);
+float? engineeringValue = CreateExtensions.ToFloat(registers, 0, swapWords: true);
+if (engineeringValue is float value)
+{
+    var encoded = new ushort[2];
+    CreateExtensions.FromFloat(value + 1.5f, encoded, 0, swapWords: true);
+    await master.WriteMultipleRegistersAsync(1, 100, encoded);
+}
+```
+
+Use `EnronModbusExtensions` only with an Enron-compatible 32-bit map. Each `uint` consumes two conventional Modbus registers; reads allow 1-62 values and writes allow 1-61 values. The helper's word ordering is defined by its implementation, so validate it with a known device value before deploying.
+
+```csharp
+using IoT.DriverCore.ModbusRx.Extensions.Enron;
+
+uint[] totals = await master.ReadHoldingRegisters32Async(
+    slaveAddress: 1, startAddress: 200, numberOfPoints: 2);
+await master.WriteSingleRegister32Async(1, registerAddress: 204, totals[0] + 1);
+await master.WriteMultipleRegisters32Async(1, startAddress: 206, data: totals);
+```
+
+### Slaves, server aggregation, request observability and simulation
+
+For one endpoint, create a slave with `ModbusTcpSlave.CreateTcp`, `ModbusUdpSlave.CreateUdp`, or `ModbusSerialSlave.CreateRtu/CreateAscii`, assign a `DataStore`, then await `ListenAsync` for the lifetime of that endpoint. `ModbusSlave` exposes request/data-store events; use `CreateExtensions.ObserveRequest`, `ObserveWriteComplete`, `ObserveDataStoreReadFrom`, and `ObserveDataStoreWrittenTo` or their async-observable bridges to observe them.
+
+`ModbusServer` aggregates TCP/UDP server endpoints and remote clients. `StartTcpServer`, `StartUdpServer`, `AddTcpClient`, and `AddUdpClient` return `IDisposable` registrations; retain them. `Start` begins the configured server, `Stop` halts it, `IsRunning` is an observable state stream, `LoadSimulationData` populates all areas, `GetCurrentData` snapshots areas, and `SimulationMode` controls simulator behaviour. `EnhancedModbusServerExtensions` offers event-driven, optimized, and buffered `ModbusServerDataSnapshot` streams. These monitoring streams are snapshots, not durable audit storage.
+
+```csharp
+using System.Net;
+using System.Net.Sockets;
+using IoT.DriverCore.ModbusRx.Data;
+using IoT.DriverCore.ModbusRx.Device;
+using IoT.DriverCore.ModbusRx.Reactive;
+
+using var slave = ModbusTcpSlave.CreateTcp(1, new TcpListener(IPAddress.Loopback, 1502));
+slave.DataStore = DataStoreFactory.CreateDefaultDataStore();
+using var writes = CreateExtensions.ObserveDataStoreWrittenTo(slave)
+    .Subscribe(e => Console.WriteLine($"Area={e.ModbusDataType}, start={e.StartAddress}"));
+var listening = slave.ListenAsync(); // await/host this task until disposal
+
+using var server = new ModbusServer { SimulationMode = true };
+using var tcpEndpoint = server.StartTcpServer(1503, 1);
+server.LoadSimulationData([1, 2], [3, 4], [true, false], [false, true]);
+server.Start();
+using var snapshots = server.ObserveDataChangesEventDriven().Subscribe(snapshot =>
+    Console.WriteLine(snapshot.HoldingRegisters.Length));
+// server.Stop() is called explicitly before the using scope ends when required.
+```
+
+For server-owned memory, use the optimized `DataStoreExtensions` methods only while holding the store's lock, then inspect operation metrics as logical operation counters. They are useful for deterministic simulation setup and bridge code; normal Modbus clients should use master requests instead. `ObserveDataChangesBuffered` batches snapshots by count (the current implementation does not apply its time argument), so choose a bounded buffer and dispose the subscription.
+
+```csharp
+using IoT.DriverCore.ModbusRx.Data;
+using IoT.DriverCore.ModbusRx.Reactive;
+
+var source = DataStoreFactory.CreateDefaultDataStore();
+var replica = DataStoreFactory.CreateDefaultDataStore();
+lock (source.SyncRoot)
+{
+    source.WriteHoldingRegistersOptimized(1, [10, 20, 30]);
+    source.BulkCopyHoldingRegisters(replica, 1, 3);
+    bool identical = source.CompareHoldingRegisters(replica, 1, 3);
+    Console.WriteLine($"In sync: {identical}");
+}
+DataStoreOperationMetrics metrics = source.GetOperationMetrics();
+Console.WriteLine($"Reads={metrics.ReadOperations}, writes={metrics.WriteOperations}");
+using var batches = server.ObserveDataChangesBuffered(bufferSize: 8, bufferTimeMilliseconds: 250)
+    .Subscribe(batch => Console.WriteLine($"Received {batch.Length} snapshots."));
+```
+
+`ModbusSimulator` owns a local `DataStore`, creates an in-memory master, starts a TCP loopback endpoint, queues `ModbusSimulatorFaultKind` failures, clears faults, and exposes `RequestCount`. `ModbusTcpLoopbackEndpoint` is the lower-level public deterministic endpoint. `SimulationDataProvider` can generate sine/square/sawtooth/random/boolean patterns, load `TestPattern`, expose `IsRunning`, and start/stop changes to a `DataStore`. Use them for integration tests, fault paths, dashboards, and model validation before a live device.
+
+```csharp
+using var simulator = new ModbusSimulator(unitId: 1);
+using var simulatedMaster = simulator.CreateMaster();
+simulator.DataStore.HoldingRegisters[0] = 77;
+ushort[] initial = await simulatedMaster.ReadHoldingRegistersAsync(1, 0, 1);
+simulator.QueueFault(ModbusSimulatorFaultKind.Timeout);
+try { await simulatedMaster.ReadHoldingRegistersAsync(1, 0, 1); }
+catch (ModbusCommunicationException) { Console.WriteLine("Expected simulated timeout."); }
+simulator.ClearFaults();
+```
+
+### Reactive connection factories, polling, async observables, and server writers
+
+`Create.TcpIpMaster`, `UdpIpMaster`, `SerialIpMaster`, `SerialRtuMaster`, and `SerialAsciiMaster` emit connection tuples `(Connected, Error, Master)`. `Create.PingInterval` controls reachability probes and `CheckConnectionInterval` controls connection checks globally for those factories. `CreateExtensions` and `Create` read overloads project a master stream to `(Data, Error)` observations for coils, inputs, holding registers, and input registers; overloads select default/unit ID and polling interval. An error tuple is a value, so inspect `Error` and never dereference `Data` until it is null-checked. `ModbusAsyncObservableExtensions` supplies equivalent `IObservableAsync<T>` read, request, datastore, and point-observation bridges. Dispose the final subscription; it owns the connection/master lifecycle in the factory pipeline.
+
+```csharp
+using IoT.DriverCore.ModbusRx.Reactive;
+
+Create.PingInterval = TimeSpan.FromSeconds(2);
+using var poll = Create.TcpIpMaster("192.168.0.20", 502)
+    .ReadHoldingRegisters(slaveAddress: 1, startAddress: 0, numberOfPoints: 2, interval: 500)
+    .Subscribe(result =>
+    {
+        if (result.Error is not null)
+            Console.Error.WriteLine(result.Error.Message);
+        else if (result.Data is { Length: > 0 } registers)
+            Console.WriteLine($"value={registers[0]}");
+    });
+```
+
+`ToModbusObservable` converts a factory stream to `IObservableAsync<T>`; use the async extension read overloads when the rest of the pipeline uses ReactiveUI.Primitives.Async. The returned value still carries `Error`, so check it before using `Data`.
+
+```csharp
+using IoT.DriverCore.ModbusRx;
+using IoT.DriverCore.ModbusRx.Reactive;
+
+var asyncConnections = Create.TcpIpMaster("192.168.0.20", 502).ToModbusObservable();
+var asyncRegisters = asyncConnections.ReadHoldingRegisters(
+    startAddress: 0, numberOfPoints: 2, interval: 500);
+using var subscription = asyncRegisters.ToObservable().Subscribe(result =>
+{
+    if (result.Error is null && result.Data is { Length: > 0 } values)
+        Console.WriteLine(values[0]);
 });
 ```
 
-The generated members include:
-
-- The annotated property, updated from the matching Modbus stream.
-- `{PropertyName}Observable` as `IObservable<T>` for consumers that want a stream.
-- `{PropertyName}Error` for the last read error observed by that property binding.
-- `BindGeneratedModbusStreams()` and `BindGeneratedModbusStreams(CompositeDisposable)` for lifecycle management.
-
-For serial maps, set the master kind and slave address on the device attribute:
+The async slave writer methods combine a slave stream and a value stream, then write to the slave `DataStore`. They return the original slave stream: retain a subscription to keep the combined pipeline alive. The same four writer names (`WriteHoldingRegisters`, `WriteInputRegisters`, `WriteCoilDiscretes`, `WriteInputDiscretes`) are available for TCP, UDP, and serial slaves.
 
 ```csharp
-[ModbusReactiveDevice(
-    ConnectionMember = nameof(MasterStream),
-    MasterKind = ModbusReactiveMasterKind.Serial,
-    SlaveAddress = 2,
-    DefaultInterval = 250)]
-public partial class DriveMap
-{
-    public IObservable<(bool connected, Exception? error, IModbusSerialMaster? master)> MasterStream { get; }
+using IoT.DriverCore.ModbusRx;
+using IoT.DriverCore.ModbusRx.Device;
+using IoT.DriverCore.ModbusRx.Reactive;
+using ReactiveUI.Primitives.Async;
 
-    [InputRegister(10)]
-    public partial short? Speed { get; private set; }
-}
+// Build both streams from public reactive factories/operators.
+IObservableAsync<ModbusTcpSlave> slaveStream = Create.TcpIpSlave("127.0.0.1", 1502, 1)
+    .ToAsyncObservable();
+IObservableAsync<ushort[]> setpoints = SignalAsync.Return(new ushort[] { 100, 200 });
+IObservableAsync<ModbusTcpSlave> updated = slaveStream.WriteHoldingRegisters(10, setpoints);
+using var writer = updated.ToObservable().Subscribe(static _ => { });
 ```
 
-Supported point attributes are `HoldingRegister`, `InputRegister`, `Coil`, and `DiscreteInput`. Supported generated property types include nullable and non-nullable `bool`, `ushort`, `short`, `uint`, `int`, `float`, and `double`; wider numeric types read the number of registers required by the target type.
-
-## Simulation and Testing Features
-
-### 1. Using the Simulation Data Provider
+`ModbusBufferManager` is a per-owner pool facade. Rent the buffer, use only the required slice, and always return it in `finally`; `clearArray: true` is appropriate for sensitive payloads. `GetMetrics` is a deterministic counter snapshot, not a throughput measurement.
 
 ```csharp
-using ModbusRx.Data;
+using IoT.DriverCore.ModbusRx.IO;
 
-// Create simulation data provider
-using var simulator = new SimulationDataProvider();
-var dataStore = DataStoreFactory.CreateDefaultDataStore();
-
-// Generate different wave patterns
-var sineWave = SimulationDataProvider.GenerateSineWave(
-    length: 100, 
-    amplitude: 32767, 
-    frequency: 1.0, 
-    phase: 0.0);
-
-var squareWave = SimulationDataProvider.GenerateSquareWave(
-    length: 100, 
-    highValue: 65535, 
-    lowValue: 0, 
-    dutyCycle: 0.3);
-
-var sawtoothWave = SimulationDataProvider.GenerateSawtoothWave(
-    length: 100, 
-    maxValue: 1000, 
-    minValue: 0);
-
-var randomData = simulator.GenerateRandomData(
-    length: 100, 
-    minValue: 0, 
-    maxValue: 1000);
-
-Console.WriteLine($"Sine Wave (first 5): [{string.Join(", ", sineWave.Take(5))}]");
-Console.WriteLine($"Square Wave (first 5): [{string.Join(", ", squareWave.Take(5))}]");
-Console.WriteLine($"Sawtooth Wave (first 5): [{string.Join(", ", sawtoothWave.Take(5))}]");
-Console.WriteLine($"Random Data (first 5): [{string.Join(", ", randomData.Take(5))}]");
-
-// Generate boolean patterns for discrete values
-var boolPatterns = new[]
-{
-    simulator.GenerateBooleanPattern(8, BooleanPattern.AllTrue),
-    simulator.GenerateBooleanPattern(8, BooleanPattern.AllFalse),
-    simulator.GenerateBooleanPattern(8, BooleanPattern.Alternating),
-    simulator.GenerateBooleanPattern(8, BooleanPattern.Random)
-};
-
-Console.WriteLine("Boolean Patterns:");
-Console.WriteLine($"All True: {string.Join("", boolPatterns[0].Select(b => b ? "1" : "0"))}");
-Console.WriteLine($"All False: {string.Join("", boolPatterns[1].Select(b => b ? "1" : "0"))}");
-Console.WriteLine($"Alternating: {string.Join("", boolPatterns[2].Select(b => b ? "1" : "0"))}");
-Console.WriteLine($"Random: {string.Join("", boolPatterns[3].Select(b => b ? "1" : "0"))}");
-```
-
-### 2. Loading Predefined Test Patterns
-
-```csharp
-using ModbusRx.Data;
-
-using var simulator = new SimulationDataProvider();
-var dataStore = DataStoreFactory.CreateDefaultDataStore();
-
-// Load different test patterns
-var patterns = new[]
-{
-    TestPattern.CountingUp,
-    TestPattern.CountingDown,
-    TestPattern.SineWave,
-    TestPattern.SquareWave,
-    TestPattern.Random,
-    TestPattern.AllZeros,
-    TestPattern.AllOnes
-};
-
-foreach (var pattern in patterns)
-{
-    simulator.LoadTestPattern(dataStore, pattern);
-    
-    // Get first 5 values to see the pattern
-    var holdingRegs = dataStore.HoldingRegisters.Skip(1).Take(5).ToArray();
-    var coils = dataStore.CoilDiscretes.Skip(1).Take(8).ToArray();
-    
-    Console.WriteLine($"{pattern}:");
-    Console.WriteLine($"  Holding Registers: [{string.Join(", ", holdingRegs)}]");
-    Console.WriteLine($"  Coils: {string.Join("", coils.Select(c => c ? "1" : "0"))}");
-}
-```
-
-### 3. Dynamic Simulation
-
-```csharp
-using ModbusRx.Data;
-
-// Create a server with dynamic simulation
-using var server = new ModbusServer();
-using var simulator = new SimulationDataProvider();
-
-// Start server
-server.StartTcpServer(502, 1);
-server.Start();
-
-// Start different simulation types
-Console.WriteLine("Starting Random simulation...");
-simulator.Start(server.DataStore!, TimeSpan.FromMilliseconds(500), SimulationType.Random);
-
-await Task.Delay(5000);
-
-Console.WriteLine("Switching to Counting Up...");
-simulator.Stop();
-simulator.Start(server.DataStore!, TimeSpan.FromMilliseconds(200), SimulationType.CountingUp);
-
-await Task.Delay(5000);
-
-Console.WriteLine("Switching to Sine Wave...");
-simulator.Stop();
-simulator.Start(server.DataStore!, TimeSpan.FromMilliseconds(100), SimulationType.SineWave);
-
-await Task.Delay(5000);
-
-simulator.Stop();
-Console.WriteLine("Simulation stopped.");
-```
-
-## Error Handling and Resilience
-
-### 1. Comprehensive Error Handling
-
-```csharp
-using ModbusRx.Device;
-using ModbusRx.Reactive;
-using ReactiveUI.Primitives.Reactive;
-using Observable = ReactiveUI.Primitives.Signals.Signal;
-
-// Create master with comprehensive error handling
-async Task<bool> SafeModbusOperation()
-{
-    try
-    {
-        var client = new TcpClientRx("192.168.1.100", 502);
-        using var master = ModbusIpMaster.CreateIp(client);
-        
-        var registers = await master.ReadHoldingRegistersAsync(1, 0, 10);
-        Console.WriteLine($"Success: [{string.Join(", ", registers)}]");
-        return true;
-    }
-    catch (SlaveException ex)
-    {
-        Console.WriteLine($"Slave Exception - Function Code: {ex.FunctionCode}, Slave Code: {ex.SlaveExceptionCode}");
-        return false;
-    }
-    catch (InvalidModbusRequestException ex)
-    {
-        Console.WriteLine($"Invalid Request: {ex.Message}");
-        return false;
-    }
-    catch (ModbusCommunicationException ex)
-    {
-        Console.WriteLine($"Communication Error: {ex.Message}");
-        return false;
-    }
-    catch (TimeoutException ex)
-    {
-        Console.WriteLine($"Timeout: {ex.Message}");
-        return false;
-    }
-    catch (Exception ex)
-    {
-        Console.WriteLine($"Unexpected Error: {ex.Message}");
-        return false;
-    }
-}
-
-// Use reactive error handling with retry
-var masterStream = Create.TcpIpMaster("192.168.1.100", 502);
-
-var resilientRead = masterStream
-    .ReadHoldingRegisters(0, 10, 1000)
-    .Retry(3) // Retry up to 3 times
-    .Catch<(ushort[]? data, Exception? error), Exception>(ex =>
-    {
-        Console.WriteLine($"All retries failed: {ex.Message}");
-        return Observable.Return<(ushort[]? data, Exception? error)>((null, ex));
-    })
-    .Subscribe(result =>
-    {
-        if (result.error == null && result.data != null)
-        {
-            Console.WriteLine($"Data: [{string.Join(", ", result.data)}]");
-        }
-        else
-        {
-            Console.WriteLine($"Final error: {result.error?.Message}");
-        }
-    });
-
-await Task.Delay(30000);
-resilientRead.Dispose();
-```
-
-### 2. Connection Health Monitoring
-
-```csharp
-using ModbusRx.Reactive;
-using ReactiveUI.Primitives.Reactive;
-using Observable = ReactiveUI.Primitives.Signals.Signal;
-
-// Monitor connection health
-var masterStream = Create.TcpIpMaster("192.168.1.100", 502);
-
-var healthMonitor = masterStream
-    .Select(status => new
-    {
-        Timestamp = DateTime.Now,
-        Connected = status.connected,
-        Error = status.error?.Message,
-        Master = status.master != null ? "Available" : "Not Available"
-    })
-    .DistinctUntilChanged(h => h.Connected)
-    .Subscribe(health =>
-    {
-        Console.WriteLine($"[{health.Timestamp:HH:mm:ss}] Connection: {(health.Connected ? "UP" : "DOWN")} - {health.Error ?? "OK"}");
-    });
-
-// Read data only when connected
-var dataReader = masterStream
-    .Where(status => status.connected && status.master != null)
-    .SelectMany(status => status.master!.ReadHoldingRegistersAsync(1, 0, 5)
-        .ToObservable()
-        .Catch<ushort[], Exception>(ex => 
-        {
-            Console.WriteLine($"Read error: {ex.Message}");
-            return Observable.Empty<ushort[]>();
-        }))
-    .Subscribe(data => Console.WriteLine($"Data: [{string.Join(", ", data)}]"));
-
-await Task.Delay(60000);
-
-healthMonitor.Dispose();
-dataReader.Dispose();
-```
-
-## Protocol Details and Function Codes
-
-### Supported Function Codes
-
-| Function Code | Description | Master Support | Slave Support | Example Usage |
-|---------------|-------------|----------------|---------------|---------------|
-| 01 | Read Coils | ✅ | ✅ | `master.ReadCoilsAsync(1, 0, 16)` |
-| 02 | Read Discrete Inputs | ✅ | ✅ | `master.ReadInputsAsync(1, 0, 16)` |
-| 03 | Read Holding Registers | ✅ | ✅ | `master.ReadHoldingRegistersAsync(1, 0, 10)` |
-| 04 | Read Input Registers | ✅ | ✅ | `master.ReadInputRegistersAsync(1, 0, 10)` |
-| 05 | Write Single Coil | ✅ | ✅ | `master.WriteSingleCoilAsync(1, 0, true)` |
-| 06 | Write Single Register | ✅ | ✅ | `master.WriteSingleRegisterAsync(1, 0, 12345)` |
-| 15 | Write Multiple Coils | ✅ | ✅ | `master.WriteMultipleCoilsAsync(1, 0, coilArray)` |
-| 16 | Write Multiple Registers | ✅ | ✅ | `master.WriteMultipleRegistersAsync(1, 0, regArray)` |
-| 23 | Read/Write Multiple Registers | ✅ | ✅ | `master.ReadWriteMultipleRegistersAsync(...)` |
-
-### Address Ranges and Limitations
-
-| Data Type | Address Range | Max Read/Write | Storage Type |
-|-----------|---------------|----------------|--------------|
-| Coils | 1-65536 | 2000 per request | `bool[]` |
-| Discrete Inputs | 1-65536 | 2000 per request | `bool[]` |
-| Holding Registers | 1-65536 | 125 per request | `ushort[]` |
-| Input Registers | 1-65536 | 125 per request | `ushort[]` |
-
-### Example: Working with All Function Codes
-
-```csharp
-using ModbusRx.Device;
-using CP.IO.Ports;
-
-var client = new TcpClientRx("192.168.1.100", 502);
-using var master = ModbusIpMaster.CreateIp(client);
-
-// Function Code 01: Read Coils
-var coils = await master.ReadCoilsAsync(
-    slaveAddress: 1, 
-    startAddress: 0, 
-    numberOfPoints: 16);
-Console.WriteLine($"FC01 - Coils: {string.Join("", coils.Select(c => c ? "1" : "0"))}");
-
-// Function Code 02: Read Discrete Inputs  
-var discreteInputs = await master.ReadInputsAsync(
-    slaveAddress: 1,
-    startAddress: 0,
-    numberOfPoints: 16);
-Console.WriteLine($"FC02 - Discrete Inputs: {string.Join("", discreteInputs.Select(d => d ? "1" : "0"))}");
-
-// Function Code 03: Read Holding Registers
-var holdingRegisters = await master.ReadHoldingRegistersAsync(
-    slaveAddress: 1,
-    startAddress: 0,
-    numberOfPoints: 10);
-Console.WriteLine($"FC03 - Holding Registers: [{string.Join(", ", holdingRegisters)}]");
-
-// Function Code 04: Read Input Registers
-var inputRegisters = await master.ReadInputRegistersAsync(
-    slaveAddress: 1,
-    startAddress: 0,
-    numberOfPoints: 10);
-Console.WriteLine($"FC04 - Input Registers: [{string.Join(", ", inputRegisters)}]");
-
-// Function Code 05: Write Single Coil
-await master.WriteSingleCoilAsync(
-    slaveAddress: 1,
-    coilAddress: 0,
-    value: true);
-Console.WriteLine("FC05 - Single coil written");
-
-// Function Code 06: Write Single Register
-await master.WriteSingleRegisterAsync(
-    slaveAddress: 1,
-    registerAddress: 0,
-    value: 12345);
-Console.WriteLine("FC06 - Single register written");
-
-// Function Code 15: Write Multiple Coils
-var coilsToWrite = new bool[] { true, false, true, true, false, false, true, false };
-await master.WriteMultipleCoilsAsync(
-    slaveAddress: 1,
-    startAddress: 10,
-    data: coilsToWrite);
-Console.WriteLine("FC15 - Multiple coils written");
-
-// Function Code 16: Write Multiple Registers
-var registersToWrite = new ushort[] { 1000, 2000, 3000, 4000, 5000 };
-await master.WriteMultipleRegistersAsync(
-    slaveAddress: 1,
-    startAddress: 20,
-    data: registersToWrite);
-Console.WriteLine("FC16 - Multiple registers written");
-
-// Function Code 23: Read/Write Multiple Registers
-var readWriteResult = await master.ReadWriteMultipleRegistersAsync(
-    slaveAddress: 1,
-    startReadAddress: 0,
-    numberOfPointsToRead: 5,
-    startWriteAddress: 30,
-    writeData: new ushort[] { 100, 200, 300 });
-Console.WriteLine($"FC23 - Read/Write result: [{string.Join(", ", readWriteResult)}]");
-```
-
-## Performance Optimization and Best Practices
-
-### 1. High-Performance Data Operations
-
-```csharp
-using ModbusRx.Data;
-using System.Buffers;
-
-// Use memory pools for large data operations
-var pool = ArrayPool<ushort>.Shared;
-var buffer = pool.Rent(1000);
-
+using var buffers = new ModbusBufferManager();
+byte[] frame = buffers.RentByteBuffer(260);
 try
 {
-    // Bulk read operation
-    var registers = await master.ReadHoldingRegistersAsync(1, 0, 1000);
-    
-    // Process data efficiently
-    for (int i = 0; i < registers.Length; i++)
-    {
-        buffer[i] = (ushort)(registers[i] * 2); // Example processing
-    }
-    
-    // Write back efficiently
-    await master.WriteMultipleRegistersAsync(1, 1000, buffer.AsSpan(0, registers.Length).ToArray());
+    frame[0] = 1; // populate only the actual PDU length before sending it
 }
 finally
 {
-    pool.Return(buffer);
+    buffers.ReturnByteBuffer(frame, clearArray: true);
 }
-
-// Use spans for zero-copy operations where possible
-ReadOnlySpan<ushort> dataSpan = registers;
-var floatValue = dataSpan.ToFloat(0);
-var doubleValue = dataSpan.ToDouble(2);
+ModbusBufferMetrics bufferMetrics = buffers.GetMetrics();
+Console.WriteLine($"rents={bufferMetrics.RentOperations}, returns={bufferMetrics.ReturnOperations}");
 ```
 
-### 2. Optimized Server Configuration
+### Logical-tag catalog, batch planning, CSV and SQLite persistence
+
+`ModbusTagConfiguration` declares logical name, unit, `ModbusDataArea`, zero-based address, count, CLR value type, optional byte order/access/scan options. `ModbusLogicalTagClient.CreateTag` constructs and registers one; `RegisterTag`/`RemoveTag` manage an existing map. `ReadAsync`/`WriteAsync` return `TagOperationResult<LogicalTagValue>`; `ReadManyAsync`/`WriteManyAsync` batch requests by compatible ranges. `Observe`, `ObserveMany`, `ObserveAsync`, and `ObserveManyAsync` repeat reads at the configured scan interval. `ModbusTagCatalog` provides in-memory list/create/upsert/import/export; `ModbusTagSqliteStore` and the client's store methods initialize/load/get/list/upsert/update/delete persisted tags. Persistence contains configuration, not a distributed lock or a write transaction.
 
 ```csharp
-using ModbusRx.Device;
-using ModbusRx.Data;
+using IoT.DriverCore.Core;
+using IoT.DriverCore.ModbusRx.LogicalTags;
 
-// Create high-performance server
-using var server = new ModbusServer();
-
-// Use custom data store for better performance
-var customDataStore = new DataStore();
-
-// Pre-allocate data for known size
-const int dataSize = 10000;
-for (int i = 1; i <= dataSize; i++)
+using var tags = new ModbusLogicalTagClient(master, catalog: null,
+    defaultScanInterval: TimeSpan.FromMilliseconds(500));
+tags.CreateTag(new ModbusTagConfiguration("TankTemperature", 1,
+    ModbusDataArea.HoldingRegister, 100, 2, typeof(float))
 {
-    customDataStore.HoldingRegisters.Add((ushort)(i % 65536));
-    customDataStore.InputRegisters.Add((ushort)(i % 65536));
-    customDataStore.CoilDiscretes.Add((i % 2) == 0);
-    customDataStore.InputDiscretes.Add((i % 3) == 0);
-}
-
-server.DataStore = customDataStore;
-
-// Start optimized TCP server
-server.StartTcpServer(502, 1);
-server.Start();
-
-Console.WriteLine($"High-performance server started with {dataSize} data points");
-```
-
-### 3. Connection Pooling and Management
-
-```csharp
-using ModbusRx.Device;
-using CP.IO.Ports;
-using System.Collections.Concurrent;
-
-// Simple connection pool
-public class ModbusConnectionPool : IDisposable
-{
-    private readonly ConcurrentQueue<ModbusIpMaster> _availableConnections = new();
-    private readonly string _ipAddress;
-    private readonly int _port;
-    private readonly int _maxConnections;
-    private int _currentConnections;
-
-    public ModbusConnectionPool(string ipAddress, int port = 502, int maxConnections = 10)
-    {
-        _ipAddress = ipAddress;
-        _port = port;
-        _maxConnections = maxConnections;
-    }
-
-    public async Task<ModbusIpMaster?> GetConnectionAsync()
-    {
-        if (_availableConnections.TryDequeue(out var connection))
-        {
-            return connection;
-        }
-
-        if (_currentConnections < _maxConnections)
-        {
-            try
-            {
-                var client = new TcpClientRx(_ipAddress, _port);
-                var master = ModbusIpMaster.CreateIp(client);
-                Interlocked.Increment(ref _currentConnections);
-                return master;
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
-        return null;
-    }
-
-    public void ReturnConnection(ModbusIpMaster connection)
-    {
-        if (connection != null)
-        {
-            _availableConnections.Enqueue(connection);
-        }
-    }
-
-    public void Dispose()
-    {
-        while (_availableConnections.TryDequeue(out var connection))
-        {
-            connection.Dispose();
-        }
-    }
-}
-
-// Usage example
-using var connectionPool = new ModbusConnectionPool("192.168.1.100", 502, 5);
-
-// Perform multiple concurrent operations
-var tasks = Enumerable.Range(0, 20).Select(async i =>
-{
-    var master = await connectionPool.GetConnectionAsync();
-    if (master != null)
-    {
-        try
-        {
-            var data = await master.ReadHoldingRegistersAsync(1, (ushort)(i * 10), 10);
-            Console.WriteLine($"Task {i}: [{string.Join(", ", data)}]");
-        }
-        finally
-        {
-            connectionPool.ReturnConnection(master);
-        }
-    }
+    ByteOrder = ModbusByteOrder.BigEndian,
+    SwapWords = true,
 });
 
-await Task.WhenAll(tasks);
+using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+var reading = await tags.ReadAsync("TankTemperature", deadline.Token);
+if (!reading.Succeeded) Console.Error.WriteLine(reading.Error);
+else Console.WriteLine(reading.Value?.Value);
+
+await tags.InitializeStoreAsync("Data Source=tags.db", deadline.Token);
+await tags.ExportCsvAsync(Console.Out, deadline.Token);
 ```
 
-## Testing and Debugging
+### Combined workflow 1: safely derived command from a reactive read
 
-The repository test projects use [TUnit](https://tunit.dev/docs/getting-started/installation/) and run through Microsoft Testing Platform. The shared test configuration intentionally does not reference `Microsoft.NET.Test.Sdk` or Coverlet; TUnit test projects build as executable test apps and can be run with `dotnet test` from the solution or project level.
-
-```bash
-# Run the full test suite
-dotnet test
-
-# Run focused projects during development
-dotnet test src/ModbusRx.UnitTests/ModbusRx.UnitTests.csproj --framework net9.0
-dotnet test src/ModbusRx.Generators.Tests/ModbusRx.Generators.Tests.csproj --framework net9.0
-```
-
-### 1. Unit Testing with ModbusRx
+Keep data acquisition and command policy separate: the subscription publishes measurements, while an awaited function makes an explicit, bounded write after range validation.
 
 ```csharp
-using CP.IO.Ports;
-using ModbusRx.Device;
-using ModbusRx.Data;
-using TUnit.Assertions;
-using TUnit.Core;
+using var commandDeadline = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+using var display = Create.TcpIpMaster("192.168.0.20", 502)
+    .ReadHoldingRegisters(1, 0, 1, 1_000)
+    .Subscribe(r => { if (r.Error is null) Console.WriteLine(r.Data?[0]); });
 
-public class ModbusTests
-{
-    [Test]
-    public async Task TestModbusReadWrite()
-    {
-        // Arrange - Create test server
-        using var server = new ModbusServer();
-        var port = GetAvailablePort();
-        server.StartTcpServer(port, 1);
-        server.Start();
-        
-        // Load test data
-        server.LoadSimulationData(new ushort[] { 1, 2, 3, 4, 5 });
-        
-        // Create client
-        var client = new TcpClientRx("127.0.0.1", port);
-        using var master = ModbusIpMaster.CreateIp(client);
-        
-        // Act
-        var result = await master.ReadHoldingRegistersAsync(1, 0, 5);
-        
-        // Assert
-        await Assert.That(result.Length).IsEqualTo(5);
-        await Assert.That(result[0]).IsEqualTo((ushort)1);
-        await Assert.That(result[4]).IsEqualTo((ushort)5);
-    }
-
-    [Test]
-    public async Task TestModbusWriteOperations()
-    {
-        using var server = new ModbusServer();
-        var port = GetAvailablePort();
-        server.StartTcpServer(port, 1);
-        server.Start();
-        
-        var client = new TcpClientRx("127.0.0.1", port);
-        using var master = ModbusIpMaster.CreateIp(client);
-        
-        // Test write single register
-        await master.WriteSingleRegisterAsync(1, 0, 12345);
-        var readResult = await master.ReadHoldingRegistersAsync(1, 0, 1);
-        await Assert.That(readResult[0]).IsEqualTo((ushort)12345);
-        
-        // Test write multiple registers
-        var writeData = new ushort[] { 1000, 2000, 3000 };
-        await master.WriteMultipleRegistersAsync(1, 10, writeData);
-        var multiReadResult = await master.ReadHoldingRegistersAsync(1, 10, 3);
-        await Assert.That(multiReadResult.SequenceEqual(writeData)).IsTrue();
-    }
-
-    private static int GetAvailablePort()
-    {
-        using var socket = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
-        socket.Start();
-        var port = ((System.Net.IPEndPoint)socket.LocalEndpoint).Port;
-        socket.Stop();
-        return port;
-    }
-}
+ushort[] level = await master.ReadHoldingRegistersAsync(1, 0, 1);
+if (level[0] < 900)
+    await master.WriteSingleCoilAsync(1, 10, true); // validate policy before command
 ```
 
-### 2. Integration Testing with Simulation
+### Combined workflow 2: simulated logical map, fault injection, and server observation
 
 ```csharp
-using ModbusRx.Data;
-using TUnit.Assertions;
-using TUnit.Core;
-
-public class SimulationTests
-{
-    [Test]
-    public async Task TestSimulationPatterns()
-    {
-        using var provider = new SimulationDataProvider();
-        var dataStore = DataStoreFactory.CreateDefaultDataStore();
-        
-        // Test counting pattern
-        provider.LoadTestPattern(dataStore, TestPattern.CountingUp);
-        await Assert.That(dataStore.HoldingRegisters[1]).IsEqualTo((ushort)0);
-        await Assert.That(dataStore.HoldingRegisters[2]).IsEqualTo((ushort)1);
-        await Assert.That(dataStore.HoldingRegisters[3]).IsEqualTo((ushort)2);
-        
-        // Test sine wave pattern
-        provider.LoadTestPattern(dataStore, TestPattern.SineWave);
-        await Assert.That(dataStore.HoldingRegisters.Skip(1).Take(100).Any(x => x > 0)).IsTrue();
-    }
-
-    [Test]
-    public async Task TestWaveGeneration()
-    {
-        var sineWave = SimulationDataProvider.GenerateSineWave(360, 32767);
-        await Assert.That(sineWave.Length).IsEqualTo(360);
-        await Assert.That(sineWave[0]).IsEqualTo((ushort)32767); // sin(0) + amplitude
-        await Assert.That(sineWave[90] > 32767).IsTrue(); // sin(90°) = 1
-        
-        var squareWave = SimulationDataProvider.GenerateSquareWave(100, 1000, 0, 0.5);
-        var highCount = squareWave.Count(x => x == 1000);
-        await Assert.That(Math.Abs(highCount - 50) <= 1).IsTrue(); // 50% duty cycle
-    }
-}
+using var simulator = new ModbusSimulator(1);
+using var simulatedMaster = simulator.CreateMaster();
+using var map = new ModbusLogicalTagClient(simulatedMaster, null, TimeSpan.FromMilliseconds(100));
+map.CreateTag(new ModbusTagConfiguration("Pressure", 1, ModbusDataArea.HoldingRegister, 0, 1, typeof(ushort)));
+simulator.DataStore.HoldingRegisters[0] = 250;
+using var observed = map.Observe("Pressure").Subscribe(value => Console.WriteLine(value.Value));
+simulator.QueueFault(ModbusSimulatorFaultKind.Timeout);
+var failed = await map.ReadAsync("Pressure", CancellationToken.None);
+Console.WriteLine($"Succeeded={failed.Succeeded}");
 ```
 
-### 3. Debugging and Diagnostics
+### Complete generator workflow
+
+`ModbusRx.Generators` is a Roslyn analyzer package. Annotate a partial device class with `ModbusReactiveDevice` and properties with `HoldingRegister`, `InputRegister`, `Coil`, or `DiscreteInput`. The `ConnectionMember` must expose the supported `Create` master stream; optional `MasterKind`/`TagClientMember` select a master factory or logical-tag helpers. Point attributes use zero-based address and may set count, data type, word swap, and generated tag name. The analyzer validates unsupported point/property combinations and a non-partial class through diagnostics. Generated code supplies a binder, current values, observables, async observables where available, and logical read/write helpers when a tag client is configured. Dispose the `BindGeneratedModbusStreams()` result.
 
 ```csharp
-using ModbusRx.Device;
-using ModbusRx.Reactive;
-using System.Diagnostics;
+using IoT.DriverCore.ModbusRx;
+using IoT.DriverCore.ModbusRx.Generators;
+using IoT.DriverCore.ModbusRx.LogicalTags;
+using IoT.DriverCore.ModbusRx.Reactive;
 
-// Enable debug logging
-Debug.WriteLine("Starting Modbus operations");
-
-var client = new TcpClientRx("192.168.1.100", 502);
-using var master = ModbusIpMaster.CreateIp(client);
-
-// Monitor transport layer
-if (master.Transport != null)
+[ModbusReactiveDevice(ConnectionMember = "MasterStream", TagClientMember = "Tags")]
+public partial class PumpMap
 {
-    Debug.WriteLine($"Transport Type: {master.Transport.GetType().Name}");
-    Debug.WriteLine($"Read Timeout: {master.Transport.ReadTimeout}ms");
-    Debug.WriteLine($"Retries: {master.Transport.Retries}");
+    public IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> MasterStream { get; set; } = default!;
+    public ModbusLogicalTagClient? Tags { get; set; }
+
+    [HoldingRegister(0, Count = 2, DataType = ModbusReactiveDataType.Float32, SwapWords = true)]
+    public partial float? Pressure { get; private set; }
+
+    [Coil(5, TagName = "PumpEnabled")]
+    public partial bool? Enabled { get; private set; }
 }
 
-try
-{
-    var stopwatch = Stopwatch.StartNew();
-    var registers = await master.ReadHoldingRegistersAsync(1, 0, 10);
-    stopwatch.Stop();
-    
-    Debug.WriteLine($"Read completed in {stopwatch.ElapsedMilliseconds}ms");
-    Debug.WriteLine($"Data: [{string.Join(", ", registers)}]");
-}
-catch (Exception ex)
-{
-    Debug.WriteLine($"Error: {ex.GetType().Name} - {ex.Message}");
-    Debug.WriteLine($"Stack trace: {ex.StackTrace}");
-}
-
-// Use reactive operators for debugging
-var masterStream = Create.TcpIpMaster("192.168.1.100", 502);
-
-masterStream
-    .ReadHoldingRegisters(0, 10, 1000)
-    .Do(result => Debug.WriteLine($"Before processing: {result.data?.Length} registers"))
-    .Where(result => result.error == null)
-    .Do(result => Debug.WriteLine($"After filtering: Success"))
-    .Subscribe(
-        result => Debug.WriteLine($"Final result: [{string.Join(", ", result.data!)}]"),
-        error => Debug.WriteLine($"Observable error: {error.Message}"));
+var map = new PumpMap { MasterStream = Create.TcpIpMaster("192.168.0.20", 502) };
+using var mapBinding = map.BindGeneratedModbusStreams();
+using var pressure = map.PressureObservable.Subscribe(Console.WriteLine);
 ```
 
-## Configuration and Deployment
+## Complete public API reference
 
-### 1. Configuration for Different Environments
+This list is the public type inventory from `src/ModbusRx`; `ModbusRx.Reactive` mirrors it under `IoT.DriverCore.ModbusRx.Reactive`.
+
+| Area | Public types / API |
+| --- | --- |
+| Master/device | `ICancelable`, `IModbusMaster`, `IModbusSerialMaster`, `ModbusDevice`, `ModbusMaster`, `ModbusIpMaster`, `ModbusSerialMaster`; standard reads/writes, combined read/write, custom messages, and disposal. |
+| Slave/server | `ModbusSlave`, `ModbusTcpSlave`, `ModbusUdpSlave`, `ModbusSerialSlave`, `ModbusServer`, `ModbusTcpLoopbackEndpoint`, `ModbusSlaveRequestEventArgs`, `ModbusServerExtensions`, `EnhancedModbusServerExtensions`, `ModbusTcpSlaveExtensions`, `ModbusUdpSlaveExtensions`, and `ModbusSerialSlaveExtensions`. |
+| Data/simulation | `DataStore`, `DataStoreFactory`, `DataStoreExtensions`, `DataStoreEventArgs`, `DataStoreOperationMetrics`, `ModbusDataCollection<T>`, `RegisterCollection`, `DiscreteCollection`, `IDataCollection`, `ModbusDataType`, `BooleanPattern`, `SimulationDataProvider`, `SimulationType`, `TestPattern`, `ModbusSimulator`, `ModbusSimulatorRequestEventArgs`, and `ModbusSimulatorFaultKind`. |
+| Logical tags | `ModbusLogicalTagClient`, `ModbusTagCatalog`, `ModbusTagSqliteStore`, `ModbusTagConfiguration`, `ModbusLogicalTag`, `ModbusDataArea`, and `ModbusByteOrder`; create/register/import/export/store/CRUD/read/write/batch/observe methods. |
+| Transport | `IStreamResource`, `SerialPortAdapter`, `ModbusTransport`, `ModbusSerialTransport`, `EmptyTransport`, `ModbusBufferManager`, and `ModbusBufferMetrics`. |
+| Reactive | `Create`, `CreateExtensions`, `ModbusAsyncObservableExtensions`, `ModbusObservationMetrics`, `ModbusServerDataSnapshot`, and `ModbusCommunicationException`. |
+| Generation | `ModbusRx.Generators` injects `ModbusReactiveDeviceAttribute`, `ModbusReactiveMasterKind`, `ModbusReactiveDataType`, `HoldingRegisterAttribute`, `InputRegisterAttribute`, `CoilAttribute`, and `DiscreteInputAttribute`; `ModbusReactiveStreamGenerator` then generates binding and typed stream members for valid partial device maps. |
+| Messages/utilities | `IModbusMessage`, `IModbusRequest`, `AbstractModbusMessage`, `AbstractModbusMessageWithData<T>`, `ModbusMessageFactory`, `OptimizedModbusMessageFactory`, `ReadCoilsInputsRequest`, `ReadCoilsInputsResponse`, `ReadHoldingInputRegistersRequest`, `ReadHoldingInputRegistersResponse`, `ReadWriteMultipleRegistersRequest`, `WriteMultipleCoilsRequest`, `WriteMultipleCoilsResponse`, `WriteMultipleRegistersRequest`, `WriteMultipleRegistersResponse`, `WriteSingleCoilRequestResponse`, `WriteSingleRegisterRequestResponse`, the remaining supported function-code messages, `SlaveException`, `SlaveExceptionResponse`, `InvalidModbusRequestException`, `ModbusUtility`, `EnronModbusExtensions`, `DiscriminatedUnion<TA,TB>`, and `DiscriminatedUnionOption`. |
+
+### Member-family contract
+
+| Area | Members, returns, errors, and ownership |
+| --- | --- |
+| Master | Factory overloads create a disposable master; all standard FC01/02/03/04 reads return arrays, FC05/06/15/16 writes return `Task`, and FC23 returns registers. Use unit-ID overloads unless the IP default is intended; handle request, slave, and transport failures. |
+| Transport | `IStreamResource`, adapters, transports, buffers and metrics own framing. Set timeout/retry before operations; disposal cancels/reclaims transport resources but cannot undo a remote write. |
+| Slave/server | `Create*`, `ListenAsync`, data store/request events, `ModbusServer` start/stop/client/endpoint/snapshot methods. Host listening tasks and dispose endpoint registrations, server and subscriptions. |
+| Data/conversion | Stores/collections/factory/extensions, simulation patterns, utility/Enron conversions. Lock direct store mutation and validate endian/count/type using known device values. |
+| Reactive | `Create` connection factory/read/slave methods, `CreateExtensions`, async-observable bridges and server extensions. Tuples carry errors as values; dispose final subscriptions. |
+| Logical tags | Configuration/catalog/store/client/codec/planner values. Catalog/persistence validates mapping but does not make physical multi-write operations atomic. Pass cancellation to every database/PLC call. |
+| Generator/messages | `ModbusReactiveStreamGenerator` is the public analyzer type; its attributes are injected into the consuming compilation rather than exported as runtime package API. PDU contracts/factories/exception types require partial models, compiler-diagnostic review, and a documented PDU contract for every custom message. |
+
+### Supporting public member index
+
+The following complete member groups round out the API reference. Their low-level nature is intentional: use master/slave/logical APIs first, and confine direct helper use to tested protocol adapters.
+
+| Feature | Members and use |
+| --- | --- |
+| Data-store maintenance | `ReadHoldingRegistersOptimized`, `ReadInputRegistersOptimized`, `ReadCoilsOptimized`, `ReadInputsOptimized`, `WriteHoldingRegistersOptimized`, `WriteCoilsOptimized`, `BulkCopyHoldingRegisters`, `BulkCopyCoils`, `ClearHoldingRegisters`, `ClearCoils`, `CompareHoldingRegisters`, and `GetMetrics`. Lock the store around direct mutation and use protocol operations for normal client/server traffic. |
+| Encoding and utility | `PackBooleans`, `UnpackBooleans`, `FastEquals`, `ToRegisters`, `ToInt32`, `ToUInt32`, `GetUInt32`, `ToInt64`, `GetSingle`, `GetDouble`, `ReadSingle`, `ReadDouble`, `WriteSingle`, `WriteDouble`, `CalculateCrc`, `CalculateLrc`, `GetAsciiBytes`, `HexToBytes`, `NetworkBytesToHostUInt16`, `ValidateMessageCrc`, and `ValidateResponse`. These helpers have explicit byte-order/length requirements; validate using known device values. |
+| 32-bit and Enron helpers | `ReadHoldingRegisters32Async`, `ReadInputRegisters32Async`, `WriteSingleRegister32Async`, `WriteMultipleRegisters32Async`, and Enron read/write helpers. They issue multiple-register operations and do not remove normal unit/address/word-order requirements. |
+| Factories/messages | `CreateModbusRequest`, `CreateReadCoilsRequest`, `CreateReadHoldingRegistersRequest`, `CreateWriteSingleCoilRequest`, `CreateWriteSingleRegisterRequest`, `CreateWriteMultipleCoilsRequest`, `CreateWriteMultipleRegistersRequest`, `ParseReadCoilsResponse`, and `ParseReadHoldingRegistersResponse`. They create/parse PDUs; validate the response function/unit/CRC before accepting custom traffic. |
+| Collection/catalog/store | `CreateA`, `CreateB`, `FromLogicalTag`, `ToLogicalTag`, `TryAdd`, `TryGet`, `TryRemove`, `ImportCsvAsync`, `InitializeAsync`, `GetAsync`, `ListAsync`, `UpsertAsync`, `UpdateAsync`, `DeleteAsync`, `LoadCatalogAsync`, `LoadFromSqliteAsync`, `LoadTagsAsync`, `GetStoredTagAsync`, `ListStoredTagsAsync`, `UpsertStoredTagAsync`, `UpdateStoredTagAsync`, and `DeleteStoredTagAsync`. These methods separate in-memory mapping from SQLite persistence; pass cancellation and dispose stores/catalogs. |
+| Simulation and loopback | `GenerateSineWave`, `GenerateSquareWave`, `GenerateSawtoothWave`, `GenerateRandomData`, `GenerateBooleanPattern`, `LoadTestPattern`, `StartTcpLoopback`, and simulator request events. Generated data modifies a supplied store on a schedule; stop/dispose the provider and loopback endpoint. |
+| Observable server/read helpers | `ObserveCoils`, `ObserveCoilsObservable`, `ObserveHoldingRegisters`, `ObserveHoldingRegistersObservable`, `ObserveInputRegisters`, `ObserveInputRegistersObservable`, `ObserveDiscreteInputs`, `ObserveDiscreteInputsObservable`, `ObserveDataChangesOptimized`, `ObserveDataChangesBuffered`, `ObserveHoldingRegistersOptimized`, `ObserveCoilsOptimized`, `ObserveRequestObservable`, `ObserveWriteCompleteObservable`, `ObserveDataStoreReadFromObservable`, and `ObserveDataStoreWrittenToObservable`. All expose subscriptions that must be disposed and all errors/data tuples must be checked. |
+| Slave writers and resource pools | `WriteHoldingRegisters`, `WriteInputRegisters`, `WriteCoilDiscretes`, `WriteInputDiscretes`, `RentByteBuffer`, `ReturnByteBuffer`, `RentUshortBuffer`, `ReturnUshortBuffer`, `RentBoolBuffer`, `ReturnBoolBuffer`, `DisposeSharedResources`, and `DiscardInBuffer`. These are infrastructure helpers; pair each rent with the matching return and do not dispose shared pools while active transport work remains. |
+| Value/object members | `Equals`, `GetHashCode`, `ToString`, plus `ToLogicalTag`/`FromLogicalTag` conversions preserve configuration values for comparison/persistence rather than physical device state. |
+
+## Operational guidance
+
+Use one master per serialized physical link unless the device explicitly supports concurrent transactions. Batch contiguous ranges and keep within the protocol limits. Keep writes idempotent where retries are possible, record unit ID/address/value/result, and dispose masters, slaves, servers, and subscriptions. Synchronize direct `DataStore` collection access with `SyncRoot` or `Lock`; normal protocol operations already protect the store.
+
+## Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| `SlaveException` | Function, unit ID, zero-based address, point count, and device permissions. |
+| Timeout/communication failure | IP/port/firewall, gateway route, transport timeout/retry values, and whether the endpoint is TCP or UDP. |
+| Serial failure | Port ownership and exact serial settings; use RTU or ASCII to match the device. |
+| Wrong decoded number | Register count, signedness, and `ModbusByteOrder`; use `ModbusDataExtensions`/`ModbusUtility` rather than ad-hoc casts. |
+| Polling churn | Increase interval, consolidate ranges/tags, and dispose obsolete connection/read subscriptions. |
+
+## AI skill
+
+For source-grounded ModbusRx work, use [skills/modbus-rx/SKILL.md](../../skills/modbus-rx/SKILL.md). It directs an agent to validate namespaces, transport semantics, limits, and current public APIs against source.
+
+<!-- BEGIN GENERATED PUBLIC API -->
+
+## Exhaustive public API reference
+
+This catalogue is generated from the packaged runtime assemblies and their XML documentation. It includes exported public types and their declared public members; inherited members and non-public implementation details are intentionally omitted.
+
+### `ModbusRx`
+
+Exported public types: 81; declared public members: 618.
+
+#### `T:IoT.DriverCore.ModbusRx.Create`
 
 ```csharp
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using ModbusRx.Device;
-
-// Configuration class
-public class ModbusConfiguration
-{
-    public string IpAddress { get; set; } = "127.0.0.1";
-    public int Port { get; set; } = 502;
-    public int ReadTimeout { get; set; } = 5000;
-    public int Retries { get; set; } = 3;
-    public byte SlaveAddress { get; set; } = 1;
-}
-
-// Service registration
-public static class ServiceExtensions
-{
-    public static IServiceCollection AddModbusRx(
-        this IServiceCollection services, 
-        IConfiguration configuration)
-    {
-        services.Configure<ModbusConfiguration>(
-            configuration.GetSection("Modbus"));
-        
-        services.AddSingleton<IModbusMaster>(provider =>
-        {
-            var config = provider.GetRequiredService<IOptions<ModbusConfiguration>>().Value;
-            var client = new TcpClientRx(config.IpAddress, config.Port)
-            {
-                ReadTimeout = config.ReadTimeout,
-                WriteTimeout = config.ReadTimeout
-            };
-            
-            var master = ModbusIpMaster.CreateIp(client);
-            if (master.Transport != null)
-            {
-                master.Transport.ReadTimeout = config.ReadTimeout;
-                master.Transport.Retries = config.Retries;
-            }
-            
-            return master;
-        });
-        
-        return services;
-    }
-}
-
-// Usage in application
-var builder = WebApplication.CreateBuilder(args);
-builder.Services.AddModbusRx(builder.Configuration);
-
-var app = builder.Build();
-
-// Use injected Modbus master
-app.MapGet("/read-registers", async (IModbusMaster master) =>
-{
-    var registers = await master.ReadHoldingRegistersAsync(1, 0, 10);
-    return Results.Ok(registers);
-});
+public class IoT.DriverCore.ModbusRx.Create
 ```
+Provides ModbusRx functionality.
 
-### 2. appsettings.json Configuration
+##### Declared public members
 
-```json
-{
-  "Modbus": {
-    "IpAddress": "192.168.1.100",
-    "Port": 502,
-    "ReadTimeout": 5000,
-    "Retries": 3,
-    "SlaveAddress": 1
-  },
-  "ModbusServer": {
-    "TcpPort": 502,
-    "UdpPort": 503,
-    "UnitId": 1,
-    "SimulationMode": true,
-    "SimulationInterval": 500
-  }
-}
-```
+###### `M:IoT.DriverCore.ModbusRx.Create.ReadCoils(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.Byte,System.UInt16,System.UInt16,System.Double)`
 
-## Troubleshooting Guide
-
-### Common Issues and Solutions
-
-#### 1. Connection Timeouts
-
-**Problem**: Operations timeout frequently
-**Solutions**:
 ```csharp
-// Increase timeouts
-var client = new TcpClientRx("192.168.1.100", 502)
-{
-    ReadTimeout = 10000,  // 10 seconds
-    WriteTimeout = 10000
-};
-
-var master = ModbusIpMaster.CreateIp(client);
-master.Transport!.ReadTimeout = 10000;
-master.Transport.Retries = 5;
+public static System.IObservable<System.ValueTuple<bool[], System.Exception>> ReadCoils(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, byte slaveAddress, ushort startAddress, ushort numberOfPoints, double interval)
 ```
+Executes the `ReadCoils` operation.
 
-#### 2. Address Errors
+- Parameter `source`: The `source` value.
+- Parameter `slaveAddress`: The `slaveAddress` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<bool[], System.Exception>>` result.
 
-**Problem**: "Illegal Data Address" exceptions
-**Solutions**:
+###### `M:IoT.DriverCore.ModbusRx.Create.ReadCoils(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.UInt16,System.UInt16,System.Double)`
+
 ```csharp
-// Ensure addresses are within valid ranges (1-65536)
-// Check that start + count doesn't exceed device limits
-
-try
-{
-    var registers = await master.ReadHoldingRegistersAsync(1, 0, 10);
-}
-catch (SlaveException ex) when (ex.SlaveExceptionCode == 2)
-{
-    Console.WriteLine("Address out of range - reduce count or change start address");
-}
+public static System.IObservable<System.ValueTuple<bool[], System.Exception>> ReadCoils(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
 ```
+Executes the `ReadCoils` operation.
 
-#### 3. Serial Port Issues
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<bool[], System.Exception>>` result.
 
-**Problem**: Serial communication failures
-**Solutions**:
+###### `M:IoT.DriverCore.ModbusRx.Create.ReadCoils(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.ModbusIpMaster}},System.UInt16,System.UInt16,System.Double)`
+
 ```csharp
-// Check all serial parameters match device settings
-using var port = new SerialPortRx("COM1")
-{
-    BaudRate = 9600,      // Must match device
-    DataBits = 8,         // Check device manual
-    Parity = Parity.None, // Common configurations: None, Even, Odd
-    StopBits = StopBits.One,
-    Handshake = Handshake.None
-};
-
-// Verify port is available
-var availablePorts = SerialPortRx.GetPortNames();
-Console.WriteLine($"Available ports: {string.Join(", ", availablePorts)}");
+public static System.IObservable<System.ValueTuple<bool[], System.Exception>> ReadCoils(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
 ```
+Executes the `ReadCoils` operation.
 
-#### 4. Network Connectivity
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<bool[], System.Exception>>` result.
 
-**Problem**: Cannot connect to remote devices
-**Solutions**:
+###### `M:IoT.DriverCore.ModbusRx.Create.ReadHoldingRegisters(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.Byte,System.UInt16,System.UInt16,System.Double)`
+
 ```csharp
-// Test network connectivity first
-using var ping = new System.Net.NetworkInformation.Ping();
-var reply = await ping.SendPingAsync("192.168.1.100", 1000);
-
-if (reply.Status == System.Net.NetworkInformation.IPStatus.Success)
-{
-    Console.WriteLine($"Ping successful: {reply.RoundtripTime}ms");
-}
-else
-{
-    Console.WriteLine($"Ping failed: {reply.Status}");
-}
-
-// Test port connectivity
-using var tcpClient = new System.Net.Sockets.TcpClient();
-try
-{
-    await tcpClient.ConnectAsync("192.168.1.100", 502);
-    Console.WriteLine("Port 502 is accessible");
-}
-catch (Exception ex)
-{
-    Console.WriteLine($"Port 502 not accessible: {ex.Message}");
-}
+public static System.IObservable<System.ValueTuple<ushort[], System.Exception>> ReadHoldingRegisters(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, byte slaveAddress, ushort startAddress, ushort numberOfPoints, double interval)
 ```
+Executes the `ReadHoldingRegisters` operation.
 
-## Contributing
+- Parameter `source`: The `source` value.
+- Parameter `slaveAddress`: The `slaveAddress` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<ushort[], System.Exception>>` result.
 
-We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.md) for details.
+###### `M:IoT.DriverCore.ModbusRx.Create.ReadHoldingRegisters(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.UInt16,System.UInt16,System.Double)`
 
-### Development Setup
-
-1. **Clone the repository**
-   ```bash
-   git clone https://github.com/ChrisPulman/ModbusRx.git
-   cd ModbusRx
-   ```
-
-2. **Install .NET SDK**
-   - .NET 8.0 or later
-   - .NET Framework 4.8 (for full framework support)
-
-3. **Restore packages and build**
-   ```bash
-   dotnet restore
-   dotnet build
-   ```
-
-4. **Run tests**
-   ```bash
-   dotnet test
-   dotnet test src/ModbusRx.UnitTests/ModbusRx.UnitTests.csproj --framework net9.0
-   dotnet test src/ModbusRx.Generators.Tests/ModbusRx.Generators.Tests.csproj --framework net9.0
-   ```
-
-   Tests use TUnit on Microsoft Testing Platform. For coverage, use the TUnit/MTP coverage switch instead of Coverlet:
-
-   ```bash
-   dotnet run --project src/ModbusRx.UnitTests/ModbusRx.UnitTests.csproj --framework net9.0 --coverage
-   ```
-
-### Project Structure
-
+```csharp
+public static System.IObservable<System.ValueTuple<ushort[], System.Exception>> ReadHoldingRegisters(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
 ```
-ModbusRx/
-└── src/
-    ├── ModbusRx/                   # Core library
-    ├── ModbusRx.Reactive/          # Shared-source reactive shim under ModbusRx.Reactive.*
-    ├── ModbusRx.Generators/        # Reactive register-map source generator
-    ├── ModbusRx.Generators.Tests/  # Source generator tests
-    ├── ModbusRx.Testing/           # Shared TUnit compatibility helpers
-    ├── ModbusRx.UnitTests/         # Unit tests
-    ├── ModbusRx.IntegrationTests/  # Integration tests
-    └── ModbusRx.Server.UI/         # WPF visualization app
+Executes the `ReadHoldingRegisters` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<ushort[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.Create.ReadHoldingRegisters(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.ModbusIpMaster}},System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<ushort[], System.Exception>> ReadHoldingRegisters(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
 ```
+Executes the `ReadHoldingRegisters` operation.
 
-### Building for Different Targets
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<ushort[], System.Exception>>` result.
 
-```bash
-# Build for all target frameworks
-dotnet build
+###### `M:IoT.DriverCore.ModbusRx.Create.ReadInputRegisters(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.Byte,System.UInt16,System.UInt16,System.Double)`
 
-# Build for specific framework
-dotnet build -f net10.0
-dotnet build -f net9.0
-dotnet build -f net8.0
-dotnet build -f net48
+```csharp
+public static System.IObservable<System.ValueTuple<ushort[], System.Exception>> ReadInputRegisters(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, byte slaveAddress, ushort startAddress, ushort numberOfPoints, double interval)
 ```
+Executes the `ReadInputRegisters` operation.
 
-## License
+- Parameter `source`: The `source` value.
+- Parameter `slaveAddress`: The `slaveAddress` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<ushort[], System.Exception>>` result.
 
-ModbusRx is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+###### `M:IoT.DriverCore.ModbusRx.Create.ReadInputRegisters(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.UInt16,System.UInt16,System.Double)`
 
-## Support and Community
+```csharp
+public static System.IObservable<System.ValueTuple<ushort[], System.Exception>> ReadInputRegisters(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadInputRegisters` operation.
 
-- 📖 **[Documentation](https://github.com/ChrisPulman/ModbusRx/wiki)** - Comprehensive guides and API reference
-- 🐛 **[Issue Tracker](https://github.com/ChrisPulman/ModbusRx/issues)** - Report bugs or request features
-- 💬 **[Discussions](https://github.com/ChrisPulman/ModbusRx/discussions)** - Community support and questions
-- 📧 **Email**: For commercial support inquiries
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<ushort[], System.Exception>>` result.
 
-### Getting Help
+###### `M:IoT.DriverCore.ModbusRx.Create.ReadInputRegisters(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.ModbusIpMaster}},System.UInt16,System.UInt16,System.Double)`
 
-1. **Check the documentation** - Most common scenarios are covered
-2. **Search existing issues** - Someone may have had the same problem
-3. **Create a minimal reproduction** - When reporting issues
-4. **Provide environment details** - OS, .NET version, device information
+```csharp
+public static System.IObservable<System.ValueTuple<ushort[], System.Exception>> ReadInputRegisters(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadInputRegisters` operation.
 
-## Acknowledgments
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<ushort[], System.Exception>>` result.
 
-- **Based on NModbus4** - Solid foundation for Modbus protocol implementation
-- **Built with [ReactiveUI.Primitives](https://www.nuget.org/packages/ReactiveUI.Primitives)** - Lightweight reactive primitives and async observable support
-- **Inspired by industrial automation needs** - Real-world requirements drive development
+###### `M:IoT.DriverCore.ModbusRx.Create.ReadInputs(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.Byte,System.UInt16,System.UInt16,System.Double)`
 
----
+```csharp
+public static System.IObservable<System.ValueTuple<bool[], System.Exception>> ReadInputs(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, byte slaveAddress, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadInputs` operation.
 
-**ModbusRx** - Making industrial communication reactive and modern! 🏭⚡
+- Parameter `source`: The `source` value.
+- Parameter `slaveAddress`: The `slaveAddress` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<bool[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.Create.ReadInputs(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<bool[], System.Exception>> ReadInputs(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadInputs` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<bool[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.Create.ReadInputs(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.ModbusIpMaster}},System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<bool[], System.Exception>> ReadInputs(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadInputs` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<bool[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.Create.SerialAsciiMaster(System.String,System.Int32,System.Int32,System.IO.Ports.Parity,System.IO.Ports.StopBits,System.IO.Ports.Handshake)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> SerialAsciiMaster(string port, int baudRate, int dataBits, System.IO.Ports.Parity parity, System.IO.Ports.StopBits stopBits, System.IO.Ports.Handshake handshake)
+```
+Create a reactive Modbus Serial ASCII master that automatically manages connection state.
+
+- Parameter `port`: The COM port (e.g., "COM1").
+- Parameter `baudRate`: The baud rate.
+- Parameter `dataBits`: The data bits.
+- Parameter `parity`: The parity.
+- Parameter `stopBits`: The stop bits.
+- Parameter `handshake`: The handshake.
+- Returns: An observable stream of connection status and the ASCII master.
+
+###### `M:IoT.DriverCore.ModbusRx.Create.SerialAsciiSlave(System.String,System.Byte,System.Int32,System.Int32,System.IO.Ports.Parity,System.IO.Ports.StopBits,System.IO.Ports.Handshake)`
+
+```csharp
+public static System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave> SerialAsciiSlave(string port, byte unitId, int baudRate, int dataBits, System.IO.Ports.Parity parity, System.IO.Ports.StopBits stopBits, System.IO.Ports.Handshake handshake)
+```
+Creates an Serial Ascii Slave.
+
+- Parameter `port`: The port.
+- Parameter `unitId`: The unit identifier.
+- Parameter `baudRate`: The baud rate.
+- Parameter `dataBits`: The data bits.
+- Parameter `parity`: The parity.
+- Parameter `stopBits`: The stop bits.
+- Parameter `handshake`: The handshake.
+- Returns: An observable of serial ASCII slave instances.
+
+###### `M:IoT.DriverCore.ModbusRx.Create.SerialIpMaster(System.String,System.Int32)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> SerialIpMaster(string port, int baudRate)
+```
+Create a SerialIpMaster with the specified ip address.
+
+- Parameter `port`: The COM Port.
+- Parameter `baudRate`: The baud rate.
+- Returns: The master and connection status.
+
+###### `M:IoT.DriverCore.ModbusRx.Create.SerialRtuMaster(System.String,System.Int32,System.Int32,System.IO.Ports.Parity,System.IO.Ports.StopBits,System.IO.Ports.Handshake)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> SerialRtuMaster(string port, int baudRate, int dataBits, System.IO.Ports.Parity parity, System.IO.Ports.StopBits stopBits, System.IO.Ports.Handshake handshake)
+```
+Create a reactive Modbus Serial RTU master that automatically manages connection state.
+
+- Parameter `port`: The COM port (e.g., "COM1").
+- Parameter `baudRate`: The baud rate.
+- Parameter `dataBits`: The data bits.
+- Parameter `parity`: The parity.
+- Parameter `stopBits`: The stop bits.
+- Parameter `handshake`: The handshake.
+- Returns: An observable stream of connection status and the RTU master.
+
+###### `M:IoT.DriverCore.ModbusRx.Create.SerialRtuSlave(System.String,System.Byte,System.Int32,System.Int32,System.IO.Ports.Parity,System.IO.Ports.StopBits,System.IO.Ports.Handshake)`
+
+```csharp
+public static System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave> SerialRtuSlave(string port, byte unitId, int baudRate, int dataBits, System.IO.Ports.Parity parity, System.IO.Ports.StopBits stopBits, System.IO.Ports.Handshake handshake)
+```
+Creates an Serial Rtu Slave.
+
+- Parameter `port`: The port.
+- Parameter `unitId`: The unit identifier.
+- Parameter `baudRate`: The baud rate.
+- Parameter `dataBits`: The data bits.
+- Parameter `parity`: The parity.
+- Parameter `stopBits`: The stop bits.
+- Parameter `handshake`: The handshake.
+- Returns: An observable of serial RTU slave instances.
+
+###### `M:IoT.DriverCore.ModbusRx.Create.TcpIpMaster(System.String,System.Int32)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> TcpIpMaster(string hostAddress, int port)
+```
+Create a TcpIpMaster with the specified host address.
+
+- Parameter `hostAddress`: The host address.
+- Parameter `port`: The port.
+- Returns: The master and connection status.
+
+###### `M:IoT.DriverCore.ModbusRx.Create.TcpIpSlave(System.String,System.Int32,System.Byte)`
+
+```csharp
+public static System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave> TcpIpSlave(string hostAddress, int port, byte unitId)
+```
+TCPs the ip slave.
+
+- Parameter `hostAddress`: The host address.
+- Parameter `port`: The port.
+- Parameter `unitId`: The unit identifier.
+- Returns: An Observable of.
+
+###### `M:IoT.DriverCore.ModbusRx.Create.UdpIpMaster(System.String,System.Int32)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> UdpIpMaster(string hostAddress, int port)
+```
+Create a UdpIpMaster with the specified host address.
+
+- Parameter `hostAddress`: The host address.
+- Parameter `port`: The port.
+- Returns: The master and connection status.
+
+###### `M:IoT.DriverCore.ModbusRx.Create.UdpIpSlave(System.String,System.Int32,System.Byte)`
+
+```csharp
+public static System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave> UdpIpSlave(string hostAddress, int port, byte unitId)
+```
+Creates an UdpIp slave.
+
+- Parameter `hostAddress`: The host address.
+- Parameter `port`: The port.
+- Parameter `unitId`: The unit identifier.
+- Returns: An Observable of.
+
+###### `P:IoT.DriverCore.ModbusRx.Create.CheckConnectionInterval`
+
+```csharp
+public System.TimeSpan CheckConnectionInterval { get; set; }
+```
+Gets or sets the check connection interval.
+
+- Value: The check connection interval.
+
+###### `P:IoT.DriverCore.ModbusRx.Create.PingInterval`
+
+```csharp
+public System.TimeSpan PingInterval { get; set; }
+```
+Gets or sets the ping interval.
+
+- Value: The ping interval.
+
+#### `T:IoT.DriverCore.ModbusRx.CreateExtensions`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.CreateExtensions
+```
+Extension methods for Modbus reactive creation helpers.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.FromDouble(System.Double,System.Span`1{System.UInt16},System.Int32,System.Boolean)`
+
+```csharp
+public static void FromDouble(double input, System.Span<ushort> output, int start, bool swapWords)
+```
+Executes the `FromDouble` operation.
+
+- Parameter `input`: The `input` value.
+- Parameter `output`: The `output` value.
+- Parameter `start`: The `start` value.
+- Parameter `swapWords`: The `swapWords` value.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.FromDouble(System.Double,System.UInt16[],System.Int32,System.Boolean)`
+
+```csharp
+public static void FromDouble(double input, ushort[] output, int start, bool swapWords)
+```
+Writes the double value to a register array.
+
+- Parameter `input`: The extension receiver.
+- Parameter `output`: The output array.
+- Parameter `start`: The start index.
+- Parameter `swapWords`: Whether to swap words.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.FromFloat(System.Single,System.Span`1{System.UInt16},System.Int32,System.Boolean)`
+
+```csharp
+public static void FromFloat(float input, System.Span<ushort> output, int start, bool swapWords)
+```
+Executes the `FromFloat` operation.
+
+- Parameter `input`: The `input` value.
+- Parameter `output`: The `output` value.
+- Parameter `start`: The `start` value.
+- Parameter `swapWords`: The `swapWords` value.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.FromFloat(System.Single,System.UInt16[],System.Int32,System.Boolean)`
+
+```csharp
+public static void FromFloat(float input, ushort[] output, int start, bool swapWords)
+```
+Writes the float value to a register array.
+
+- Parameter `input`: The extension receiver.
+- Parameter `output`: The output array.
+- Parameter `start`: The start index.
+- Parameter `swapWords`: Whether to swap words.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.ObserveDataStoreReadFrom(IoT.DriverCore.ModbusRx.Device.ModbusSlave)`
+
+```csharp
+public static System.IObservable<IoT.DriverCore.ModbusRx.Data.DataStoreEventArgs> ObserveDataStoreReadFrom(IoT.DriverCore.ModbusRx.Device.ModbusSlave slave)
+```
+Observes reads from the data store.
+
+- Parameter `slave`: The extension receiver.
+- Returns: An observable of data-store events.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.ObserveDataStoreWrittenTo(IoT.DriverCore.ModbusRx.Device.ModbusSlave)`
+
+```csharp
+public static System.IObservable<IoT.DriverCore.ModbusRx.Data.DataStoreEventArgs> ObserveDataStoreWrittenTo(IoT.DriverCore.ModbusRx.Device.ModbusSlave slave)
+```
+Observes writes to the data store.
+
+- Parameter `slave`: The extension receiver.
+- Returns: An observable of data-store events.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.ObserveRequest(IoT.DriverCore.ModbusRx.Device.ModbusSlave)`
+
+```csharp
+public static System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusSlaveRequestEventArgs> ObserveRequest(IoT.DriverCore.ModbusRx.Device.ModbusSlave slave)
+```
+Observes received slave requests.
+
+- Parameter `slave`: The extension receiver.
+- Returns: An observable of request events.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.ObserveWriteComplete(IoT.DriverCore.ModbusRx.Device.ModbusSlave)`
+
+```csharp
+public static System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusSlaveRequestEventArgs> ObserveWriteComplete(IoT.DriverCore.ModbusRx.Device.ModbusSlave slave)
+```
+Observes completed writes.
+
+- Parameter `slave`: The extension receiver.
+- Returns: An observable of request events.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.ReadCoils(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.Byte,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<bool[], System.Exception>> ReadCoils(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, byte slaveAddress, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadCoils` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `slaveAddress`: The `slaveAddress` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<bool[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.ReadCoils(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<bool[], System.Exception>> ReadCoils(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadCoils` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<bool[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.ReadCoils(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.ModbusIpMaster}},System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<bool[], System.Exception>> ReadCoils(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadCoils` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<bool[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.ReadHoldingRegisters(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.Byte,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<ushort[], System.Exception>> ReadHoldingRegisters(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, byte slaveAddress, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadHoldingRegisters` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `slaveAddress`: The `slaveAddress` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<ushort[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.ReadHoldingRegisters(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<ushort[], System.Exception>> ReadHoldingRegisters(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadHoldingRegisters` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<ushort[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.ReadHoldingRegisters(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.ModbusIpMaster}},System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<ushort[], System.Exception>> ReadHoldingRegisters(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadHoldingRegisters` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<ushort[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.ReadInputRegisters(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.Byte,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<ushort[], System.Exception>> ReadInputRegisters(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, byte slaveAddress, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadInputRegisters` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `slaveAddress`: The `slaveAddress` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<ushort[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.ReadInputRegisters(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<ushort[], System.Exception>> ReadInputRegisters(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadInputRegisters` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<ushort[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.ReadInputRegisters(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.ModbusIpMaster}},System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<ushort[], System.Exception>> ReadInputRegisters(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadInputRegisters` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<ushort[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.ReadInputs(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.Byte,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<bool[], System.Exception>> ReadInputs(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, byte slaveAddress, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadInputs` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `slaveAddress`: The `slaveAddress` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<bool[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.ReadInputs(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<bool[], System.Exception>> ReadInputs(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadInputs` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<bool[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.ReadInputs(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.ModbusIpMaster}},System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<bool[], System.Exception>> ReadInputs(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadInputs` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `System.IObservable<System.ValueTuple<bool[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.ToDouble(System.ReadOnlySpan`1{System.UInt16},System.Int32,System.Boolean)`
+
+```csharp
+public static System.Nullable<double> ToDouble(System.ReadOnlySpan<ushort> inputs, int start, bool swapWords)
+```
+Executes the `ToDouble` operation.
+
+- Parameter `inputs`: The `inputs` value.
+- Parameter `start`: The `start` value.
+- Parameter `swapWords`: The `swapWords` value.
+- Returns: A `System.Nullable<double>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.ToDouble(System.UInt16[],System.Int32,System.Boolean)`
+
+```csharp
+public static System.Nullable<double> ToDouble(ushort[] inputs, int start, bool swapWords)
+```
+Converts register data to a double.
+
+- Parameter `inputs`: The extension receiver.
+- Parameter `start`: The start index.
+- Parameter `swapWords`: Whether to swap words.
+- Returns: A double value or null if insufficient data is available.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.ToFloat(System.ReadOnlySpan`1{System.UInt16},System.Int32,System.Boolean)`
+
+```csharp
+public static System.Nullable<float> ToFloat(System.ReadOnlySpan<ushort> inputs, int start, bool swapWords)
+```
+Executes the `ToFloat` operation.
+
+- Parameter `inputs`: The `inputs` value.
+- Parameter `start`: The `start` value.
+- Parameter `swapWords`: The `swapWords` value.
+- Returns: A `System.Nullable<float>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.CreateExtensions.ToFloat(System.UInt16[],System.Int32,System.Boolean)`
+
+```csharp
+public static System.Nullable<float> ToFloat(ushort[] inputs, int start, bool swapWords)
+```
+Converts register data to a float.
+
+- Parameter `inputs`: The extension receiver.
+- Parameter `start`: The start index.
+- Parameter `swapWords`: Whether to swap words.
+- Returns: A float value or null if insufficient data is available.
+
+#### `T:IoT.DriverCore.ModbusRx.Data.BooleanPattern`
+
+```csharp
+public enum IoT.DriverCore.ModbusRx.Data.BooleanPattern
+```
+Boolean pattern types.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.ModbusRx.Data.BooleanPattern.AllFalse`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Data.BooleanPattern AllFalse
+```
+All false values.
+
+###### `F:IoT.DriverCore.ModbusRx.Data.BooleanPattern.AllTrue`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Data.BooleanPattern AllTrue
+```
+All true values.
+
+###### `F:IoT.DriverCore.ModbusRx.Data.BooleanPattern.Alternating`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Data.BooleanPattern Alternating
+```
+Alternating true/false pattern.
+
+###### `F:IoT.DriverCore.ModbusRx.Data.BooleanPattern.Random`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Data.BooleanPattern Random
+```
+Random true/false values.
+
+#### `T:IoT.DriverCore.ModbusRx.Data.DataStore`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Data.DataStore
+```
+Object simulation of device memory map. The underlying collections are thread safe when using the ModbusMaster API to read/write values. You can use the SyncRoot property to synchronize direct access to the DataStore collections.
+
+##### Declared public members
+
+###### `E:IoT.DriverCore.ModbusRx.Data.DataStore.DataStoreReadFrom`
+
+```csharp
+public event System.EventHandler<IoT.DriverCore.ModbusRx.Data.DataStoreEventArgs> DataStoreReadFrom
+```
+Occurs when the DataStore is read from via a Modbus command.
+
+###### `E:IoT.DriverCore.ModbusRx.Data.DataStore.DataStoreWrittenTo`
+
+```csharp
+public event System.EventHandler<IoT.DriverCore.ModbusRx.Data.DataStoreEventArgs> DataStoreWrittenTo
+```
+Occurs when the DataStore is written to via a Modbus command.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DataStore.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.DataStore()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Data.DataStore` class.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DataStore.Dispose`
+
+```csharp
+public void Dispose()
+```
+Disposes the DataStore and releases resources.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DataStore.GetOperationMetrics`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.DataStoreOperationMetrics GetOperationMetrics()
+```
+Gets a deterministic snapshot of data-store range-operation work.
+
+- Returns: The current range-operation counters.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DataStore.ReadDataOptimized``2(IoT.DriverCore.ModbusRx.Data.ModbusDataCollection`1{``1},System.Func`1{``0},System.UInt16,System.UInt16)`
+
+```csharp
+public T ReadDataOptimized<T, TU>(IoT.DriverCore.ModbusRx.Data.ModbusDataCollection<TU> dataSource, System.Func<T> resultFactory, ushort startAddress, ushort count)
+```
+Executes the `ReadDataOptimized` operation.
+
+- Parameter `dataSource`: The `dataSource` value.
+- Parameter `resultFactory`: The `resultFactory` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `count`: The `count` value.
+- Returns: A `T` result.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DataStore.WriteDataOptimized``1(System.Collections.Generic.IEnumerable`1{``0},IoT.DriverCore.ModbusRx.Data.ModbusDataCollection`1{``0},System.UInt16)`
+
+```csharp
+public void WriteDataOptimized<TData>(System.Collections.Generic.IEnumerable<TData> items, IoT.DriverCore.ModbusRx.Data.ModbusDataCollection<TData> destination, ushort startAddress)
+```
+Executes the `WriteDataOptimized` operation.
+
+- Parameter `items`: The `items` value.
+- Parameter `destination`: The `destination` value.
+- Parameter `startAddress`: The `startAddress` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Data.DataStore.CoilDiscretes`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.ModbusDataCollection<bool> CoilDiscretes { get; }
+```
+Gets the discrete coils.
+
+- Value: The `CoilDiscretes` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Data.DataStore.HoldingRegisters`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.ModbusDataCollection<ushort> HoldingRegisters { get; }
+```
+Gets the holding registers.
+
+- Value: The `HoldingRegisters` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Data.DataStore.InputDiscretes`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.ModbusDataCollection<bool> InputDiscretes { get; }
+```
+Gets the discrete inputs.
+
+- Value: The `InputDiscretes` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Data.DataStore.InputRegisters`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.ModbusDataCollection<ushort> InputRegisters { get; }
+```
+Gets the input registers.
+
+- Value: The `InputRegisters` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Data.DataStore.Lock`
+
+```csharp
+public System.Threading.ReaderWriterLockSlim Lock { get; }
+```
+Gets the reader-writer lock for more granular access control.
+
+- Value: The `Lock` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Data.DataStore.SyncRoot`
+
+```csharp
+public object SyncRoot { get; }
+```
+Gets an object that can be used to synchronize direct access to the DataStore collections.
+
+- Value: The `SyncRoot` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Data.DataStoreEventArgs`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Data.DataStoreEventArgs
+```
+Event args for read write actions performed on the DataStore.
+
+##### Declared public members
+
+###### `P:IoT.DriverCore.ModbusRx.Data.DataStoreEventArgs.Data`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnion<System.Collections.ObjectModel.ReadOnlyCollection<bool>, System.Collections.ObjectModel.ReadOnlyCollection<ushort>> Data { get; }
+```
+Gets data that was read or written.
+
+- Value: The `Data` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Data.DataStoreEventArgs.ModbusDataType`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.ModbusDataType ModbusDataType { get; }
+```
+Gets type of Modbus data (e.g. Holding register).
+
+- Value: The `ModbusDataType` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Data.DataStoreEventArgs.StartAddress`
+
+```csharp
+public ushort StartAddress { get; }
+```
+Gets start address of data.
+
+- Value: The `StartAddress` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Data.DataStoreExtensions`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Data.DataStoreExtensions
+```
+High-performance extensions for DataStore operations using optimized techniques.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DataStoreExtensions.BulkCopyCoils(IoT.DriverCore.ModbusRx.Data.DataStore,IoT.DriverCore.ModbusRx.Data.DataStore,System.UInt16,System.UInt16)`
+
+```csharp
+public static void BulkCopyCoils(IoT.DriverCore.ModbusRx.Data.DataStore dataStore, IoT.DriverCore.ModbusRx.Data.DataStore destinationStore, ushort startAddress, ushort count)
+```
+Performs a bulk copy operation for coils between data stores with high performance.
+
+- Parameter `dataStore`: The extension receiver.
+- Parameter `destinationStore`: The destination data store.
+- Parameter `startAddress`: The start address.
+- Parameter `count`: The number of elements to copy.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DataStoreExtensions.BulkCopyHoldingRegisters(IoT.DriverCore.ModbusRx.Data.DataStore,IoT.DriverCore.ModbusRx.Data.DataStore,System.UInt16,System.UInt16)`
+
+```csharp
+public static void BulkCopyHoldingRegisters(IoT.DriverCore.ModbusRx.Data.DataStore dataStore, IoT.DriverCore.ModbusRx.Data.DataStore destinationStore, ushort startAddress, ushort count)
+```
+Performs a bulk copy operation between data stores with high performance.
+
+- Parameter `dataStore`: The extension receiver.
+- Parameter `destinationStore`: The destination data store.
+- Parameter `startAddress`: The start address.
+- Parameter `count`: The number of elements to copy.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DataStoreExtensions.ClearCoils(IoT.DriverCore.ModbusRx.Data.DataStore,System.UInt16,System.UInt16)`
+
+```csharp
+public static void ClearCoils(IoT.DriverCore.ModbusRx.Data.DataStore dataStore, ushort startAddress, ushort count)
+```
+Clears a range of coils with high performance.
+
+- Parameter `dataStore`: The extension receiver.
+- Parameter `startAddress`: The start address.
+- Parameter `count`: The number of coils to clear.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DataStoreExtensions.ClearHoldingRegisters(IoT.DriverCore.ModbusRx.Data.DataStore,System.UInt16,System.UInt16)`
+
+```csharp
+public static void ClearHoldingRegisters(IoT.DriverCore.ModbusRx.Data.DataStore dataStore, ushort startAddress, ushort count)
+```
+Clears a range of holding registers with high performance.
+
+- Parameter `dataStore`: The extension receiver.
+- Parameter `startAddress`: The start address.
+- Parameter `count`: The number of registers to clear.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DataStoreExtensions.CompareHoldingRegisters(IoT.DriverCore.ModbusRx.Data.DataStore,IoT.DriverCore.ModbusRx.Data.DataStore,System.UInt16,System.UInt16)`
+
+```csharp
+public static bool CompareHoldingRegisters(IoT.DriverCore.ModbusRx.Data.DataStore dataStore, IoT.DriverCore.ModbusRx.Data.DataStore store2, ushort startAddress, ushort count)
+```
+Performs a memory-efficient comparison between two data stores.
+
+- Parameter `dataStore`: The extension receiver.
+- Parameter `store2`: The second data store.
+- Parameter `startAddress`: The start address.
+- Parameter `count`: The number of elements to compare.
+- Returns: True if the data ranges are identical.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DataStoreExtensions.ReadCoilsOptimized(IoT.DriverCore.ModbusRx.Data.DataStore,System.UInt16,System.UInt16)`
+
+```csharp
+public static bool[] ReadCoilsOptimized(IoT.DriverCore.ModbusRx.Data.DataStore dataStore, ushort startAddress, ushort count)
+```
+Reads coils with optimized performance.
+
+- Parameter `dataStore`: The extension receiver.
+- Parameter `startAddress`: The start address.
+- Parameter `count`: The count.
+- Returns: Array of coil values.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DataStoreExtensions.ReadHoldingRegistersOptimized(IoT.DriverCore.ModbusRx.Data.DataStore,System.UInt16,System.UInt16)`
+
+```csharp
+public static ushort[] ReadHoldingRegistersOptimized(IoT.DriverCore.ModbusRx.Data.DataStore dataStore, ushort startAddress, ushort count)
+```
+Reads holding registers with optimized performance.
+
+- Parameter `dataStore`: The extension receiver.
+- Parameter `startAddress`: The start address.
+- Parameter `count`: The count.
+- Returns: Array of register values.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DataStoreExtensions.ReadInputRegistersOptimized(IoT.DriverCore.ModbusRx.Data.DataStore,System.UInt16,System.UInt16)`
+
+```csharp
+public static ushort[] ReadInputRegistersOptimized(IoT.DriverCore.ModbusRx.Data.DataStore dataStore, ushort startAddress, ushort count)
+```
+Reads input registers with optimized performance.
+
+- Parameter `dataStore`: The extension receiver.
+- Parameter `startAddress`: The start address.
+- Parameter `count`: The count.
+- Returns: Array of register values.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DataStoreExtensions.ReadInputsOptimized(IoT.DriverCore.ModbusRx.Data.DataStore,System.UInt16,System.UInt16)`
+
+```csharp
+public static bool[] ReadInputsOptimized(IoT.DriverCore.ModbusRx.Data.DataStore dataStore, ushort startAddress, ushort count)
+```
+Reads discrete inputs with optimized performance.
+
+- Parameter `dataStore`: The extension receiver.
+- Parameter `startAddress`: The start address.
+- Parameter `count`: The count.
+- Returns: Array of input values.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DataStoreExtensions.WriteCoilsOptimized(IoT.DriverCore.ModbusRx.Data.DataStore,System.UInt16,System.Boolean[])`
+
+```csharp
+public static void WriteCoilsOptimized(IoT.DriverCore.ModbusRx.Data.DataStore dataStore, ushort startAddress, bool[] values)
+```
+Writes coils with optimized performance.
+
+- Parameter `dataStore`: The extension receiver.
+- Parameter `startAddress`: The start address.
+- Parameter `values`: The values to write.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DataStoreExtensions.WriteHoldingRegistersOptimized(IoT.DriverCore.ModbusRx.Data.DataStore,System.UInt16,System.UInt16[])`
+
+```csharp
+public static void WriteHoldingRegistersOptimized(IoT.DriverCore.ModbusRx.Data.DataStore dataStore, ushort startAddress, ushort[] values)
+```
+Writes holding registers with optimized performance.
+
+- Parameter `dataStore`: The extension receiver.
+- Parameter `startAddress`: The start address.
+- Parameter `values`: The values to write.
+
+#### `T:IoT.DriverCore.ModbusRx.Data.DataStoreFactory`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Data.DataStoreFactory
+```
+Data story factory.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DataStoreFactory.CreateDefaultDataStore`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Data.DataStore CreateDefaultDataStore()
+```
+Creates a default data store with zeroed registers and false discrete values.
+
+- Returns: A DataStore.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DataStoreFactory.CreateDefaultDataStore(System.UInt16,System.UInt16,System.UInt16,System.UInt16)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Data.DataStore CreateDefaultDataStore(ushort coilsCount, ushort inputsCount, ushort holdingRegistersCount, ushort inputRegistersCount)
+```
+Creates a default data store with zeroed registers and false discrete values.
+
+- Parameter `coilsCount`: Number of discrete coils.
+- Parameter `inputsCount`: Number of discrete inputs.
+- Parameter `holdingRegistersCount`: Number of holding registers.
+- Parameter `inputRegistersCount`: Number of input registers.
+- Returns: New instance of Data store with defined inputs/outputs.
+
+#### `T:IoT.DriverCore.ModbusRx.Data.DataStoreOperationMetrics`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Data.DataStoreOperationMetrics
+```
+Provides deterministic operation counters for data-store range operations.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DataStoreOperationMetrics.#ctor(System.Int64,System.Int64,System.Int64,System.Int64,System.Int64)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.DataStoreOperationMetrics(long readOperations, long writeOperations, long elementCopies, long resultCollectionAllocations, long inputMaterializations)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Data.DataStoreOperationMetrics` class.
+
+- Parameter `readOperations`: The number of completed range reads.
+- Parameter `writeOperations`: The number of completed range writes.
+- Parameter `elementCopies`: The number of elements copied between data-store ranges and results.
+- Parameter `resultCollectionAllocations`: The number of result collections created for reads.
+- Parameter `inputMaterializations`: The number of non-indexable write inputs materialized once.
+
+###### `P:IoT.DriverCore.ModbusRx.Data.DataStoreOperationMetrics.ElementCopies`
+
+```csharp
+public long ElementCopies { get; }
+```
+Gets the number of elements copied by range operations.
+
+- Value: The `ElementCopies` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Data.DataStoreOperationMetrics.InputMaterializations`
+
+```csharp
+public long InputMaterializations { get; }
+```
+Gets the number of non-indexable write inputs materialized exactly once.
+
+- Value: The `InputMaterializations` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Data.DataStoreOperationMetrics.ReadOperations`
+
+```csharp
+public long ReadOperations { get; }
+```
+Gets the number of completed range reads.
+
+- Value: The `ReadOperations` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Data.DataStoreOperationMetrics.ResultCollectionAllocations`
+
+```csharp
+public long ResultCollectionAllocations { get; }
+```
+Gets the number of result collections created by reads.
+
+- Value: The `ResultCollectionAllocations` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Data.DataStoreOperationMetrics.WriteOperations`
+
+```csharp
+public long WriteOperations { get; }
+```
+Gets the number of completed range writes.
+
+- Value: The `WriteOperations` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Data.DiscreteCollection`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Data.DiscreteCollection
+```
+Collection of discrete values.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DiscreteCollection.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.DiscreteCollection()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Data.DiscreteCollection` class.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DiscreteCollection.#ctor(System.Boolean[])`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.DiscreteCollection(bool[] bits)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Data.DiscreteCollection` class.
+
+- Parameter `bits`: Array for discrete collection.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DiscreteCollection.#ctor(System.Byte[])`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.DiscreteCollection(byte[] bytes)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Data.DiscreteCollection` class.
+
+- Parameter `bytes`: Array for discrete collection.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DiscreteCollection.#ctor(System.Collections.Generic.IList`1{System.Boolean})`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.DiscreteCollection(System.Collections.Generic.IList<bool> bits)
+```
+Initializes a new instance of `IoT.DriverCore.ModbusRx.Data.DiscreteCollection`.
+
+- Parameter `bits`: The `bits` value.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.DiscreteCollection.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string that represents the current object.
+
+- Returns: A `T:System.String` that represents the current `T:System.Object` .
+
+###### `P:IoT.DriverCore.ModbusRx.Data.DiscreteCollection.ByteCount`
+
+```csharp
+public byte ByteCount { get; }
+```
+Gets the byte count.
+
+- Value: The `ByteCount` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Data.DiscreteCollection.NetworkBytes`
+
+```csharp
+public byte[] NetworkBytes { get; }
+```
+Gets the network bytes.
+
+- Value: The `NetworkBytes` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Data.IDataCollection`
+
+```csharp
+public interface IoT.DriverCore.ModbusRx.Data.IDataCollection
+```
+Modbus message containing data.
+
+##### Declared public members
+
+###### `P:IoT.DriverCore.ModbusRx.Data.IDataCollection.ByteCount`
+
+```csharp
+public byte ByteCount { get; }
+```
+Gets the byte count.
+
+- Value: The `ByteCount` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Data.IDataCollection.NetworkBytes`
+
+```csharp
+public byte[] NetworkBytes { get; }
+```
+Gets the network bytes.
+
+- Value: The `NetworkBytes` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Data.ModbusDataCollection`1`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Data.ModbusDataCollection`1
+```
+A 1 origin collection represetative of the Modbus Data Model.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Data.ModbusDataCollection`1.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.ModbusDataCollection<TData>()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Data.ModbusDataCollection`1` class.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.ModbusDataCollection`1.#ctor(System.Collections.Generic.IList`1{`0})`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.ModbusDataCollection<TData>(System.Collections.Generic.IList<TData> data)
+```
+Initializes a new instance of `IoT.DriverCore.ModbusRx.Data.ModbusDataCollection`1`.
+
+- Parameter `data`: The `data` value.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.ModbusDataCollection`1.#ctor(`0[])`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.ModbusDataCollection<TData>(TData[] data)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Data.ModbusDataCollection`1` class.
+
+- Parameter `data`: The data.
+
+#### `T:IoT.DriverCore.ModbusRx.Data.ModbusDataExtensions`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Data.ModbusDataExtensions
+```
+High-performance data conversion extensions optimized for different target frameworks.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Data.ModbusDataExtensions.FastEquals(System.Byte[],System.Byte[])`
+
+```csharp
+public static bool FastEquals(byte[] bytes, byte[] array2)
+```
+Performs a fast memory comparison between two byte arrays.
+
+- Parameter `bytes`: The extension receiver.
+- Parameter `array2`: The second array.
+- Returns: True if arrays are equal.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.ModbusDataExtensions.PackBooleans(System.Boolean[])`
+
+```csharp
+public static byte[] PackBooleans(bool[] values)
+```
+Packs boolean values into bytes with optimized performance.
+
+- Parameter `values`: The extension receiver.
+- Returns: Array of bytes containing packed boolean values.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.ModbusDataExtensions.ToInt32(System.UInt16[],System.Int32,System.Boolean)`
+
+```csharp
+public static int ToInt32(ushort[] registers, int startIndex, bool swapWords)
+```
+Converts two 16-bit registers to a 32-bit integer with optimized performance.
+
+- Parameter `registers`: The extension receiver.
+- Parameter `startIndex`: The start index.
+- Parameter `swapWords`: Whether words are swapped.
+- Returns: The 32-bit integer value.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.ModbusDataExtensions.ToInt64(System.UInt16[],System.Int32,System.Boolean)`
+
+```csharp
+public static long ToInt64(ushort[] registers, int startIndex, bool swapWords)
+```
+Converts four 16-bit registers to a 64-bit long with optimized performance.
+
+- Parameter `registers`: The extension receiver.
+- Parameter `startIndex`: The start index.
+- Parameter `swapWords`: Whether words are swapped.
+- Returns: The 64-bit long value.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.ModbusDataExtensions.ToRegisters(System.Int32,System.Boolean)`
+
+```csharp
+public static ushort[] ToRegisters(int value, bool swapWords)
+```
+Converts a 32-bit integer to two 16-bit registers with optimized performance.
+
+- Parameter `value`: The extension receiver.
+- Parameter `swapWords`: Whether to swap word order.
+- Returns: Array containing two 16-bit register values.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.ModbusDataExtensions.ToRegisters(System.Int64,System.Boolean)`
+
+```csharp
+public static ushort[] ToRegisters(long value, bool swapWords)
+```
+Converts a 64-bit long to four 16-bit registers with optimized performance.
+
+- Parameter `value`: The extension receiver.
+- Parameter `swapWords`: Whether to swap word order.
+- Returns: Array containing four 16-bit register values.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.ModbusDataExtensions.ToRegisters(System.UInt32,System.Boolean)`
+
+```csharp
+public static ushort[] ToRegisters(uint value, bool swapWords)
+```
+Converts a 32-bit unsigned integer to two 16-bit registers with optimized performance.
+
+- Parameter `value`: The extension receiver.
+- Parameter `swapWords`: Whether to swap word order.
+- Returns: Array containing two 16-bit register values.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.ModbusDataExtensions.ToUInt32(System.UInt16[],System.Int32,System.Boolean)`
+
+```csharp
+public static uint ToUInt32(ushort[] registers, int startIndex, bool swapWords)
+```
+Converts two 16-bit registers to a 32-bit unsigned integer with optimized performance.
+
+- Parameter `registers`: The extension receiver.
+- Parameter `startIndex`: The start index.
+- Parameter `swapWords`: Whether words are swapped.
+- Returns: The 32-bit unsigned integer value.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.ModbusDataExtensions.UnpackBooleans(System.Byte[],System.Int32)`
+
+```csharp
+public static bool[] UnpackBooleans(byte[] bytes, int numberOfBooleans)
+```
+Unpacks bytes into boolean values with optimized performance.
+
+- Parameter `bytes`: The extension receiver.
+- Parameter `numberOfBooleans`: The number of boolean values to extract.
+- Returns: Array of boolean values.
+
+#### `T:IoT.DriverCore.ModbusRx.Data.ModbusDataType`
+
+```csharp
+public enum IoT.DriverCore.ModbusRx.Data.ModbusDataType
+```
+Types of data supported by the Modbus protocol.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.ModbusRx.Data.ModbusDataType.Coil`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Data.ModbusDataType Coil
+```
+Read/write discrete.
+
+###### `F:IoT.DriverCore.ModbusRx.Data.ModbusDataType.HoldingRegister`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Data.ModbusDataType HoldingRegister
+```
+Read/write register.
+
+###### `F:IoT.DriverCore.ModbusRx.Data.ModbusDataType.Input`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Data.ModbusDataType Input
+```
+Readonly discrete.
+
+###### `F:IoT.DriverCore.ModbusRx.Data.ModbusDataType.InputRegister`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Data.ModbusDataType InputRegister
+```
+Readonly register.
+
+#### `T:IoT.DriverCore.ModbusRx.Data.RegisterCollection`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Data.RegisterCollection
+```
+Collection of 16 bit registers.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Data.RegisterCollection.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.RegisterCollection()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Data.RegisterCollection` class.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.RegisterCollection.#ctor(System.Byte[])`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.RegisterCollection(byte[] bytes)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Data.RegisterCollection` class.
+
+- Parameter `bytes`: Array for register collection.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.RegisterCollection.#ctor(System.Collections.Generic.IList`1{System.UInt16})`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.RegisterCollection(System.Collections.Generic.IList<ushort> registers)
+```
+Initializes a new instance of `IoT.DriverCore.ModbusRx.Data.RegisterCollection`.
+
+- Parameter `registers`: The `registers` value.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.RegisterCollection.#ctor(System.UInt16[])`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.RegisterCollection(ushort[] registers)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Data.RegisterCollection` class.
+
+- Parameter `registers`: Array for register collection.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.RegisterCollection.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string that represents the current object.
+
+- Returns: A `T:System.String` that represents the current `T:System.Object` .
+
+###### `P:IoT.DriverCore.ModbusRx.Data.RegisterCollection.ByteCount`
+
+```csharp
+public byte ByteCount { get; }
+```
+Gets the byte count.
+
+- Value: The `ByteCount` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Data.RegisterCollection.NetworkBytes`
+
+```csharp
+public byte[] NetworkBytes { get; }
+```
+Gets the network bytes.
+
+- Value: The `NetworkBytes` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Data.SimulationDataProvider`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Data.SimulationDataProvider
+```
+Provides simulation data for Modbus testing and development.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Data.SimulationDataProvider.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.SimulationDataProvider()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Data.SimulationDataProvider` class.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.SimulationDataProvider.#ctor(System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.SimulationDataProvider(System.TimeProvider timeProvider)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Data.SimulationDataProvider` class.
+
+- Parameter `timeProvider`: The time provider used for simulation timing.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.SimulationDataProvider.Dispose`
+
+```csharp
+public void Dispose()
+```
+Disposes the simulation data provider.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.SimulationDataProvider.GenerateBooleanPattern(System.Int32,IoT.DriverCore.ModbusRx.Data.BooleanPattern)`
+
+```csharp
+public bool[] GenerateBooleanPattern(int length, IoT.DriverCore.ModbusRx.Data.BooleanPattern pattern)
+```
+Generates boolean pattern for discrete values.
+
+- Parameter `length`: The number of data points.
+- Parameter `pattern`: The pattern type.
+- Returns: An array of boolean values.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.SimulationDataProvider.GenerateRandomData(System.Int32,System.UInt16,System.UInt16)`
+
+```csharp
+public ushort[] GenerateRandomData(int length, ushort minValue, ushort maxValue)
+```
+Generates random data within specified bounds.
+
+- Parameter `length`: The number of data points.
+- Parameter `minValue`: The minimum value.
+- Parameter `maxValue`: The maximum value.
+- Returns: An array of random values.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.SimulationDataProvider.GenerateSawtoothWave(System.Int32,System.UInt16,System.UInt16)`
+
+```csharp
+public static ushort[] GenerateSawtoothWave(int length, ushort maxValue, ushort minValue)
+```
+Generates sawtooth wave pattern data.
+
+- Parameter `length`: The number of data points.
+- Parameter `maxValue`: The maximum value.
+- Parameter `minValue`: The minimum value.
+- Returns: An array of sawtooth wave values.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.SimulationDataProvider.GenerateSineWave(System.Int32,System.Double,System.Double,System.Double)`
+
+```csharp
+public static ushort[] GenerateSineWave(int length, double amplitude, double frequency, double phase)
+```
+Generates sine wave pattern data.
+
+- Parameter `length`: The number of data points.
+- Parameter `amplitude`: The amplitude of the sine wave.
+- Parameter `frequency`: The frequency of the sine wave.
+- Parameter `phase`: The phase offset.
+- Returns: An array of sine wave values.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.SimulationDataProvider.GenerateSquareWave(System.Int32,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ushort[] GenerateSquareWave(int length, ushort highValue, ushort lowValue, double dutyCycle)
+```
+Generates square wave pattern data.
+
+- Parameter `length`: The number of data points.
+- Parameter `highValue`: The high value of the square wave.
+- Parameter `lowValue`: The low value of the square wave.
+- Parameter `dutyCycle`: The duty cycle (0.0 to 1.0).
+- Returns: An array of square wave values.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.SimulationDataProvider.LoadTestPattern(IoT.DriverCore.ModbusRx.Data.DataStore,IoT.DriverCore.ModbusRx.Data.TestPattern)`
+
+```csharp
+public void LoadTestPattern(IoT.DriverCore.ModbusRx.Data.DataStore dataStore, IoT.DriverCore.ModbusRx.Data.TestPattern pattern)
+```
+Loads predefined test patterns into a data store.
+
+- Parameter `dataStore`: The data store to populate.
+- Parameter `pattern`: The pattern type to load.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.SimulationDataProvider.Start(IoT.DriverCore.ModbusRx.Data.DataStore,System.TimeSpan,IoT.DriverCore.ModbusRx.Data.SimulationType)`
+
+```csharp
+public void Start(IoT.DriverCore.ModbusRx.Data.DataStore dataStore, System.TimeSpan interval, IoT.DriverCore.ModbusRx.Data.SimulationType simulationType)
+```
+Starts the simulation with the specified interval.
+
+- Parameter `dataStore`: The data store to update.
+- Parameter `interval`: The update interval.
+- Parameter `simulationType`: The type of simulation to run.
+
+###### `M:IoT.DriverCore.ModbusRx.Data.SimulationDataProvider.Stop`
+
+```csharp
+public void Stop()
+```
+Stops the simulation.
+
+###### `P:IoT.DriverCore.ModbusRx.Data.SimulationDataProvider.IsRunning`
+
+```csharp
+public System.IObservable<bool> IsRunning { get; }
+```
+Gets an observable indicating if simulation is running.
+
+- Value: The `IsRunning` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Data.SimulationType`
+
+```csharp
+public enum IoT.DriverCore.ModbusRx.Data.SimulationType
+```
+Types of simulation patterns available.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.ModbusRx.Data.SimulationType.CountingDown`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Data.SimulationType CountingDown
+```
+Counting down pattern.
+
+###### `F:IoT.DriverCore.ModbusRx.Data.SimulationType.CountingUp`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Data.SimulationType CountingUp
+```
+Counting up pattern.
+
+###### `F:IoT.DriverCore.ModbusRx.Data.SimulationType.Random`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Data.SimulationType Random
+```
+Random values.
+
+###### `F:IoT.DriverCore.ModbusRx.Data.SimulationType.SineWave`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Data.SimulationType SineWave
+```
+Sine wave pattern.
+
+###### `F:IoT.DriverCore.ModbusRx.Data.SimulationType.SquareWave`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Data.SimulationType SquareWave
+```
+Square wave pattern.
+
+#### `T:IoT.DriverCore.ModbusRx.Data.TestPattern`
+
+```csharp
+public enum IoT.DriverCore.ModbusRx.Data.TestPattern
+```
+Test pattern types.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.ModbusRx.Data.TestPattern.AllOnes`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Data.TestPattern AllOnes
+```
+All ones (max values).
+
+###### `F:IoT.DriverCore.ModbusRx.Data.TestPattern.AllZeros`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Data.TestPattern AllZeros
+```
+All zeros.
+
+###### `F:IoT.DriverCore.ModbusRx.Data.TestPattern.CountingDown`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Data.TestPattern CountingDown
+```
+Counting down to 0.
+
+###### `F:IoT.DriverCore.ModbusRx.Data.TestPattern.CountingUp`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Data.TestPattern CountingUp
+```
+Counting up from 0.
+
+###### `F:IoT.DriverCore.ModbusRx.Data.TestPattern.Random`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Data.TestPattern Random
+```
+Random values.
+
+###### `F:IoT.DriverCore.ModbusRx.Data.TestPattern.SineWave`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Data.TestPattern SineWave
+```
+Sine wave pattern.
+
+###### `F:IoT.DriverCore.ModbusRx.Data.TestPattern.SquareWave`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Data.TestPattern SquareWave
+```
+Square wave pattern.
+
+#### `T:IoT.DriverCore.ModbusRx.Device.ICancelable`
+
+```csharp
+public interface IoT.DriverCore.ModbusRx.Device.ICancelable
+```
+Represents a disposable resource whose disposed state can be inspected.
+
+##### Declared public members
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ICancelable.IsDisposed`
+
+```csharp
+public bool IsDisposed { get; }
+```
+Gets a value indicating whether the resource has been disposed.
+
+- Value: The `IsDisposed` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Device.IModbusMaster`
+
+```csharp
+public interface IoT.DriverCore.ModbusRx.Device.IModbusMaster
+```
+Modbus master device.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Device.IModbusMaster.ReadCoilsAsync(System.Byte,System.UInt16,System.UInt16)`
+
+```csharp
+public System.Threading.Tasks.Task<bool[]> ReadCoilsAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+```
+Asynchronously reads from 1 to 2000 contiguous coils status.
+
+- Parameter `slaveAddress`: Address of device to read values from.
+- Parameter `startAddress`: Address to begin reading.
+- Parameter `numberOfPoints`: Number of coils to read.
+- Returns: A task that represents the asynchronous read operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.IModbusMaster.ReadHoldingRegistersAsync(System.Byte,System.UInt16,System.UInt16)`
+
+```csharp
+public System.Threading.Tasks.Task<ushort[]> ReadHoldingRegistersAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+```
+Asynchronously reads contiguous block of holding registers.
+
+- Parameter `slaveAddress`: Address of device to read values from.
+- Parameter `startAddress`: Address to begin reading.
+- Parameter `numberOfPoints`: Number of holding registers to read.
+- Returns: A task that represents the asynchronous read operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.IModbusMaster.ReadInputRegistersAsync(System.Byte,System.UInt16,System.UInt16)`
+
+```csharp
+public System.Threading.Tasks.Task<ushort[]> ReadInputRegistersAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+```
+Asynchronously reads contiguous block of input registers.
+
+- Parameter `slaveAddress`: Address of device to read values from.
+- Parameter `startAddress`: Address to begin reading.
+- Parameter `numberOfPoints`: Number of holding registers to read.
+- Returns: A task that represents the asynchronous read operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.IModbusMaster.ReadInputsAsync(System.Byte,System.UInt16,System.UInt16)`
+
+```csharp
+public System.Threading.Tasks.Task<bool[]> ReadInputsAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+```
+Asynchronously reads from 1 to 2000 contiguous discrete input status.
+
+- Parameter `slaveAddress`: Address of device to read values from.
+- Parameter `startAddress`: Address to begin reading.
+- Parameter `numberOfPoints`: Number of discrete inputs to read.
+- Returns: A task that represents the asynchronous read operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.IModbusMaster.ReadWriteMultipleRegistersAsync(System.Byte,System.UInt16,System.UInt16,System.UInt16,System.UInt16[])`
+
+```csharp
+public System.Threading.Tasks.Task<ushort[]> ReadWriteMultipleRegistersAsync(byte slaveAddress, ushort startReadAddress, ushort numberOfPointsToRead, ushort startWriteAddress, ushort[] writeData)
+```
+Asynchronously performs a combined write and read holding-register transaction. The write operation is performed before the read.
+
+- Parameter `slaveAddress`: Address of device to read values from.
+- Parameter `startReadAddress`: Address to begin reading (Holding registers are addressed starting at 0).
+- Parameter `numberOfPointsToRead`: Number of registers to read.
+- Parameter `startWriteAddress`: The zero-based holding-register address at which to begin writing.
+- Parameter `writeData`: Register values to write.
+- Returns: A task that represents the asynchronous operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.IModbusMaster.WriteMultipleCoilsAsync(System.Byte,System.UInt16,System.Boolean[])`
+
+```csharp
+public System.Threading.Tasks.Task WriteMultipleCoilsAsync(byte slaveAddress, ushort startAddress, bool[] data)
+```
+Asynchronously writes a sequence of coils.
+
+- Parameter `slaveAddress`: Address of the device to write to.
+- Parameter `startAddress`: Address to begin writing values.
+- Parameter `data`: Values to write.
+- Returns: A task that represents the asynchronous write operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.IModbusMaster.WriteMultipleRegistersAsync(System.Byte,System.UInt16,System.UInt16[])`
+
+```csharp
+public System.Threading.Tasks.Task WriteMultipleRegistersAsync(byte slaveAddress, ushort startAddress, ushort[] data)
+```
+Asynchronously writes a block of 1 to 123 contiguous registers.
+
+- Parameter `slaveAddress`: Address of the device to write to.
+- Parameter `startAddress`: Address to begin writing values.
+- Parameter `data`: Values to write.
+- Returns: A task that represents the asynchronous write operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.IModbusMaster.WriteSingleCoilAsync(System.Byte,System.UInt16,System.Boolean)`
+
+```csharp
+public System.Threading.Tasks.Task WriteSingleCoilAsync(byte slaveAddress, ushort coilAddress, bool value)
+```
+Asynchronously writes a single coil value.
+
+- Parameter `slaveAddress`: Address of the device to write to.
+- Parameter `coilAddress`: Address to write value to.
+- Parameter `value`: Value to write.
+- Returns: A task that represents the asynchronous write operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.IModbusMaster.WriteSingleRegisterAsync(System.Byte,System.UInt16,System.UInt16)`
+
+```csharp
+public System.Threading.Tasks.Task WriteSingleRegisterAsync(byte slaveAddress, ushort registerAddress, ushort value)
+```
+Asynchronously writes a single holding register.
+
+- Parameter `slaveAddress`: Address of the device to write to.
+- Parameter `registerAddress`: Address to write.
+- Parameter `value`: Value to write.
+- Returns: A task that represents the asynchronous write operation.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.IModbusMaster.Transport`
+
+```csharp
+public IoT.DriverCore.ModbusRx.IO.ModbusTransport Transport { get; }
+```
+Gets transport used by this master.
+
+- Value: The `Transport` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster`
+
+```csharp
+public interface IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster
+```
+Modbus Serial Master device.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster.ReturnQueryData(System.Byte,System.UInt16)`
+
+```csharp
+public bool ReturnQueryData(byte slaveAddress, ushort data)
+```
+Performs the serial-line return query diagnostic and verifies the echoed data.
+
+- Parameter `slaveAddress`: Address of device to test.
+- Parameter `data`: Data to return.
+- Returns: Return true if slave device echoed data.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster.Transport`
+
+```csharp
+public IoT.DriverCore.ModbusRx.IO.ModbusSerialTransport Transport { get; }
+```
+Gets transport for used by this master.
+
+- Value: The `Transport` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Device.ModbusDevice`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Device.ModbusDevice
+```
+Modbus device.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusDevice.Dispose`
+
+```csharp
+public void Dispose()
+```
+Releases unmanaged and - optionally - managed resources.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusDevice.IsDisposed`
+
+```csharp
+public bool IsDisposed { get; }
+```
+Gets a value indicating whether gets a value that indicates whether the object is disposed.
+
+- Value: The `IsDisposed` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusDevice.Transport`
+
+```csharp
+public IoT.DriverCore.ModbusRx.IO.ModbusTransport Transport { get; }
+```
+Gets the Modbus Transport.
+
+- Value: The `Transport` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Device.ModbusIpMaster`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Device.ModbusIpMaster
+```
+Modbus IP master device.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusIpMaster.CreateIp(IoT.DriverCore.ModbusRx.IO.IStreamResource)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Device.ModbusIpMaster CreateIp(IoT.DriverCore.ModbusRx.IO.IStreamResource streamResource)
+```
+Modbus IP master factory method.
+
+- Parameter `streamResource`: The stream resource.
+- Returns: streamResource. New instance of Modbus IP master device using provided stream resource.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusIpMaster.CreateIp(IoT.DriverCore.Serial.SerialPortRx)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Device.ModbusIpMaster CreateIp(IoT.DriverCore.Serial.SerialPortRx serialPort)
+```
+Modbus IP master factory method.
+
+- Parameter `serialPort`: The serial port.
+- Returns: serialPort. New instance of Modbus IP master device using provided serial port.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusIpMaster.CreateIp(IoT.DriverCore.Serial.TcpClientRx)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Device.ModbusIpMaster CreateIp(IoT.DriverCore.Serial.TcpClientRx tcpClient)
+```
+Modbus IP master factory method.
+
+- Parameter `tcpClient`: The TCP client.
+- Returns: tcpClient. New instance of Modbus IP master device using provided TCP client.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusIpMaster.CreateIp(IoT.DriverCore.Serial.UdpClientRx)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Device.ModbusIpMaster CreateIp(IoT.DriverCore.Serial.UdpClientRx udpClient)
+```
+Modbus IP master factory method.
+
+- Parameter `udpClient`: The UDP client.
+- Returns: udpClient. New instance of Modbus IP master device using provided UDP client.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusIpMaster.ReadCoilsAsync(System.UInt16,System.UInt16)`
+
+```csharp
+public System.Threading.Tasks.Task<bool[]> ReadCoilsAsync(ushort startAddress, ushort numberOfPoints)
+```
+Asynchronously reads from 1 to 2000 contiguous coils status.
+
+- Parameter `startAddress`: Address to begin reading.
+- Parameter `numberOfPoints`: Number of coils to read.
+- Returns: A task that represents the asynchronous read operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusIpMaster.ReadHoldingRegistersAsync(System.UInt16,System.UInt16)`
+
+```csharp
+public System.Threading.Tasks.Task<ushort[]> ReadHoldingRegistersAsync(ushort startAddress, ushort numberOfPoints)
+```
+Asynchronously reads contiguous block of holding registers.
+
+- Parameter `startAddress`: Address to begin reading.
+- Parameter `numberOfPoints`: Number of holding registers to read.
+- Returns: A task that represents the asynchronous read operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusIpMaster.ReadInputRegistersAsync(System.UInt16,System.UInt16)`
+
+```csharp
+public System.Threading.Tasks.Task<ushort[]> ReadInputRegistersAsync(ushort startAddress, ushort numberOfPoints)
+```
+Asynchronously reads contiguous block of input registers.
+
+- Parameter `startAddress`: Address to begin reading.
+- Parameter `numberOfPoints`: Number of holding registers to read.
+- Returns: A task that represents the asynchronous read operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusIpMaster.ReadInputsAsync(System.UInt16,System.UInt16)`
+
+```csharp
+public System.Threading.Tasks.Task<bool[]> ReadInputsAsync(ushort startAddress, ushort numberOfPoints)
+```
+Asynchronously reads from 1 to 2000 contiguous discrete input status.
+
+- Parameter `startAddress`: Address to begin reading.
+- Parameter `numberOfPoints`: Number of discrete inputs to read.
+- Returns: A task that represents the asynchronous read operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusIpMaster.ReadWriteMultipleRegistersAsync(System.UInt16,System.UInt16,System.UInt16,System.UInt16[])`
+
+```csharp
+public System.Threading.Tasks.Task<ushort[]> ReadWriteMultipleRegistersAsync(ushort startReadAddress, ushort numberOfPointsToRead, ushort startWriteAddress, ushort[] writeData)
+```
+Asynchronously performs a combined write and read holding-register transaction. The write operation is performed before the read.
+
+- Parameter `startReadAddress`: Address to begin reading (Holding registers are addressed starting at 0).
+- Parameter `numberOfPointsToRead`: Number of registers to read.
+- Parameter `startWriteAddress`: The zero-based holding-register address at which to begin writing.
+- Parameter `writeData`: Register values to write.
+- Returns: A task that represents the asynchronous operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusIpMaster.WriteMultipleCoilsAsync(System.UInt16,System.Boolean[])`
+
+```csharp
+public System.Threading.Tasks.Task WriteMultipleCoilsAsync(ushort startAddress, bool[] data)
+```
+Asynchronously writes a sequence of coils.
+
+- Parameter `startAddress`: Address to begin writing values.
+- Parameter `data`: Values to write.
+- Returns: A task that represents the asynchronous write operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusIpMaster.WriteMultipleRegistersAsync(System.UInt16,System.UInt16[])`
+
+```csharp
+public System.Threading.Tasks.Task WriteMultipleRegistersAsync(ushort startAddress, ushort[] data)
+```
+Asynchronously writes a block of 1 to 123 contiguous registers.
+
+- Parameter `startAddress`: Address to begin writing values.
+- Parameter `data`: Values to write.
+- Returns: A task that represents the asynchronous write operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusIpMaster.WriteSingleCoilAsync(System.UInt16,System.Boolean)`
+
+```csharp
+public System.Threading.Tasks.Task WriteSingleCoilAsync(ushort coilAddress, bool value)
+```
+Asynchronously writes a single coil value.
+
+- Parameter `coilAddress`: Address to write value to.
+- Parameter `value`: Value to write.
+- Returns: A task that represents the asynchronous write operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusIpMaster.WriteSingleRegisterAsync(System.UInt16,System.UInt16)`
+
+```csharp
+public System.Threading.Tasks.Task WriteSingleRegisterAsync(ushort registerAddress, ushort value)
+```
+Asynchronously writes a single holding register.
+
+- Parameter `registerAddress`: Address to write.
+- Parameter `value`: Value to write.
+- Returns: A task that represents the asynchronous write operation.
+
+#### `T:IoT.DriverCore.ModbusRx.Device.ModbusMaster`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Device.ModbusMaster
+```
+Modbus master device.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusMaster.ExecuteCustomMessage``1(IoT.DriverCore.ModbusRx.Message.IModbusMessage,System.Func`1{``0})`
+
+```csharp
+public TResponse ExecuteCustomMessage<TResponse>(IoT.DriverCore.ModbusRx.Message.IModbusMessage request, System.Func<TResponse> responseFactory)
+```
+Executes the `ExecuteCustomMessage` operation.
+
+- Parameter `request`: The `request` value.
+- Parameter `responseFactory`: The `responseFactory` value.
+- Returns: A `TResponse` result.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusMaster.ReadCoilsAsync(System.Byte,System.UInt16,System.UInt16)`
+
+```csharp
+public System.Threading.Tasks.Task<bool[]> ReadCoilsAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+```
+Asynchronously reads from 1 to 2000 contiguous coils status.
+
+- Parameter `slaveAddress`: Address of device to read values from.
+- Parameter `startAddress`: Address to begin reading.
+- Parameter `numberOfPoints`: Number of coils to read.
+- Returns: A task that represents the asynchronous read operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusMaster.ReadHoldingRegistersAsync(System.Byte,System.UInt16,System.UInt16)`
+
+```csharp
+public System.Threading.Tasks.Task<ushort[]> ReadHoldingRegistersAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+```
+Asynchronously reads contiguous block of holding registers.
+
+- Parameter `slaveAddress`: Address of device to read values from.
+- Parameter `startAddress`: Address to begin reading.
+- Parameter `numberOfPoints`: Number of holding registers to read.
+- Returns: A task that represents the asynchronous read operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusMaster.ReadInputRegistersAsync(System.Byte,System.UInt16,System.UInt16)`
+
+```csharp
+public System.Threading.Tasks.Task<ushort[]> ReadInputRegistersAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+```
+Asynchronously reads contiguous block of input registers.
+
+- Parameter `slaveAddress`: Address of device to read values from.
+- Parameter `startAddress`: Address to begin reading.
+- Parameter `numberOfPoints`: Number of holding registers to read.
+- Returns: A task that represents the asynchronous read operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusMaster.ReadInputsAsync(System.Byte,System.UInt16,System.UInt16)`
+
+```csharp
+public System.Threading.Tasks.Task<bool[]> ReadInputsAsync(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+```
+Asynchronously reads from 1 to 2000 contiguous discrete input status.
+
+- Parameter `slaveAddress`: Address of device to read values from.
+- Parameter `startAddress`: Address to begin reading.
+- Parameter `numberOfPoints`: Number of discrete inputs to read.
+- Returns: A task that represents the asynchronous read operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusMaster.ReadWriteMultipleRegistersAsync(System.Byte,System.UInt16,System.UInt16,System.UInt16,System.UInt16[])`
+
+```csharp
+public System.Threading.Tasks.Task<ushort[]> ReadWriteMultipleRegistersAsync(byte slaveAddress, ushort startReadAddress, ushort numberOfPointsToRead, ushort startWriteAddress, ushort[] writeData)
+```
+Asynchronously performs a combined write and read holding-register transaction. The write operation is performed before the read.
+
+- Parameter `slaveAddress`: Address of device to read values from.
+- Parameter `startReadAddress`: Address to begin reading (Holding registers are addressed starting at 0).
+- Parameter `numberOfPointsToRead`: Number of registers to read.
+- Parameter `startWriteAddress`: The zero-based holding-register address at which to begin writing.
+- Parameter `writeData`: Register values to write.
+- Returns: A task that represents the asynchronous operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusMaster.WriteMultipleCoilsAsync(System.Byte,System.UInt16,System.Boolean[])`
+
+```csharp
+public System.Threading.Tasks.Task WriteMultipleCoilsAsync(byte slaveAddress, ushort startAddress, bool[] data)
+```
+Asynchronously writes a sequence of coils.
+
+- Parameter `slaveAddress`: Address of the device to write to.
+- Parameter `startAddress`: Address to begin writing values.
+- Parameter `data`: Values to write.
+- Returns: A task that represents the asynchronous write operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusMaster.WriteMultipleRegistersAsync(System.Byte,System.UInt16,System.UInt16[])`
+
+```csharp
+public System.Threading.Tasks.Task WriteMultipleRegistersAsync(byte slaveAddress, ushort startAddress, ushort[] data)
+```
+Asynchronously writes a block of 1 to 123 contiguous registers.
+
+- Parameter `slaveAddress`: Address of the device to write to.
+- Parameter `startAddress`: Address to begin writing values.
+- Parameter `data`: Values to write.
+- Returns: A task that represents the asynchronous write operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusMaster.WriteSingleCoilAsync(System.Byte,System.UInt16,System.Boolean)`
+
+```csharp
+public System.Threading.Tasks.Task WriteSingleCoilAsync(byte slaveAddress, ushort coilAddress, bool value)
+```
+Asynchronously writes a single coil value.
+
+- Parameter `slaveAddress`: Address of the device to write to.
+- Parameter `coilAddress`: Address to write value to.
+- Parameter `value`: Value to write.
+- Returns: A task that represents the asynchronous write operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusMaster.WriteSingleRegisterAsync(System.Byte,System.UInt16,System.UInt16)`
+
+```csharp
+public System.Threading.Tasks.Task WriteSingleRegisterAsync(byte slaveAddress, ushort registerAddress, ushort value)
+```
+Asynchronously writes a single holding register.
+
+- Parameter `slaveAddress`: Address of the device to write to.
+- Parameter `registerAddress`: Address to write.
+- Parameter `value`: Value to write.
+- Returns: A task that represents the asynchronous write operation.
+
+#### `T:IoT.DriverCore.ModbusRx.Device.ModbusSerialMaster`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Device.ModbusSerialMaster
+```
+Modbus serial master device.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSerialMaster.CreateAscii(IoT.DriverCore.ModbusRx.IO.IStreamResource)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Device.ModbusSerialMaster CreateAscii(IoT.DriverCore.ModbusRx.IO.IStreamResource streamResource)
+```
+Modbus ASCII master factory method.
+
+- Parameter `streamResource`: The stream resource.
+- Returns: A ModbusSerialMaster.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSerialMaster.CreateAscii(IoT.DriverCore.Serial.SerialPortRx)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Device.ModbusSerialMaster CreateAscii(IoT.DriverCore.Serial.SerialPortRx serialPort)
+```
+Modbus ASCII master factory method.
+
+- Parameter `serialPort`: The serial port.
+- Returns: A ModbusSerialMaster.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSerialMaster.CreateAscii(IoT.DriverCore.Serial.TcpClientRx)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Device.ModbusSerialMaster CreateAscii(IoT.DriverCore.Serial.TcpClientRx tcpClient)
+```
+Modbus ASCII master factory method.
+
+- Parameter `tcpClient`: The TCP client.
+- Returns: A ModbusSerialMaster.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSerialMaster.CreateAscii(IoT.DriverCore.Serial.UdpClientRx)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Device.ModbusSerialMaster CreateAscii(IoT.DriverCore.Serial.UdpClientRx udpClient)
+```
+Modbus ASCII master factory method.
+
+- Parameter `udpClient`: The UDP client.
+- Returns: A ModbusSerialMaster.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSerialMaster.CreateRtu(IoT.DriverCore.ModbusRx.IO.IStreamResource)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Device.ModbusSerialMaster CreateRtu(IoT.DriverCore.ModbusRx.IO.IStreamResource streamResource)
+```
+Modbus RTU master factory method.
+
+- Parameter `streamResource`: The stream resource.
+- Returns: A ModbusSerialMaster.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSerialMaster.CreateRtu(IoT.DriverCore.Serial.SerialPortRx)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Device.ModbusSerialMaster CreateRtu(IoT.DriverCore.Serial.SerialPortRx serialPort)
+```
+Modbus RTU master factory method.
+
+- Parameter `serialPort`: The serial port.
+- Returns: A ModbusSerialMaster.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSerialMaster.CreateRtu(IoT.DriverCore.Serial.TcpClientRx)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Device.ModbusSerialMaster CreateRtu(IoT.DriverCore.Serial.TcpClientRx tcpClient)
+```
+Modbus RTU master factory method.
+
+- Parameter `tcpClient`: The TCP client.
+- Returns: A ModbusSerialMaster.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSerialMaster.CreateRtu(IoT.DriverCore.Serial.UdpClientRx)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Device.ModbusSerialMaster CreateRtu(IoT.DriverCore.Serial.UdpClientRx udpClient)
+```
+Modbus RTU master factory method.
+
+- Parameter `udpClient`: The UDP client.
+- Returns: A ModbusSerialMaster.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSerialMaster.ReturnQueryData(System.Byte,System.UInt16)`
+
+```csharp
+public bool ReturnQueryData(byte slaveAddress, ushort data)
+```
+Performs the serial-line return query diagnostic and verifies the echoed data.
+
+- Parameter `slaveAddress`: Address of device to test.
+- Parameter `data`: Data to return.
+- Returns: Return true if slave device echoed data.
+
+#### `T:IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave
+```
+Modbus serial slave device.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave.CreateAscii(System.Byte,IoT.DriverCore.ModbusRx.IO.IStreamResource)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave CreateAscii(byte unitId, IoT.DriverCore.ModbusRx.IO.IStreamResource streamResource)
+```
+Modbus ASCII slave factory method.
+
+- Parameter `unitId`: The unit identifier.
+- Parameter `streamResource`: The stream resource.
+- Returns: A ModbusSerialSlave.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave.CreateAscii(System.Byte,IoT.DriverCore.Serial.SerialPortRx)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave CreateAscii(byte unitId, IoT.DriverCore.Serial.SerialPortRx serialPort)
+```
+Modbus ASCII slave factory method.
+
+- Parameter `unitId`: The unit identifier.
+- Parameter `serialPort`: The serial port.
+- Returns: A ModbusSerialSlave.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave.CreateRtu(System.Byte,IoT.DriverCore.ModbusRx.IO.IStreamResource)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave CreateRtu(byte unitId, IoT.DriverCore.ModbusRx.IO.IStreamResource streamResource)
+```
+Modbus RTU slave factory method.
+
+- Parameter `unitId`: The unit identifier.
+- Parameter `streamResource`: The stream resource.
+- Returns: A ModbusSerialSlave.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave.CreateRtu(System.Byte,IoT.DriverCore.Serial.SerialPortRx)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave CreateRtu(byte unitId, IoT.DriverCore.Serial.SerialPortRx serialPort)
+```
+Modbus RTU slave factory method.
+
+- Parameter `unitId`: The unit identifier.
+- Parameter `serialPort`: The serial port.
+- Returns: A ModbusSerialSlave.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave.ListenAsync`
+
+```csharp
+public System.Threading.Tasks.Task ListenAsync()
+```
+Start slave listening for requests.
+
+- Returns: A `T:System.Threading.Tasks.Task` representing the asynchronous operation.
+
+#### `T:IoT.DriverCore.ModbusRx.Device.ModbusServer`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Device.ModbusServer
+```
+A reactive Modbus server that can serve multiple clients via TCP/UDP. Supports unified client aggregation and simulation modes.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusServer.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Device.ModbusServer()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Device.ModbusServer` class.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusServer.AddTcpClient(System.String,System.String,System.Int32,System.Byte)`
+
+```csharp
+public System.IDisposable AddTcpClient(string name, string hostAddress, int port, byte slaveAddress)
+```
+Adds a Modbus TCP/IP client to serve data from.
+
+- Parameter `name`: The name identifier for the client.
+- Parameter `hostAddress`: The host address of the client.
+- Parameter `port`: The port number.
+- Parameter `slaveAddress`: The slave address.
+- Returns: A disposable subscription.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusServer.AddUdpClient(System.String,System.String,System.Int32,System.Byte)`
+
+```csharp
+public System.IDisposable AddUdpClient(string name, string hostAddress, int port, byte slaveAddress)
+```
+Adds a Modbus UDP client to serve data from.
+
+- Parameter `name`: The name identifier for the client.
+- Parameter `hostAddress`: The host address of the client.
+- Parameter `port`: The port number.
+- Parameter `slaveAddress`: The slave address.
+- Returns: A disposable subscription.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusServer.Dispose`
+
+```csharp
+public void Dispose()
+```
+Disposes the server and all resources.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusServer.GetCurrentData`
+
+```csharp
+public System.ValueTuple<ushort[], ushort[], bool[], bool[]> GetCurrentData()
+```
+Gets the current data from the server's data store.
+
+- Returns: A snapshot of the current data.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusServer.LoadSimulationData(System.UInt16[],System.UInt16[],System.Boolean[],System.Boolean[])`
+
+```csharp
+public void LoadSimulationData(ushort[] holdingRegisters, ushort[] inputRegisters, bool[] coils, bool[] inputs)
+```
+Loads simulation data from specified values for testing.
+
+- Parameter `holdingRegisters`: Holding register values.
+- Parameter `inputRegisters`: Input register values.
+- Parameter `coils`: Coil values.
+- Parameter `inputs`: Input values.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusServer.Start`
+
+```csharp
+public void Start()
+```
+Starts the server with all configured endpoints.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusServer.StartTcpServer(System.Int32,System.Byte)`
+
+```csharp
+public System.IDisposable StartTcpServer(int port, byte unitId)
+```
+Starts a TCP server on the specified port.
+
+- Parameter `port`: The port to listen on.
+- Parameter `unitId`: The unit ID for the slave.
+- Returns: A disposable subscription.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusServer.StartUdpServer(System.Int32,System.Byte)`
+
+```csharp
+public System.IDisposable StartUdpServer(int port, byte unitId)
+```
+Starts a UDP server on the specified port.
+
+- Parameter `port`: The port to listen on.
+- Parameter `unitId`: The unit ID for the slave.
+- Returns: A disposable subscription.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusServer.Stop`
+
+```csharp
+public void Stop()
+```
+Stops the server and all endpoints.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusServer.DataStore`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.DataStore DataStore { get; set; }
+```
+Gets or sets the data store for the server.
+
+- Value: The `DataStore` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusServer.IsRunning`
+
+```csharp
+public System.IObservable<bool> IsRunning { get; }
+```
+Gets an observable that indicates if the server is running.
+
+- Value: The `IsRunning` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusServer.SimulationMode`
+
+```csharp
+public bool SimulationMode { get; set; }
+```
+Gets or sets a value indicating whether simulation mode is enabled.
+
+- Value: The `SimulationMode` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Device.ModbusSimulator`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Device.ModbusSimulator
+```
+Provides a deterministic, stateful Modbus device for development, testing, and offline operation.
+
+##### Declared public members
+
+###### `E:IoT.DriverCore.ModbusRx.Device.ModbusSimulator.RequestProcessed`
+
+```csharp
+public event System.EventHandler<IoT.DriverCore.ModbusRx.Device.ModbusSimulatorRequestEventArgs> RequestProcessed
+```
+Occurs after a complete request frame has been accepted by the simulator.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSimulator.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Device.ModbusSimulator()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Device.ModbusSimulator` class.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSimulator.#ctor(System.Byte)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Device.ModbusSimulator(byte unitId)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Device.ModbusSimulator` class.
+
+- Parameter `unitId`: The Modbus unit identifier.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSimulator.#ctor(System.Byte,IoT.DriverCore.ModbusRx.Data.DataStore)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Device.ModbusSimulator(byte unitId, IoT.DriverCore.ModbusRx.Data.DataStore dataStore)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Device.ModbusSimulator` class.
+
+- Parameter `unitId`: The Modbus unit identifier.
+- Parameter `dataStore`: The persistent device memory used by the simulator.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSimulator.#ctor(System.Byte,IoT.DriverCore.ModbusRx.Data.DataStore,System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Device.ModbusSimulator(byte unitId, IoT.DriverCore.ModbusRx.Data.DataStore dataStore, System.TimeProvider timeProvider)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Device.ModbusSimulator` class.
+
+- Parameter `unitId`: The Modbus unit identifier.
+- Parameter `dataStore`: The persistent device memory used by the simulator.
+- Parameter `timeProvider`: The time provider used for request-event timestamps.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSimulator.ClearFaults`
+
+```csharp
+public void ClearFaults()
+```
+Removes every scripted fault that has not yet been applied.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSimulator.CreateMaster`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Device.ModbusIpMaster CreateMaster()
+```
+Creates a Modbus IP master connected through a complete in-memory MBAP transport.
+
+- Returns: A master that communicates with this simulator.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSimulator.Dispose`
+
+```csharp
+public void Dispose()
+```
+Disposes simulator endpoints and owned resources.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSimulator.QueueFault(IoT.DriverCore.ModbusRx.Device.ModbusSimulatorFaultKind)`
+
+```csharp
+public void QueueFault(IoT.DriverCore.ModbusRx.Device.ModbusSimulatorFaultKind fault)
+```
+Queues a deterministic fault for the next request.
+
+- Parameter `fault`: The fault to apply.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSimulator.StartTcpLoopback`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Device.ModbusTcpLoopbackEndpoint StartTcpLoopback()
+```
+Starts an IPv4 loopback TCP endpoint on an operating-system assigned port.
+
+- Returns: An endpoint that creates masters connected through the real socket stack.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusSimulator.DataStore`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.DataStore DataStore { get; }
+```
+Gets the persistent Modbus device memory.
+
+- Value: The `DataStore` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusSimulator.RequestCount`
+
+```csharp
+public long RequestCount { get; }
+```
+Gets the number of requests accepted by the simulator.
+
+- Value: The `RequestCount` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusSimulator.ResponseDelay`
+
+```csharp
+public System.TimeSpan ResponseDelay { get; set; }
+```
+Gets or sets a delay applied before each in-memory response is made available.
+
+- Value: The `ResponseDelay` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusSimulator.UnitId`
+
+```csharp
+public byte UnitId { get; }
+```
+Gets the Modbus unit identifier served by this simulator.
+
+- Value: The `UnitId` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Device.ModbusSimulatorFaultKind`
+
+```csharp
+public enum IoT.DriverCore.ModbusRx.Device.ModbusSimulatorFaultKind
+```
+Identifies a deterministic fault applied to the next simulator request.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.ModbusRx.Device.ModbusSimulatorFaultKind.CorruptTransactionId`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Device.ModbusSimulatorFaultKind CorruptTransactionId
+```
+The device returns a response with a different transaction identifier.
+
+###### `F:IoT.DriverCore.ModbusRx.Device.ModbusSimulatorFaultKind.IOException`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Device.ModbusSimulatorFaultKind IOException
+```
+The request fails while it is written to the in-memory transport.
+
+###### `F:IoT.DriverCore.ModbusRx.Device.ModbusSimulatorFaultKind.None`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Device.ModbusSimulatorFaultKind None
+```
+No fault is applied.
+
+###### `F:IoT.DriverCore.ModbusRx.Device.ModbusSimulatorFaultKind.SlaveDeviceBusy`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Device.ModbusSimulatorFaultKind SlaveDeviceBusy
+```
+The device returns the Modbus slave-device-busy exception.
+
+###### `F:IoT.DriverCore.ModbusRx.Device.ModbusSimulatorFaultKind.Timeout`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Device.ModbusSimulatorFaultKind Timeout
+```
+The response read fails with a timeout.
+
+#### `T:IoT.DriverCore.ModbusRx.Device.ModbusSimulatorRequestEventArgs`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Device.ModbusSimulatorRequestEventArgs
+```
+Provides details about a request processed by a `T:IoT.DriverCore.ModbusRx.Device.ModbusSimulator` .
+
+##### Declared public members
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusSimulatorRequestEventArgs.Fault`
+
+```csharp
+public System.Nullable<IoT.DriverCore.ModbusRx.Device.ModbusSimulatorFaultKind> Fault { get; }
+```
+Gets the scripted fault applied to the request, if any.
+
+- Value: The `Fault` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusSimulatorRequestEventArgs.Request`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.IModbusMessage Request { get; }
+```
+Gets the request received by the simulator.
+
+- Value: The `Request` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusSimulatorRequestEventArgs.Response`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.IModbusMessage Response { get; }
+```
+Gets the response produced by the simulator, if any.
+
+- Value: The `Response` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusSimulatorRequestEventArgs.Timestamp`
+
+```csharp
+public System.DateTimeOffset Timestamp { get; }
+```
+Gets the time at which the request was processed.
+
+- Value: The `Timestamp` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Device.ModbusSlave`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Device.ModbusSlave
+```
+Modbus slave device.
+
+##### Declared public members
+
+###### `E:IoT.DriverCore.ModbusRx.Device.ModbusSlave.ModbusSlaveRequestReceived`
+
+```csharp
+public event System.EventHandler<IoT.DriverCore.ModbusRx.Device.ModbusSlaveRequestEventArgs> ModbusSlaveRequestReceived
+```
+Raised when a Modbus slave receives a request, before processing request function.
+
+###### `E:IoT.DriverCore.ModbusRx.Device.ModbusSlave.WriteComplete`
+
+```csharp
+public event System.EventHandler<IoT.DriverCore.ModbusRx.Device.ModbusSlaveRequestEventArgs> WriteComplete
+```
+Raised after a Modbus slave processes the write portion of a request.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusSlave.ListenAsync`
+
+```csharp
+public System.Threading.Tasks.Task ListenAsync()
+```
+Start slave listening for requests.
+
+- Returns: A Task.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusSlave.DataStore`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Data.DataStore DataStore { get; set; }
+```
+Gets or sets the data store.
+
+- Value: The `DataStore` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusSlave.UnitId`
+
+```csharp
+public byte UnitId { get; set; }
+```
+Gets or sets the unit ID.
+
+- Value: The `UnitId` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Device.ModbusSlaveRequestEventArgs`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Device.ModbusSlaveRequestEventArgs
+```
+Modbus Slave request event args containing information on the message.
+
+##### Declared public members
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusSlaveRequestEventArgs.Message`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.IModbusMessage Message { get; }
+```
+Gets the message.
+
+- Value: The `Message` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Device.ModbusTcpLoopbackEndpoint`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Device.ModbusTcpLoopbackEndpoint
+```
+Represents a running IPv4 Modbus TCP loopback endpoint.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusTcpLoopbackEndpoint.CreateMaster`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Device.ModbusIpMaster CreateMaster()
+```
+Creates a Modbus IP master connected through the operating-system TCP stack.
+
+- Returns: A connected master.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusTcpLoopbackEndpoint.Dispose`
+
+```csharp
+public void Dispose()
+```
+Stops the listener and disconnects its masters.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusTcpLoopbackEndpoint.Completion`
+
+```csharp
+public System.Threading.Tasks.Task Completion { get; }
+```
+Gets the listener completion task.
+
+- Value: The `Completion` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusTcpLoopbackEndpoint.EndPoint`
+
+```csharp
+public System.Net.IPEndPoint EndPoint { get; }
+```
+Gets the bound IPv4 loopback endpoint.
+
+- Value: The `EndPoint` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusTcpLoopbackEndpoint.Port`
+
+```csharp
+public int Port { get; }
+```
+Gets the operating-system assigned TCP port.
+
+- Value: The `Port` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave
+```
+Modbus TCP slave device.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave.CreateTcp(System.Byte,System.Net.Sockets.TcpListener)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave CreateTcp(byte unitId, System.Net.Sockets.TcpListener tcpListener)
+```
+Modbus TCP slave factory method.
+
+- Parameter `unitId`: The unit identifier.
+- Parameter `tcpListener`: The TCP listener.
+- Returns: A ModbusTcpSlave.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave.ListenAsync`
+
+```csharp
+public System.Threading.Tasks.Task ListenAsync()
+```
+Start slave listening for requests.
+
+- Returns: A `T:System.Threading.Tasks.Task` representing the asynchronous operation.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave.IsListening`
+
+```csharp
+public bool IsListening { get; }
+```
+Gets a value indicating whether this slave currently owns an active accept loop.
+
+- Value: The `IsListening` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave.Masters`
+
+```csharp
+public System.Collections.ObjectModel.ReadOnlyCollection<IoT.DriverCore.Serial.TcpClientRx> Masters { get; }
+```
+Gets the Modbus TCP Masters connected to this Modbus TCP Slave.
+
+- Value: The `Masters` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave
+```
+Modbus UDP slave device.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave.CreateUdp(IoT.DriverCore.Serial.UdpClientRx)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave CreateUdp(IoT.DriverCore.Serial.UdpClientRx client)
+```
+Modbus UDP slave factory method. Creates NModbus UDP slave with default.
+
+- Parameter `client`: The client.
+- Returns: A ModbusUdpSlave.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave.CreateUdp(System.Byte,IoT.DriverCore.Serial.UdpClientRx)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave CreateUdp(byte unitId, IoT.DriverCore.Serial.UdpClientRx client)
+```
+Modbus UDP slave factory method.
+
+- Parameter `unitId`: The unit identifier.
+- Parameter `client`: The client.
+- Returns: A ModbusUdpSlave.
+
+###### `M:IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave.ListenAsync`
+
+```csharp
+public System.Threading.Tasks.Task ListenAsync()
+```
+Start slave listening for requests.
+
+- Returns: A `T:System.Threading.Tasks.Task` representing the asynchronous operation.
+
+#### `T:IoT.DriverCore.ModbusRx.EnhancedModbusServerExtensions`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.EnhancedModbusServerExtensions
+```
+Enhanced reactive extensions for ModbusServer with performance optimizations.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.EnhancedModbusServerExtensions.ObserveCoilsOptimized(IoT.DriverCore.ModbusRx.Device.ModbusServer,System.UInt16,System.UInt16,System.Int32)`
+
+```csharp
+public static System.IObservable<bool[]> ObserveCoilsOptimized(IoT.DriverCore.ModbusRx.Device.ModbusServer server, ushort startAddress, ushort count, int interval)
+```
+Observes coil changes with range filtering.
+
+- Parameter `server`: The extension receiver.
+- Parameter `startAddress`: The start address to observe.
+- Parameter `count`: The number of coils to observe.
+- Parameter `interval`: The observation interval in milliseconds.
+- Returns: An observable of coil values.
+
+###### `M:IoT.DriverCore.ModbusRx.EnhancedModbusServerExtensions.ObserveDataChangesBuffered(IoT.DriverCore.ModbusRx.Device.ModbusServer,System.Int32,System.Int32)`
+
+```csharp
+public static System.IObservable<IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot[]> ObserveDataChangesBuffered(IoT.DriverCore.ModbusRx.Device.ModbusServer server, int bufferSize, int bufferTimeMilliseconds)
+```
+Creates a buffered observable with change detection and batching.
+
+- Parameter `server`: The extension receiver.
+- Parameter `bufferSize`: The buffer size for batching changes.
+- Parameter `bufferTimeMilliseconds`: The buffer time window in milliseconds.
+- Returns: An observable of batched data changes.
+
+###### `M:IoT.DriverCore.ModbusRx.EnhancedModbusServerExtensions.ObserveDataChangesBuffered(IoT.DriverCore.ModbusRx.Device.ModbusServer,System.Int32,System.Int32,System.TimeProvider)`
+
+```csharp
+public static System.IObservable<IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot[]> ObserveDataChangesBuffered(IoT.DriverCore.ModbusRx.Device.ModbusServer server, int bufferSize, int bufferTimeMilliseconds, System.TimeProvider timeProvider)
+```
+Creates a buffered observable with change detection and batching.
+
+- Parameter `server`: The extension receiver.
+- Parameter `bufferSize`: The buffer size for batching changes.
+- Parameter `bufferTimeMilliseconds`: The buffer time window in milliseconds.
+- Parameter `timeProvider`: The time provider used for snapshot timestamps.
+- Returns: An observable of batched data changes.
+
+###### `M:IoT.DriverCore.ModbusRx.EnhancedModbusServerExtensions.ObserveDataChangesEventDriven(IoT.DriverCore.ModbusRx.Device.ModbusServer)`
+
+```csharp
+public static System.IObservable<IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot> ObserveDataChangesEventDriven(IoT.DriverCore.ModbusRx.Device.ModbusServer server)
+```
+Observes data-store writes without polling or elapsed-time dependencies.
+
+- Parameter `server`: The extension receiver.
+- Returns: An observable that emits one snapshot for each completed data-store write.
+
+###### `M:IoT.DriverCore.ModbusRx.EnhancedModbusServerExtensions.ObserveDataChangesEventDriven(IoT.DriverCore.ModbusRx.Device.ModbusServer,System.TimeProvider,IoT.DriverCore.ModbusRx.ModbusObservationMetrics)`
+
+```csharp
+public static System.IObservable<IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot> ObserveDataChangesEventDriven(IoT.DriverCore.ModbusRx.Device.ModbusServer server, System.TimeProvider timeProvider, IoT.DriverCore.ModbusRx.ModbusObservationMetrics metrics)
+```
+Observes data-store writes without polling or elapsed-time dependencies.
+
+- Parameter `server`: The extension receiver.
+- Parameter `timeProvider`: The time provider used for snapshot timestamps.
+- Parameter `metrics`: Optional deterministic observation counters.
+- Returns: An observable that emits one snapshot for each completed data-store write.
+
+###### `M:IoT.DriverCore.ModbusRx.EnhancedModbusServerExtensions.ObserveDataChangesOptimized(IoT.DriverCore.ModbusRx.Device.ModbusServer,System.Int32)`
+
+```csharp
+public static System.IObservable<IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot> ObserveDataChangesOptimized(IoT.DriverCore.ModbusRx.Device.ModbusServer server, int interval)
+```
+Observes data changes in the server with high-performance optimizations.
+
+- Parameter `server`: The extension receiver.
+- Parameter `interval`: The observation interval in milliseconds.
+- Returns: An observable of data changes.
+
+###### `M:IoT.DriverCore.ModbusRx.EnhancedModbusServerExtensions.ObserveDataChangesOptimized(IoT.DriverCore.ModbusRx.Device.ModbusServer,System.Int32,System.TimeProvider)`
+
+```csharp
+public static System.IObservable<IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot> ObserveDataChangesOptimized(IoT.DriverCore.ModbusRx.Device.ModbusServer server, int interval, System.TimeProvider timeProvider)
+```
+Observes data changes in the server with high-performance optimizations.
+
+- Parameter `server`: The extension receiver.
+- Parameter `interval`: The observation interval in milliseconds.
+- Parameter `timeProvider`: The time provider used for snapshot timestamps.
+- Returns: An observable of data changes.
+
+###### `M:IoT.DriverCore.ModbusRx.EnhancedModbusServerExtensions.ObserveHoldingRegistersOptimized(IoT.DriverCore.ModbusRx.Device.ModbusServer,System.UInt16,System.UInt16,System.Int32)`
+
+```csharp
+public static System.IObservable<ushort[]> ObserveHoldingRegistersOptimized(IoT.DriverCore.ModbusRx.Device.ModbusServer server, ushort startAddress, ushort count, int interval)
+```
+Observes holding register changes with range filtering.
+
+- Parameter `server`: The extension receiver.
+- Parameter `startAddress`: The start address to observe.
+- Parameter `count`: The number of registers to observe.
+- Parameter `interval`: The observation interval in milliseconds.
+- Returns: An observable of register values.
+
+#### `T:IoT.DriverCore.ModbusRx.Extensions.Enron.EnronModbusExtensions`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Extensions.Enron.EnronModbusExtensions
+```
+Utility extensions for the Enron Modbus dialect.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Extensions.Enron.EnronModbusExtensions.ReadHoldingRegisters32Async(IoT.DriverCore.ModbusRx.Device.ModbusMaster,System.Byte,System.UInt16,System.UInt16)`
+
+```csharp
+public static System.Threading.Tasks.Task<uint[]> ReadHoldingRegisters32Async(IoT.DriverCore.ModbusRx.Device.ModbusMaster master, byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+```
+Read contiguous block of 32 bit holding registers.
+
+- Parameter `master`: The extension receiver.
+- Parameter `slaveAddress`: Address of device to read values from.
+- Parameter `startAddress`: Address to begin reading.
+- Parameter `numberOfPoints`: Number of holding registers to read.
+- Returns: Holding registers status.
+
+###### `M:IoT.DriverCore.ModbusRx.Extensions.Enron.EnronModbusExtensions.ReadInputRegisters32Async(IoT.DriverCore.ModbusRx.Device.ModbusMaster,System.Byte,System.UInt16,System.UInt16)`
+
+```csharp
+public static System.Threading.Tasks.Task<uint[]> ReadInputRegisters32Async(IoT.DriverCore.ModbusRx.Device.ModbusMaster master, byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+```
+Read contiguous block of 32 bit input registers.
+
+- Parameter `master`: The extension receiver.
+- Parameter `slaveAddress`: Address of device to read values from.
+- Parameter `startAddress`: Address to begin reading.
+- Parameter `numberOfPoints`: Number of holding registers to read.
+- Returns: Input registers status.
+
+###### `M:IoT.DriverCore.ModbusRx.Extensions.Enron.EnronModbusExtensions.WriteMultipleRegisters32Async(IoT.DriverCore.ModbusRx.Device.ModbusMaster,System.Byte,System.UInt16,System.UInt32[])`
+
+```csharp
+public static System.Threading.Tasks.Task WriteMultipleRegisters32Async(IoT.DriverCore.ModbusRx.Device.ModbusMaster master, byte slaveAddress, ushort startAddress, uint[] data)
+```
+Write a block of contiguous 32 bit holding registers.
+
+- Parameter `master`: The extension receiver.
+- Parameter `slaveAddress`: Address of the device to write to.
+- Parameter `startAddress`: Address to begin writing values.
+- Parameter `data`: Values to write.
+- Returns: A `T:System.Threading.Tasks.Task` representing the asynchronous operation.
+
+###### `M:IoT.DriverCore.ModbusRx.Extensions.Enron.EnronModbusExtensions.WriteSingleRegister32Async(IoT.DriverCore.ModbusRx.Device.ModbusMaster,System.Byte,System.UInt16,System.UInt32)`
+
+```csharp
+public static System.Threading.Tasks.Task WriteSingleRegister32Async(IoT.DriverCore.ModbusRx.Device.ModbusMaster master, byte slaveAddress, ushort registerAddress, uint value)
+```
+Write a single 16 bit holding register.
+
+- Parameter `master`: The extension receiver.
+- Parameter `slaveAddress`: Address of the device to write to.
+- Parameter `registerAddress`: Address to write.
+- Parameter `value`: Value to write.
+- Returns: A task representing the asynchronous operation.
+
+#### `T:IoT.DriverCore.ModbusRx.IO.EmptyTransport`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.IO.EmptyTransport
+```
+Provides EmptyTransport functionality.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.IO.EmptyTransport.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.IO.EmptyTransport()
+```
+Initializes a new instance of `IoT.DriverCore.ModbusRx.IO.EmptyTransport`.
+
+#### `T:IoT.DriverCore.ModbusRx.IO.IStreamResource`
+
+```csharp
+public interface IoT.DriverCore.ModbusRx.IO.IStreamResource
+```
+Represents a serial resource. Implementor - http://en.wikipedia.org/wiki/Bridge_Pattern.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.IO.IStreamResource.DiscardInBuffer`
+
+```csharp
+public void DiscardInBuffer()
+```
+Purges the receive buffer.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.IStreamResource.ReadAsync(System.Byte[],System.Int32,System.Int32)`
+
+```csharp
+public System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count)
+```
+Reads bytes into a byte array at the specified offset.
+
+- Parameter `buffer`: The byte array to write the input to.
+- Parameter `offset`: The offset in the buffer array to begin writing.
+- Parameter `count`: The number of bytes to read.
+- Returns: The number of bytes read.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.IStreamResource.Write(System.Byte[],System.Int32,System.Int32)`
+
+```csharp
+public void Write(byte[] buffer, int offset, int count)
+```
+Writes bytes from an output buffer, starting at the specified offset.
+
+- Parameter `buffer`: The byte array that contains the data to write to the port.
+- Parameter `offset`: The offset in the buffer array to begin writing.
+- Parameter `count`: The number of bytes to write.
+
+###### `P:IoT.DriverCore.ModbusRx.IO.IStreamResource.InfiniteTimeout`
+
+```csharp
+public int InfiniteTimeout { get; }
+```
+Gets indicates that no timeout should occur.
+
+- Value: The `InfiniteTimeout` value.
+
+###### `P:IoT.DriverCore.ModbusRx.IO.IStreamResource.ReadTimeout`
+
+```csharp
+public int ReadTimeout { get; set; }
+```
+Gets or sets the read-operation timeout in milliseconds.
+
+- Value: The `ReadTimeout` value.
+
+###### `P:IoT.DriverCore.ModbusRx.IO.IStreamResource.WriteTimeout`
+
+```csharp
+public int WriteTimeout { get; set; }
+```
+Gets or sets the write-operation timeout in milliseconds.
+
+- Value: The `WriteTimeout` value.
+
+#### `T:IoT.DriverCore.ModbusRx.IO.ModbusBufferManager`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.IO.ModbusBufferManager
+```
+High-performance buffer manager for Modbus message processing with cross-platform compatibility.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.IO.ModbusBufferManager.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.IO.ModbusBufferManager()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.IO.ModbusBufferManager` class.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.ModbusBufferManager.ClearArray``1(``0[])`
+
+```csharp
+public static void ClearArray<T>(T[] array)
+```
+Clears an array with high performance.
+
+- Parameter `array`: The array to clear.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.ModbusBufferManager.CompareArrays``1(``0[],``0[])`
+
+```csharp
+public static bool CompareArrays<T>(T[] array1, T[] array2)
+```
+Performs a high-performance comparison between two arrays.
+
+- Parameter `array1`: The first array.
+- Parameter `array2`: The second array.
+- Returns: True if the arrays are equal in content.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.ModbusBufferManager.CopyDataAndTrack``1(``0[],System.Int32,``0[],System.Int32,System.Int32)`
+
+```csharp
+public int CopyDataAndTrack<T>(T[] source, int sourceIndex, T[] destination, int destinationIndex, int length)
+```
+Copies data and records deterministic operation and element-copy counts.
+
+- Parameter `source`: The source array.
+- Parameter `sourceIndex`: The source index.
+- Parameter `destination`: The destination array.
+- Parameter `destinationIndex`: The destination index.
+- Parameter `length`: The requested element count.
+- Returns: The number of copied elements.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.ModbusBufferManager.CopyData``1(``0[],System.Int32,``0[],System.Int32,System.Int32)`
+
+```csharp
+public static int CopyData<T>(T[] source, int sourceIndex, T[] destination, int destinationIndex, int length)
+```
+Copies data efficiently between arrays.
+
+- Parameter `source`: The source array.
+- Parameter `sourceIndex`: The source index.
+- Parameter `destination`: The destination array.
+- Parameter `destinationIndex`: The destination index.
+- Parameter `length`: The length to copy.
+- Returns: The number of elements copied.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.ModbusBufferManager.Dispose`
+
+```csharp
+public void Dispose()
+```
+Disposes the buffer manager and releases all resources.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.ModbusBufferManager.GetMetrics`
+
+```csharp
+public IoT.DriverCore.ModbusRx.IO.ModbusBufferMetrics GetMetrics()
+```
+Gets a deterministic snapshot of buffer-manager work.
+
+- Returns: The current operation counters.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.ModbusBufferManager.RentBoolBuffer(System.Int32)`
+
+```csharp
+public bool[] RentBoolBuffer(int minimumLength)
+```
+Rents a bool buffer from the pool or creates a new one.
+
+- Parameter `minimumLength`: The minimum length required.
+- Returns: A rented buffer that should be returned when finished.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.ModbusBufferManager.RentByteBuffer(System.Int32)`
+
+```csharp
+public byte[] RentByteBuffer(int minimumLength)
+```
+Rents a byte buffer from the pool or creates a new one.
+
+- Parameter `minimumLength`: The minimum length required.
+- Returns: A rented buffer that should be returned when finished.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.ModbusBufferManager.RentUshortBuffer(System.Int32)`
+
+```csharp
+public ushort[] RentUshortBuffer(int minimumLength)
+```
+Rents a ushort buffer from the pool or creates a new one.
+
+- Parameter `minimumLength`: The minimum length required.
+- Returns: A rented buffer that should be returned when finished.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.ModbusBufferManager.ReturnBoolBuffer(System.Boolean[],System.Boolean)`
+
+```csharp
+public void ReturnBoolBuffer(bool[] buffer, bool clearArray)
+```
+Returns a bool buffer to the pool.
+
+- Parameter `buffer`: The buffer to return.
+- Parameter `clearArray`: Whether to clear the array.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.ModbusBufferManager.ReturnByteBuffer(System.Byte[],System.Boolean)`
+
+```csharp
+public void ReturnByteBuffer(byte[] buffer, bool clearArray)
+```
+Returns a byte buffer to the pool.
+
+- Parameter `buffer`: The buffer to return.
+- Parameter `clearArray`: Whether to clear the array.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.ModbusBufferManager.ReturnUshortBuffer(System.UInt16[],System.Boolean)`
+
+```csharp
+public void ReturnUshortBuffer(ushort[] buffer, bool clearArray)
+```
+Returns a ushort buffer to the pool.
+
+- Parameter `buffer`: The buffer to return.
+- Parameter `clearArray`: Whether to clear the array.
+
+#### `T:IoT.DriverCore.ModbusRx.IO.ModbusBufferMetrics`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.IO.ModbusBufferMetrics
+```
+Provides deterministic operation counters for a `T:IoT.DriverCore.ModbusRx.IO.ModbusBufferManager` .
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.IO.ModbusBufferMetrics.#ctor(System.Int64,System.Int64,System.Int64,System.Int64,System.Int64)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.IO.ModbusBufferMetrics(long rentOperations, long returnOperations, long dedicatedAllocations, long copyOperations, long copiedElements)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.IO.ModbusBufferMetrics` class.
+
+- Parameter `rentOperations`: The number of successful rents.
+- Parameter `returnOperations`: The number of successful returns.
+- Parameter `dedicatedAllocations`: The number of arrays allocated instead of rented.
+- Parameter `copyOperations`: The number of tracked copy operations.
+- Parameter `copiedElements`: The number of elements copied by tracked operations.
+
+###### `P:IoT.DriverCore.ModbusRx.IO.ModbusBufferMetrics.CopiedElements`
+
+```csharp
+public long CopiedElements { get; }
+```
+Gets the number of elements copied by tracked copy operations.
+
+- Value: The `CopiedElements` value.
+
+###### `P:IoT.DriverCore.ModbusRx.IO.ModbusBufferMetrics.CopyOperations`
+
+```csharp
+public long CopyOperations { get; }
+```
+Gets the number of tracked copy operations.
+
+- Value: The `CopyOperations` value.
+
+###### `P:IoT.DriverCore.ModbusRx.IO.ModbusBufferMetrics.DedicatedAllocations`
+
+```csharp
+public long DedicatedAllocations { get; }
+```
+Gets the number of arrays allocated instead of rented.
+
+- Value: The `DedicatedAllocations` value.
+
+###### `P:IoT.DriverCore.ModbusRx.IO.ModbusBufferMetrics.RentOperations`
+
+```csharp
+public long RentOperations { get; }
+```
+Gets the number of successful rents.
+
+- Value: The `RentOperations` value.
+
+###### `P:IoT.DriverCore.ModbusRx.IO.ModbusBufferMetrics.ReturnOperations`
+
+```csharp
+public long ReturnOperations { get; }
+```
+Gets the number of successful returns.
+
+- Value: The `ReturnOperations` value.
+
+#### `T:IoT.DriverCore.ModbusRx.IO.ModbusSerialTransport`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.IO.ModbusSerialTransport
+```
+Transport for serial protocols.
+
+##### Declared public members
+
+###### `P:IoT.DriverCore.ModbusRx.IO.ModbusSerialTransport.CheckFrame`
+
+```csharp
+public bool CheckFrame { get; set; }
+```
+Gets or sets a value indicating whether LRC/CRC frame checking is performed on messages.
+
+- Value: The `CheckFrame` value.
+
+#### `T:IoT.DriverCore.ModbusRx.IO.ModbusTransport`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.IO.ModbusTransport
+```
+Modbus transport. Abstraction - http://en.wikipedia.org/wiki/Bridge_Pattern.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.IO.ModbusTransport.Dispose`
+
+```csharp
+public void Dispose()
+```
+Frees, releases, or resets unmanaged resources.
+
+###### `P:IoT.DriverCore.ModbusRx.IO.ModbusTransport.ReadTimeout`
+
+```csharp
+public int ReadTimeout { get; set; }
+```
+Gets or sets the read-operation timeout in milliseconds.
+
+- Value: The `ReadTimeout` value.
+
+###### `P:IoT.DriverCore.ModbusRx.IO.ModbusTransport.Retries`
+
+```csharp
+public int Retries { get; set; }
+```
+Gets or sets number of times to retry sending message after encountering a failure such as an IOException, TimeoutException, or a corrupt message.
+
+- Value: The `Retries` value.
+
+###### `P:IoT.DriverCore.ModbusRx.IO.ModbusTransport.RetryOnOldResponseThreshold`
+
+```csharp
+public uint RetryOnOldResponseThreshold { get; set; }
+```
+Gets or sets whether a second reply is read when the first is behind the sequence number. request by less than this number. For example, set this to 3, and if when sending request 5, response 3 is read, we will attempt to re-read responses.
+
+- Value: The `RetryOnOldResponseThreshold` value.
+
+###### `P:IoT.DriverCore.ModbusRx.IO.ModbusTransport.SlaveBusyUsesRetryCount`
+
+```csharp
+public bool SlaveBusyUsesRetryCount { get; set; }
+```
+Gets or sets whether a slave-busy exception consumes the retry count.
+
+- Value: The `SlaveBusyUsesRetryCount` value.
+
+###### `P:IoT.DriverCore.ModbusRx.IO.ModbusTransport.WaitToRetryMilliseconds`
+
+```csharp
+public int WaitToRetryMilliseconds { get; set; }
+```
+Gets or sets the number of milliseconds the tranport will wait before retrying a message after receiving an ACKNOWLEGE or SLAVE DEVICE BUSY slave exception response.
+
+- Value: The `WaitToRetryMilliseconds` value.
+
+###### `P:IoT.DriverCore.ModbusRx.IO.ModbusTransport.WriteTimeout`
+
+```csharp
+public int WriteTimeout { get; set; }
+```
+Gets or sets the write-operation timeout in milliseconds.
+
+- Value: The `WriteTimeout` value.
+
+#### `T:IoT.DriverCore.ModbusRx.IO.OptimizedModbusMessageFactory`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.IO.OptimizedModbusMessageFactory
+```
+High-performance Modbus message factory with cross-platform optimizations.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.IO.OptimizedModbusMessageFactory.CreateReadCoilsRequest(System.Byte,System.UInt16,System.UInt16)`
+
+```csharp
+public static byte[] CreateReadCoilsRequest(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+```
+Creates a read coils request with high performance.
+
+- Parameter `slaveAddress`: The slave address.
+- Parameter `startAddress`: The start address.
+- Parameter `numberOfPoints`: The number of points.
+- Returns: The serialized message bytes.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.OptimizedModbusMessageFactory.CreateReadHoldingRegistersRequest(System.Byte,System.UInt16,System.UInt16)`
+
+```csharp
+public static byte[] CreateReadHoldingRegistersRequest(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+```
+Creates a read holding registers request with high performance.
+
+- Parameter `slaveAddress`: The slave address.
+- Parameter `startAddress`: The start address.
+- Parameter `numberOfPoints`: The number of points.
+- Returns: The serialized message bytes.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.OptimizedModbusMessageFactory.CreateWriteMultipleCoilsRequest(System.Byte,System.UInt16,System.Boolean[])`
+
+```csharp
+public static byte[] CreateWriteMultipleCoilsRequest(byte slaveAddress, ushort startAddress, bool[] values)
+```
+Creates a write multiple coils request with high performance.
+
+- Parameter `slaveAddress`: The slave address.
+- Parameter `startAddress`: The start address.
+- Parameter `values`: The values to write.
+- Returns: The serialized message bytes.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.OptimizedModbusMessageFactory.CreateWriteMultipleRegistersRequest(System.Byte,System.UInt16,System.UInt16[])`
+
+```csharp
+public static byte[] CreateWriteMultipleRegistersRequest(byte slaveAddress, ushort startAddress, ushort[] values)
+```
+Creates a write multiple registers request with high performance.
+
+- Parameter `slaveAddress`: The slave address.
+- Parameter `startAddress`: The start address.
+- Parameter `values`: The values to write.
+- Returns: The serialized message bytes.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.OptimizedModbusMessageFactory.CreateWriteSingleCoilRequest(System.Byte,System.UInt16,System.Boolean)`
+
+```csharp
+public static byte[] CreateWriteSingleCoilRequest(byte slaveAddress, ushort coilAddress, bool value)
+```
+Creates a write single coil request with high performance.
+
+- Parameter `slaveAddress`: The slave address.
+- Parameter `coilAddress`: The coil address.
+- Parameter `value`: The value to write.
+- Returns: The serialized message bytes.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.OptimizedModbusMessageFactory.CreateWriteSingleRegisterRequest(System.Byte,System.UInt16,System.UInt16)`
+
+```csharp
+public static byte[] CreateWriteSingleRegisterRequest(byte slaveAddress, ushort registerAddress, ushort value)
+```
+Creates a write single register request with high performance.
+
+- Parameter `slaveAddress`: The slave address.
+- Parameter `registerAddress`: The register address.
+- Parameter `value`: The value to write.
+- Returns: The serialized message bytes.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.OptimizedModbusMessageFactory.DisposeSharedResources`
+
+```csharp
+public static void DisposeSharedResources()
+```
+Releases the shared buffer manager reference and replaces it for subsequent factory operations.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.OptimizedModbusMessageFactory.ParseReadCoilsResponse(System.Byte[],System.Int32)`
+
+```csharp
+public static bool[] ParseReadCoilsResponse(byte[] responseData, int numberOfCoils)
+```
+Parses a read coils response with high performance.
+
+- Parameter `responseData`: The response data.
+- Parameter `numberOfCoils`: The number of coils requested.
+- Returns: The parsed coil values.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.OptimizedModbusMessageFactory.ParseReadHoldingRegistersResponse(System.Byte[])`
+
+```csharp
+public static ushort[] ParseReadHoldingRegistersResponse(byte[] responseData)
+```
+Parses a read holding registers response with high performance.
+
+- Parameter `responseData`: The response data.
+- Returns: The parsed register values.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.OptimizedModbusMessageFactory.ValidateMessageCrc(System.Byte[])`
+
+```csharp
+public static bool ValidateMessageCrc(byte[] messageData)
+```
+Validates a Modbus message CRC with high performance.
+
+- Parameter `messageData`: The complete message data including CRC.
+- Returns: True if CRC is valid.
+
+#### `T:IoT.DriverCore.ModbusRx.IO.SerialPortAdapter`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.IO.SerialPortAdapter
+```
+Concrete Implementor - http://en.wikipedia.org/wiki/Bridge_Pattern.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.IO.SerialPortAdapter.#ctor(IoT.DriverCore.Serial.SerialPortRx)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.IO.SerialPortAdapter(IoT.DriverCore.Serial.SerialPortRx serialPort)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.IO.SerialPortAdapter` class.
+
+- Parameter `serialPort`: The serial port.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.SerialPortAdapter.DiscardInBuffer`
+
+```csharp
+public void DiscardInBuffer()
+```
+Purges the receive buffer.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.SerialPortAdapter.Dispose`
+
+```csharp
+public void Dispose()
+```
+Frees, releases, or resets unmanaged resources.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.SerialPortAdapter.ReadAsync(System.Byte[],System.Int32,System.Int32)`
+
+```csharp
+public System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count)
+```
+Reads bytes into a byte array at the specified offset.
+
+- Parameter `buffer`: The byte array to write the input to.
+- Parameter `offset`: The offset in the buffer array to begin writing.
+- Parameter `count`: The number of bytes to read.
+- Returns: The number of bytes read.
+
+###### `M:IoT.DriverCore.ModbusRx.IO.SerialPortAdapter.Write(System.Byte[],System.Int32,System.Int32)`
+
+```csharp
+public void Write(byte[] buffer, int offset, int count)
+```
+Writes bytes from an output buffer, starting at the specified offset.
+
+- Parameter `buffer`: The byte array that contains the data to write to the port.
+- Parameter `offset`: The offset in the buffer array to begin writing.
+- Parameter `count`: The number of bytes to write.
+
+###### `P:IoT.DriverCore.ModbusRx.IO.SerialPortAdapter.InfiniteTimeout`
+
+```csharp
+public int InfiniteTimeout { get; }
+```
+Gets indicates that no timeout should occur.
+
+- Value: The `InfiniteTimeout` value.
+
+###### `P:IoT.DriverCore.ModbusRx.IO.SerialPortAdapter.ReadTimeout`
+
+```csharp
+public int ReadTimeout { get; set; }
+```
+Gets or sets the read-operation timeout in milliseconds.
+
+- Value: The `ReadTimeout` value.
+
+###### `P:IoT.DriverCore.ModbusRx.IO.SerialPortAdapter.WriteTimeout`
+
+```csharp
+public int WriteTimeout { get; set; }
+```
+Gets or sets the write-operation timeout in milliseconds.
+
+- Value: The `WriteTimeout` value.
+
+#### `T:IoT.DriverCore.ModbusRx.InvalidModbusRequestException`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.InvalidModbusRequestException
+```
+An exception that provides the exception code sent in response to an invalid Modbus request.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.InvalidModbusRequestException.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.InvalidModbusRequestException()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.InvalidModbusRequestException` class.
+
+###### `M:IoT.DriverCore.ModbusRx.InvalidModbusRequestException.#ctor(System.Byte)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.InvalidModbusRequestException(byte exceptionCode)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.InvalidModbusRequestException` class.
+
+- Parameter `exceptionCode`: The Modbus exception code to provide to the slave.
+
+###### `M:IoT.DriverCore.ModbusRx.InvalidModbusRequestException.#ctor(System.Byte,System.Exception)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.InvalidModbusRequestException(byte exceptionCode, System.Exception innerException)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.InvalidModbusRequestException` class.
+
+- Parameter `exceptionCode`: The Modbus exception code to provide to the slave.
+- Parameter `innerException`: The exception that caused the current exception. If `innerException` is not null, a null reference, the current exception is raised in a catch block that handles the inner exception.
+
+###### `M:IoT.DriverCore.ModbusRx.InvalidModbusRequestException.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.InvalidModbusRequestException(string message)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.InvalidModbusRequestException` class.
+
+- Parameter `message`: The error message that explains the reason for the exception.
+
+###### `M:IoT.DriverCore.ModbusRx.InvalidModbusRequestException.#ctor(System.String,System.Byte)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.InvalidModbusRequestException(string message, byte exceptionCode)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.InvalidModbusRequestException` class.
+
+- Parameter `message`: The error message that explains the reason for the exception.
+- Parameter `exceptionCode`: The Modbus exception code to provide to the slave.
+
+###### `M:IoT.DriverCore.ModbusRx.InvalidModbusRequestException.#ctor(System.String,System.Byte,System.Exception)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.InvalidModbusRequestException(string message, byte exceptionCode, System.Exception innerException)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.InvalidModbusRequestException` class.
+
+- Parameter `message`: The error message that explains the reason for the exception.
+- Parameter `exceptionCode`: The Modbus exception code to provide to the slave.
+- Parameter `innerException`: The exception that caused the current exception. If `innerException` is not null, a null reference, the current exception is raised in a catch block that handles the inner exception.
+
+###### `M:IoT.DriverCore.ModbusRx.InvalidModbusRequestException.#ctor(System.String,System.Exception)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.InvalidModbusRequestException(string message, System.Exception innerException)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.InvalidModbusRequestException` class.
+
+- Parameter `message`: The error message that explains the reason for the exception.
+- Parameter `innerException`: The exception that is the cause of the current exception.
+
+###### `P:IoT.DriverCore.ModbusRx.InvalidModbusRequestException.ExceptionCode`
+
+```csharp
+public byte ExceptionCode { get; }
+```
+Gets the Modbus exception code to provide to the slave.
+
+- Value: The `ExceptionCode` value.
+
+#### `T:IoT.DriverCore.ModbusRx.LogicalTags.ModbusByteOrder`
+
+```csharp
+public enum IoT.DriverCore.ModbusRx.LogicalTags.ModbusByteOrder
+```
+Describes byte and word ordering for register values.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.ModbusRx.LogicalTags.ModbusByteOrder.BigEndian`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.LogicalTags.ModbusByteOrder BigEndian
+```
+Bytes and words are stored most-significant first (ABCD).
+
+###### `F:IoT.DriverCore.ModbusRx.LogicalTags.ModbusByteOrder.BigEndianWordSwap`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.LogicalTags.ModbusByteOrder BigEndianWordSwap
+```
+Big-endian bytes with least-significant word first (CDAB).
+
+###### `F:IoT.DriverCore.ModbusRx.LogicalTags.ModbusByteOrder.LittleEndian`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.LogicalTags.ModbusByteOrder LittleEndian
+```
+Bytes and words are stored least-significant first (DCBA).
+
+###### `F:IoT.DriverCore.ModbusRx.LogicalTags.ModbusByteOrder.LittleEndianWordSwap`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.LogicalTags.ModbusByteOrder LittleEndianWordSwap
+```
+Little-endian bytes with most-significant word first (BADC).
+
+#### `T:IoT.DriverCore.ModbusRx.LogicalTags.ModbusDataArea`
+
+```csharp
+public enum IoT.DriverCore.ModbusRx.LogicalTags.ModbusDataArea
+```
+Identifies a Modbus data area.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.ModbusRx.LogicalTags.ModbusDataArea.Coil`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.LogicalTags.ModbusDataArea Coil
+```
+Read/write coil bits.
+
+###### `F:IoT.DriverCore.ModbusRx.LogicalTags.ModbusDataArea.DiscreteInput`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.LogicalTags.ModbusDataArea DiscreteInput
+```
+Read-only discrete input bits.
+
+###### `F:IoT.DriverCore.ModbusRx.LogicalTags.ModbusDataArea.HoldingRegister`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.LogicalTags.ModbusDataArea HoldingRegister
+```
+Read/write holding registers.
+
+###### `F:IoT.DriverCore.ModbusRx.LogicalTags.ModbusDataArea.InputRegister`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.LogicalTags.ModbusDataArea InputRegister
+```
+Read-only input registers.
+
+#### `T:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag
+```
+Maps a logical name to a strongly typed Modbus address.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag.#ctor(IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag(IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration configuration)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag` class.
+
+- Parameter `configuration`: The address and behavior configuration.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag.FromLogicalTag(IoT.DriverCore.Core.LogicalTag)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag FromLogicalTag(IoT.DriverCore.Core.LogicalTag tag)
+```
+Converts a common logical tag to a validated Modbus definition.
+
+- Parameter `tag`: The common logical-tag definition.
+- Returns: The validated Modbus definition.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag.ToLogicalTag`
+
+```csharp
+public IoT.DriverCore.Core.LogicalTag ToLogicalTag()
+```
+Converts this definition to the common logical-tag representation.
+
+- Returns: The common definition.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag.AccessMode`
+
+```csharp
+public IoT.DriverCore.Core.LogicalTagAccessMode AccessMode { get; }
+```
+Gets the permitted access mode.
+
+- Value: The `AccessMode` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag.Address`
+
+```csharp
+public ushort Address { get; }
+```
+Gets the zero-based Modbus address.
+
+- Value: The `Address` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag.ByteOrder`
+
+```csharp
+public IoT.DriverCore.ModbusRx.LogicalTags.ModbusByteOrder ByteOrder { get; }
+```
+Gets the register byte and word order.
+
+- Value: The `ByteOrder` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag.ClrDataType`
+
+```csharp
+public System.Type ClrDataType { get; }
+```
+Gets the CLR value type exposed by the tag.
+
+- Value: The `ClrDataType` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag.Count`
+
+```csharp
+public ushort Count { get; }
+```
+Gets the number of coils, inputs, or registers.
+
+- Value: The `Count` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag.DataArea`
+
+```csharp
+public IoT.DriverCore.ModbusRx.LogicalTags.ModbusDataArea DataArea { get; }
+```
+Gets the Modbus data area.
+
+- Value: The `DataArea` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag.Description`
+
+```csharp
+public string Description { get; }
+```
+Gets the optional description.
+
+- Value: The `Description` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag.GroupName`
+
+```csharp
+public string GroupName { get; }
+```
+Gets the optional group name.
+
+- Value: The `GroupName` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag.Metadata`
+
+```csharp
+public System.Collections.Generic.IReadOnlyDictionary<string, string> Metadata { get; }
+```
+Gets caller-defined metadata.
+
+- Value: The `Metadata` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag.Name`
+
+```csharp
+public string Name { get; }
+```
+Gets the unique logical name.
+
+- Value: The `Name` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag.ScanInterval`
+
+```csharp
+public System.Nullable<System.TimeSpan> ScanInterval { get; }
+```
+Gets the preferred observation interval.
+
+- Value: The `ScanInterval` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag.UnitId`
+
+```csharp
+public byte UnitId { get; }
+```
+Gets the Modbus unit identifier.
+
+- Value: The `UnitId` value.
+
+#### `T:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient
+```
+Adapts the Modbus catalog and configured store to the common logical-tag setup contracts.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.#ctor(IoT.DriverCore.ModbusRx.Device.IModbusMaster,IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog,System.Nullable`1{System.TimeSpan})`
+
+```csharp
+public IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient(IoT.DriverCore.ModbusRx.Device.IModbusMaster master, IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog catalog, System.Nullable<System.TimeSpan> defaultScanInterval)
+```
+Initializes a new instance of `IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient`.
+
+- Parameter `master`: The `master` value.
+- Parameter `catalog`: The `catalog` value.
+- Parameter `defaultScanInterval`: The `defaultScanInterval` value.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.#ctor(IoT.DriverCore.ModbusRx.Device.IModbusMaster,IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog,System.Nullable`1{System.TimeSpan},System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient(IoT.DriverCore.ModbusRx.Device.IModbusMaster master, IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog catalog, System.Nullable<System.TimeSpan> defaultScanInterval, System.TimeProvider timeProvider)
+```
+Initializes a new instance of `IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient`.
+
+- Parameter `master`: The `master` value.
+- Parameter `catalog`: The `catalog` value.
+- Parameter `defaultScanInterval`: The `defaultScanInterval` value.
+- Parameter `timeProvider`: The `timeProvider` value.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.CreateTag(IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag CreateTag(IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration configuration)
+```
+Creates and registers a validated logical tag.
+
+- Parameter `configuration`: The address and behavior configuration.
+- Returns: The registered definition.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.DeleteStoredTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> DeleteStoredTagAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Deletes a persisted tag and removes it from the live catalog.
+
+- Parameter `name`: The logical name.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: True when the definition existed.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.Dispose`
+
+```csharp
+public void Dispose()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.ExportCsvAsync(System.IO.TextWriter,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task ExportCsvAsync(System.IO.TextWriter writer, System.Threading.CancellationToken cancellationToken)
+```
+Exports registered definitions as common RFC 4180 CSV.
+
+- Parameter `writer`: The CSV writer.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: A task representing the operation.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.GetStoredTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag> GetStoredTagAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Gets a persisted tag by logical name.
+
+- Parameter `name`: The logical name.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The stored definition, or null.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.ImportCsvAsync(System.IO.TextReader,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<int> ImportCsvAsync(System.IO.TextReader reader, System.Threading.CancellationToken cancellationToken)
+```
+Imports and registers common RFC 4180 CSV definitions.
+
+- Parameter `reader`: The CSV reader.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The number of imported definitions.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.InitializeStoreAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task InitializeStoreAsync(string connectionString, System.Threading.CancellationToken cancellationToken)
+```
+Initializes the SQLite store used by CRUD forwarding methods.
+
+- Parameter `connectionString`: The SQLite connection string.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: A task representing the operation.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.ListStoredTagsAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag>> ListStoredTagsAsync(System.Threading.CancellationToken cancellationToken)
+```
+Lists persisted tags.
+
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The stored definitions.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.LoadTagsAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<int> LoadTagsAsync(System.Threading.CancellationToken cancellationToken)
+```
+Replaces registered tags with the current SQLite snapshot.
+
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The number of loaded definitions.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.Observe(System.String)`
+
+```csharp
+public System.IObservable<IoT.DriverCore.Core.LogicalTagValue> Observe(string tagName)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Returns: A `System.IObservable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.ObserveAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue> ObserveAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.ObserveMany(System.Collections.Generic.IReadOnlyCollection`1{System.String})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.Core.LogicalTagValue> ObserveMany(System.Collections.Generic.IReadOnlyCollection<string> tagNames)
+```
+Executes the `ObserveMany` operation.
+
+- Parameter `tagNames`: The `tagNames` value.
+- Returns: A `System.IObservable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.ObserveManyAsync(System.Collections.Generic.IReadOnlyCollection`1{System.String},System.Threading.CancellationToken)`
+
+```csharp
+public System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue> ObserveManyAsync(System.Collections.Generic.IReadOnlyCollection<string> tagNames, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ObserveManyAsync` operation.
+
+- Parameter `tagNames`: The `tagNames` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.ReadAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>> ReadAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.ReadManyAsync(System.Collections.Generic.IReadOnlyCollection`1{System.String},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>> ReadManyAsync(System.Collections.Generic.IReadOnlyCollection<string> tagNames, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ReadManyAsync` operation.
+
+- Parameter `tagNames`: The `tagNames` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.RegisterTag(IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag)`
+
+```csharp
+public void RegisterTag(IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag tag)
+```
+Adds or replaces a logical tag definition.
+
+- Parameter `tag`: The definition to register.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.RemoveTag(System.String)`
+
+```csharp
+public bool RemoveTag(string name)
+```
+Removes a logical tag definition.
+
+- Parameter `name`: The logical name.
+- Returns: True when the definition existed.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.UpdateStoredTagAsync(IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> UpdateStoredTagAsync(IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag tag, System.Threading.CancellationToken cancellationToken)
+```
+Updates a persisted tag and the live catalog when it exists.
+
+- Parameter `tag`: The definition to update.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: True when the definition existed.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.UpsertStoredTagAsync(IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task UpsertStoredTagAsync(IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag tag, System.Threading.CancellationToken cancellationToken)
+```
+Creates or replaces a persisted tag and updates the live catalog.
+
+- Parameter `tag`: The definition to persist.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: A task representing the operation.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.WriteAsync(IoT.DriverCore.Core.LogicalTagValue,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>> WriteAsync(IoT.DriverCore.Core.LogicalTagValue value, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `value`: The `value` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.WriteManyAsync(System.Collections.Generic.IReadOnlyCollection`1{IoT.DriverCore.Core.LogicalTagValue},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>> WriteManyAsync(System.Collections.Generic.IReadOnlyCollection<IoT.DriverCore.Core.LogicalTagValue> values, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `WriteManyAsync` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>>` result.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.Catalog`
+
+```csharp
+public IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog Catalog { get; }
+```
+Gets the composed Modbus tag catalog.
+
+- Value: The `Catalog` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTagClient.Master`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Device.IModbusMaster Master { get; }
+```
+Gets the unchanged raw Modbus master.
+
+- Value: The `Master` value.
+
+#### `T:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog
+```
+Provides strongly typed Modbus access over a common logical-tag catalog.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog` class.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog.#ctor(IoT.DriverCore.Core.ILogicalTagCatalog)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog(IoT.DriverCore.Core.ILogicalTagCatalog catalog)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog` class.
+
+- Parameter `catalog`: The common catalog to wrap.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog.Create(IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag Create(IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration configuration)
+```
+Creates a validated tag definition without registering it.
+
+- Parameter `configuration`: The address and behavior configuration.
+- Returns: The validated definition.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog.Dispose`
+
+```csharp
+public void Dispose()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog.ExportCsvAsync(System.IO.TextWriter,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task ExportCsvAsync(System.IO.TextWriter writer, System.Threading.CancellationToken cancellationToken)
+```
+Exports this catalog using the common RFC 4180 CSV representation.
+
+- Parameter `writer`: The CSV writer.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: A task representing the operation.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog.ImportCsvAsync(System.IO.TextReader,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<int> ImportCsvAsync(System.IO.TextReader reader, System.Threading.CancellationToken cancellationToken)
+```
+Imports common RFC 4180 CSV definitions into this catalog.
+
+- Parameter `reader`: The CSV reader.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The number of imported definitions.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog.List`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag> List()
+```
+Returns a stable logical-name-ordered snapshot.
+
+- Returns: The current definitions.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog.LoadFromSqliteAsync(IoT.DriverCore.Core.LogicalTagSqliteStore,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<int> LoadFromSqliteAsync(IoT.DriverCore.Core.LogicalTagSqliteStore store, System.Threading.CancellationToken cancellationToken)
+```
+Replaces the in-memory snapshot with tags currently stored in SQLite.
+
+- Parameter `store`: The common SQLite store.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The number of loaded definitions.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog.TryAdd(IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag)`
+
+```csharp
+public bool TryAdd(IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag tag)
+```
+Adds a definition when its logical name is unused.
+
+- Parameter `tag`: The definition to add.
+- Returns: True when the definition was added.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog.TryGet(System.String,IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag@)`
+
+```csharp
+public bool TryGet(string name, out IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag tag)
+```
+Gets a definition by logical name.
+
+- Parameter `name`: The logical name.
+- Parameter `tag`: The resolved definition.
+- Returns: True when the definition exists.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog.TryRemove(System.String,IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag@)`
+
+```csharp
+public bool TryRemove(string name, out IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag tag)
+```
+Removes a definition by logical name.
+
+- Parameter `name`: The logical name.
+- Parameter `tag`: The removed definition.
+- Returns: True when the definition was removed.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog.Upsert(IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag)`
+
+```csharp
+public void Upsert(IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag tag)
+```
+Adds or replaces a definition.
+
+- Parameter `tag`: The definition to add or replace.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog.CoreCatalog`
+
+```csharp
+public IoT.DriverCore.Core.ILogicalTagCatalog CoreCatalog { get; }
+```
+Gets the composed common catalog.
+
+- Value: The `CoreCatalog` value.
+
+#### `T:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration
+```
+Collects the required address and optional behavior of a Modbus logical tag.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration.#ctor(System.String,System.Byte,IoT.DriverCore.ModbusRx.LogicalTags.ModbusDataArea,System.UInt16,System.UInt16,System.Type)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration(string name, byte unitId, IoT.DriverCore.ModbusRx.LogicalTags.ModbusDataArea dataArea, ushort address, ushort count, System.Type clrDataType)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration` class.
+
+- Parameter `name`: The unique logical name.
+- Parameter `unitId`: The Modbus unit identifier.
+- Parameter `dataArea`: The Modbus data area.
+- Parameter `address`: The zero-based Modbus address.
+- Parameter `count`: The number of Modbus points.
+- Parameter `clrDataType`: The exposed CLR data type.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration.AccessMode`
+
+```csharp
+public IoT.DriverCore.Core.LogicalTagAccessMode AccessMode { get; set; }
+```
+Gets or sets the permitted access mode.
+
+- Value: The `AccessMode` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration.Address`
+
+```csharp
+public ushort Address { get; }
+```
+Gets the zero-based Modbus address.
+
+- Value: The `Address` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration.ByteOrder`
+
+```csharp
+public IoT.DriverCore.ModbusRx.LogicalTags.ModbusByteOrder ByteOrder { get; set; }
+```
+Gets or sets the register byte and word order.
+
+- Value: The `ByteOrder` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration.ClrDataType`
+
+```csharp
+public System.Type ClrDataType { get; }
+```
+Gets the exposed CLR data type.
+
+- Value: The `ClrDataType` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration.Count`
+
+```csharp
+public ushort Count { get; }
+```
+Gets the number of Modbus points.
+
+- Value: The `Count` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration.DataArea`
+
+```csharp
+public IoT.DriverCore.ModbusRx.LogicalTags.ModbusDataArea DataArea { get; }
+```
+Gets the Modbus data area.
+
+- Value: The `DataArea` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration.Description`
+
+```csharp
+public string Description { get; set; }
+```
+Gets or sets the optional description.
+
+- Value: The `Description` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration.GroupName`
+
+```csharp
+public string GroupName { get; set; }
+```
+Gets or sets the optional group name.
+
+- Value: The `GroupName` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration.Metadata`
+
+```csharp
+public System.Collections.Generic.IReadOnlyDictionary<string, string> Metadata { get; set; }
+```
+Gets or sets caller-defined metadata.
+
+- Value: The `Metadata` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration.Name`
+
+```csharp
+public string Name { get; }
+```
+Gets the unique logical name.
+
+- Value: The `Name` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration.ScanInterval`
+
+```csharp
+public System.Nullable<System.TimeSpan> ScanInterval { get; set; }
+```
+Gets or sets the preferred observation interval.
+
+- Value: The `ScanInterval` value.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagConfiguration.UnitId`
+
+```csharp
+public byte UnitId { get; }
+```
+Gets the Modbus unit identifier.
+
+- Value: The `UnitId` value.
+
+#### `T:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagSqliteStore`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagSqliteStore
+```
+Provides Modbus-specific CRUD over the common SQLite logical-tag store.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagSqliteStore.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagSqliteStore(string connectionString)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagSqliteStore` class.
+
+- Parameter `connectionString`: The SQLite connection string.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagSqliteStore.DeleteAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> DeleteAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Deletes a stored Modbus tag.
+
+- Parameter `name`: The logical name.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: True when the definition existed.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagSqliteStore.GetAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag> GetAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Gets a Modbus tag by logical name.
+
+- Parameter `name`: The logical name.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The stored definition, or null.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagSqliteStore.InitializeAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task InitializeAsync(System.Threading.CancellationToken cancellationToken)
+```
+Creates or upgrades the common schema.
+
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: A task representing the operation.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagSqliteStore.ListAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag>> ListAsync(System.Threading.CancellationToken cancellationToken)
+```
+Lists all stored Modbus tags.
+
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The stored definitions.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagSqliteStore.LoadCatalogAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagCatalog> LoadCatalogAsync(System.Threading.CancellationToken cancellationToken)
+```
+Loads a new in-memory Modbus catalog from SQLite.
+
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The loaded catalog.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagSqliteStore.UpdateAsync(IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> UpdateAsync(IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag tag, System.Threading.CancellationToken cancellationToken)
+```
+Updates an existing stored Modbus tag.
+
+- Parameter `tag`: The definition to update.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: True when the definition existed.
+
+###### `M:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagSqliteStore.UpsertAsync(IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task UpsertAsync(IoT.DriverCore.ModbusRx.LogicalTags.ModbusLogicalTag tag, System.Threading.CancellationToken cancellationToken)
+```
+Creates or replaces a stored Modbus tag.
+
+- Parameter `tag`: The definition to persist.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: A task representing the operation.
+
+###### `P:IoT.DriverCore.ModbusRx.LogicalTags.ModbusTagSqliteStore.CoreStore`
+
+```csharp
+public IoT.DriverCore.Core.LogicalTagSqliteStore CoreStore { get; }
+```
+Gets the composed common store.
+
+- Value: The `CoreStore` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Message.AbstractModbusMessage`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Message.AbstractModbusMessage
+```
+Abstract Modbus message.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Message.AbstractModbusMessage.Initialize(System.Byte[])`
+
+```csharp
+public void Initialize(byte[] frame)
+```
+Initializes the specified frame.
+
+- Parameter `frame`: The frame.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.AbstractModbusMessage.FunctionCode`
+
+```csharp
+public byte FunctionCode { get; set; }
+```
+Gets or sets the function code.
+
+- Value: The function code.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.AbstractModbusMessage.MessageFrame`
+
+```csharp
+public byte[] MessageFrame { get; }
+```
+Gets the message frame.
+
+- Value: The message frame.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.AbstractModbusMessage.MinimumFrameSize`
+
+```csharp
+public int MinimumFrameSize { get; }
+```
+Gets the minimum size of the frame.
+
+- Value: The minimum size of the frame.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.AbstractModbusMessage.ProtocolDataUnit`
+
+```csharp
+public byte[] ProtocolDataUnit { get; }
+```
+Gets the protocol data unit.
+
+- Value: The protocol data unit.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.AbstractModbusMessage.SlaveAddress`
+
+```csharp
+public byte SlaveAddress { get; set; }
+```
+Gets or sets the slave address.
+
+- Value: The slave address.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.AbstractModbusMessage.TransactionId`
+
+```csharp
+public ushort TransactionId { get; set; }
+```
+Gets or sets the transaction identifier.
+
+- Value: The transaction identifier.
+
+#### `T:IoT.DriverCore.ModbusRx.Message.AbstractModbusMessageWithData`1`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Message.AbstractModbusMessageWithData`1
+```
+Provides AbstractModbusMessageWithData functionality.
+
+##### Declared public members
+
+###### `P:IoT.DriverCore.ModbusRx.Message.AbstractModbusMessageWithData`1.Data`
+
+```csharp
+public TData Data { get; set; }
+```
+Gets or sets the data.
+
+- Value: The data.
+
+#### `T:IoT.DriverCore.ModbusRx.Message.IModbusMessage`
+
+```csharp
+public interface IoT.DriverCore.ModbusRx.Message.IModbusMessage
+```
+A message built by the master (client) that initiates a Modbus transaction.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Message.IModbusMessage.Initialize(System.Byte[])`
+
+```csharp
+public void Initialize(byte[] frame)
+```
+Initializes a modbus message from the specified message frame.
+
+- Parameter `frame`: Bytes of Modbus frame.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.IModbusMessage.FunctionCode`
+
+```csharp
+public byte FunctionCode { get; set; }
+```
+Gets or sets the function code tells the server what kind of action to perform.
+
+- Value: The `FunctionCode` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.IModbusMessage.MessageFrame`
+
+```csharp
+public byte[] MessageFrame { get; }
+```
+Gets composition of the slave address and protocol data unit.
+
+- Value: The `MessageFrame` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.IModbusMessage.ProtocolDataUnit`
+
+```csharp
+public byte[] ProtocolDataUnit { get; }
+```
+Gets composition of the function code and message data.
+
+- Value: The `ProtocolDataUnit` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.IModbusMessage.SlaveAddress`
+
+```csharp
+public byte SlaveAddress { get; set; }
+```
+Gets or sets address of the slave (server).
+
+- Value: The `SlaveAddress` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.IModbusMessage.TransactionId`
+
+```csharp
+public ushort TransactionId { get; set; }
+```
+Gets or sets a unique identifier assigned to a message when using the IP protocol.
+
+- Value: The `TransactionId` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Message.IModbusRequest`
+
+```csharp
+public interface IoT.DriverCore.ModbusRx.Message.IModbusRequest
+```
+Methods specific to a modbus request message.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Message.IModbusRequest.ValidateResponse(IoT.DriverCore.ModbusRx.Message.IModbusMessage)`
+
+```csharp
+public void ValidateResponse(IoT.DriverCore.ModbusRx.Message.IModbusMessage response)
+```
+Validate the specified response against the current request.
+
+- Parameter `response`: The response.
+
+#### `T:IoT.DriverCore.ModbusRx.Message.ModbusMessageFactory`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Message.ModbusMessageFactory
+```
+Modbus message factory.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Message.ModbusMessageFactory.CreateModbusMessage``1(``0,System.Byte[])`
+
+```csharp
+public static T CreateModbusMessage<T>(T message, byte[] frame)
+```
+Create a Modbus message.
+
+- Parameter `message`: The message instance to initialize.
+- Parameter `frame`: Bytes of Modbus frame.
+- Returns: New Modbus message based on type and frame bytes.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.ModbusMessageFactory.CreateModbusRequest(System.Byte[])`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Message.IModbusMessage CreateModbusRequest(byte[] frame)
+```
+Create a Modbus request.
+
+- Parameter `frame`: Bytes of Modbus frame.
+- Returns: Modbus request.
+
+#### `T:IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsRequest`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsRequest
+```
+Provides ReadCoilsInputsRequest functionality.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsRequest.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsRequest()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsRequest` class.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsRequest.#ctor(System.Byte,System.Byte,System.UInt16,System.UInt16)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsRequest(byte functionCode, byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsRequest` class.
+
+- Parameter `functionCode`: The function code.
+- Parameter `slaveAddress`: The slave address.
+- Parameter `startAddress`: The start address.
+- Parameter `numberOfPoints`: The number of points.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsRequest.ToString`
+
+```csharp
+public string ToString()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsRequest.ValidateResponse(IoT.DriverCore.ModbusRx.Message.IModbusMessage)`
+
+```csharp
+public void ValidateResponse(IoT.DriverCore.ModbusRx.Message.IModbusMessage response)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `response`: The `response` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsRequest.MinimumFrameSize`
+
+```csharp
+public int MinimumFrameSize { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `MinimumFrameSize` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsRequest.NumberOfPoints`
+
+```csharp
+public ushort NumberOfPoints { get; set; }
+```
+Gets or sets the number of points.
+
+- Value: The `NumberOfPoints` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsRequest.StartAddress`
+
+```csharp
+public ushort StartAddress { get; set; }
+```
+Gets or sets the start address.
+
+- Value: The start address.
+
+#### `T:IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsResponse`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsResponse
+```
+Provides ReadCoilsInputsResponse functionality.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsResponse.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsResponse()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsResponse` class.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsResponse.#ctor(System.Byte,System.Byte,System.Byte,IoT.DriverCore.ModbusRx.Data.DiscreteCollection)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsResponse(byte functionCode, byte slaveAddress, byte byteCount, IoT.DriverCore.ModbusRx.Data.DiscreteCollection data)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsResponse` class.
+
+- Parameter `functionCode`: The function code.
+- Parameter `slaveAddress`: The slave address.
+- Parameter `byteCount`: The byte count.
+- Parameter `data`: The data.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsResponse.ToString`
+
+```csharp
+public string ToString()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `string` result.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsResponse.ByteCount`
+
+```csharp
+public byte ByteCount { get; set; }
+```
+Gets or sets the byte count.
+
+- Value: The byte count.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.ReadCoilsInputsResponse.MinimumFrameSize`
+
+```csharp
+public int MinimumFrameSize { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `MinimumFrameSize` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersRequest`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersRequest
+```
+Provides ReadHoldingInputRegistersRequest functionality.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersRequest.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersRequest()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersRequest` class.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersRequest.#ctor(System.Byte,System.Byte,System.UInt16,System.UInt16)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersRequest(byte functionCode, byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersRequest` class.
+
+- Parameter `functionCode`: The function code.
+- Parameter `slaveAddress`: The slave address.
+- Parameter `startAddress`: The start address.
+- Parameter `numberOfPoints`: The number of points.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersRequest.ToString`
+
+```csharp
+public string ToString()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersRequest.ValidateResponse(IoT.DriverCore.ModbusRx.Message.IModbusMessage)`
+
+```csharp
+public void ValidateResponse(IoT.DriverCore.ModbusRx.Message.IModbusMessage response)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `response`: The `response` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersRequest.MinimumFrameSize`
+
+```csharp
+public int MinimumFrameSize { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `MinimumFrameSize` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersRequest.NumberOfPoints`
+
+```csharp
+public ushort NumberOfPoints { get; set; }
+```
+Gets or sets the number of points.
+
+- Value: The `NumberOfPoints` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersRequest.StartAddress`
+
+```csharp
+public ushort StartAddress { get; set; }
+```
+Gets or sets the start address.
+
+- Value: The start address.
+
+#### `T:IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersResponse`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersResponse
+```
+Provides ReadHoldingInputRegistersResponse functionality.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersResponse.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersResponse()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersResponse` class.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersResponse.#ctor(System.Byte,System.Byte,IoT.DriverCore.ModbusRx.Data.RegisterCollection)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersResponse(byte functionCode, byte slaveAddress, IoT.DriverCore.ModbusRx.Data.RegisterCollection data)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersResponse` class.
+
+- Parameter `functionCode`: The function code.
+- Parameter `slaveAddress`: The slave address.
+- Parameter `data`: The data.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersResponse.ToString`
+
+```csharp
+public string ToString()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `string` result.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersResponse.ByteCount`
+
+```csharp
+public byte ByteCount { get; set; }
+```
+Gets or sets the byte count.
+
+- Value: The byte count.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersResponse.MinimumFrameSize`
+
+```csharp
+public int MinimumFrameSize { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `MinimumFrameSize` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Message.ReadWriteMultipleRegistersRequest`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Message.ReadWriteMultipleRegistersRequest
+```
+Provides ReadWriteMultipleRegistersRequest functionality.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Message.ReadWriteMultipleRegistersRequest.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.ReadWriteMultipleRegistersRequest()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.ReadWriteMultipleRegistersRequest` class.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.ReadWriteMultipleRegistersRequest.#ctor(System.Byte,System.UInt16,System.UInt16,System.UInt16,IoT.DriverCore.ModbusRx.Data.RegisterCollection)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.ReadWriteMultipleRegistersRequest(byte slaveAddress, ushort startReadAddress, ushort numberOfPointsToRead, ushort startWriteAddress, IoT.DriverCore.ModbusRx.Data.RegisterCollection writeData)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.ReadWriteMultipleRegistersRequest` class.
+
+- Parameter `slaveAddress`: The slave address.
+- Parameter `startReadAddress`: The start read address.
+- Parameter `numberOfPointsToRead`: The number of points to read.
+- Parameter `startWriteAddress`: The start write address.
+- Parameter `writeData`: The write data.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.ReadWriteMultipleRegistersRequest.ToString`
+
+```csharp
+public string ToString()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.ReadWriteMultipleRegistersRequest.ValidateResponse(IoT.DriverCore.ModbusRx.Message.IModbusMessage)`
+
+```csharp
+public void ValidateResponse(IoT.DriverCore.ModbusRx.Message.IModbusMessage response)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `response`: The `response` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.ReadWriteMultipleRegistersRequest.MinimumFrameSize`
+
+```csharp
+public int MinimumFrameSize { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `MinimumFrameSize` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.ReadWriteMultipleRegistersRequest.ProtocolDataUnit`
+
+```csharp
+public byte[] ProtocolDataUnit { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `ProtocolDataUnit` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.ReadWriteMultipleRegistersRequest.ReadRequest`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.ReadHoldingInputRegistersRequest ReadRequest { get; }
+```
+Gets the read request.
+
+- Value: The read request.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.ReadWriteMultipleRegistersRequest.WriteRequest`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersRequest WriteRequest { get; }
+```
+Gets the write request.
+
+- Value: The write request.
+
+#### `T:IoT.DriverCore.ModbusRx.Message.SlaveExceptionResponse`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Message.SlaveExceptionResponse
+```
+Provides SlaveExceptionResponse functionality.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Message.SlaveExceptionResponse.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.SlaveExceptionResponse()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.SlaveExceptionResponse` class.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.SlaveExceptionResponse.#ctor(System.Byte,System.Byte,System.Byte)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.SlaveExceptionResponse(byte slaveAddress, byte functionCode, byte exceptionCode)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.SlaveExceptionResponse` class.
+
+- Parameter `slaveAddress`: The slave address.
+- Parameter `functionCode`: The function code.
+- Parameter `exceptionCode`: The exception code.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.SlaveExceptionResponse.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string that represents the current object.
+
+- Returns: A `T:System.String` that represents the current `T:System.Object` .
+
+###### `P:IoT.DriverCore.ModbusRx.Message.SlaveExceptionResponse.MinimumFrameSize`
+
+```csharp
+public int MinimumFrameSize { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `MinimumFrameSize` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.SlaveExceptionResponse.SlaveExceptionCode`
+
+```csharp
+public byte SlaveExceptionCode { get; set; }
+```
+Gets or sets the slave exception code.
+
+- Value: The slave exception code.
+
+#### `T:IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsRequest`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsRequest
+```
+Write Multiple Coils request.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsRequest.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsRequest()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsRequest` class.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsRequest.#ctor(System.Byte,System.UInt16,IoT.DriverCore.ModbusRx.Data.DiscreteCollection)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsRequest(byte slaveAddress, ushort startAddress, IoT.DriverCore.ModbusRx.Data.DiscreteCollection data)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsRequest` class.
+
+- Parameter `slaveAddress`: The slave address.
+- Parameter `startAddress`: The start address.
+- Parameter `data`: The data.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsRequest.ToString`
+
+```csharp
+public string ToString()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsRequest.ValidateResponse(IoT.DriverCore.ModbusRx.Message.IModbusMessage)`
+
+```csharp
+public void ValidateResponse(IoT.DriverCore.ModbusRx.Message.IModbusMessage response)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `response`: The `response` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsRequest.ByteCount`
+
+```csharp
+public byte ByteCount { get; set; }
+```
+Gets or sets the byte count.
+
+- Value: The byte count.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsRequest.MinimumFrameSize`
+
+```csharp
+public int MinimumFrameSize { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `MinimumFrameSize` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsRequest.NumberOfPoints`
+
+```csharp
+public ushort NumberOfPoints { get; set; }
+```
+Gets or sets the number of points.
+
+- Value: The `NumberOfPoints` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsRequest.StartAddress`
+
+```csharp
+public ushort StartAddress { get; set; }
+```
+Gets or sets the start address.
+
+- Value: The start address.
+
+#### `T:IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsResponse`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsResponse
+```
+Provides WriteMultipleCoilsResponse functionality.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsResponse.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsResponse()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsResponse` class.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsResponse.#ctor(System.Byte,System.UInt16,System.UInt16)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsResponse(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsResponse` class.
+
+- Parameter `slaveAddress`: The slave address.
+- Parameter `startAddress`: The start address.
+- Parameter `numberOfPoints`: The number of points.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsResponse.ToString`
+
+```csharp
+public string ToString()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `string` result.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsResponse.MinimumFrameSize`
+
+```csharp
+public int MinimumFrameSize { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `MinimumFrameSize` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsResponse.NumberOfPoints`
+
+```csharp
+public ushort NumberOfPoints { get; set; }
+```
+Gets or sets the number of points.
+
+- Value: The `NumberOfPoints` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.WriteMultipleCoilsResponse.StartAddress`
+
+```csharp
+public ushort StartAddress { get; set; }
+```
+Gets or sets the start address.
+
+- Value: The start address.
+
+#### `T:IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersRequest`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersRequest
+```
+Provides WriteMultipleRegistersRequest functionality.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersRequest.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersRequest()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersRequest` class.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersRequest.#ctor(System.Byte,System.UInt16,IoT.DriverCore.ModbusRx.Data.RegisterCollection)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersRequest(byte slaveAddress, ushort startAddress, IoT.DriverCore.ModbusRx.Data.RegisterCollection data)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersRequest` class.
+
+- Parameter `slaveAddress`: The slave address.
+- Parameter `startAddress`: The start address.
+- Parameter `data`: The data.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersRequest.ToString`
+
+```csharp
+public string ToString()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersRequest.ValidateResponse(IoT.DriverCore.ModbusRx.Message.IModbusMessage)`
+
+```csharp
+public void ValidateResponse(IoT.DriverCore.ModbusRx.Message.IModbusMessage response)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `response`: The `response` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersRequest.ByteCount`
+
+```csharp
+public byte ByteCount { get; set; }
+```
+Gets or sets the byte count.
+
+- Value: The byte count.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersRequest.MinimumFrameSize`
+
+```csharp
+public int MinimumFrameSize { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `MinimumFrameSize` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersRequest.NumberOfPoints`
+
+```csharp
+public ushort NumberOfPoints { get; set; }
+```
+Gets or sets the number of points.
+
+- Value: The `NumberOfPoints` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersRequest.StartAddress`
+
+```csharp
+public ushort StartAddress { get; set; }
+```
+Gets or sets the start address.
+
+- Value: The start address.
+
+#### `T:IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersResponse`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersResponse
+```
+Provides WriteMultipleRegistersResponse functionality.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersResponse.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersResponse()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersResponse` class.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersResponse.#ctor(System.Byte,System.UInt16,System.UInt16)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersResponse(byte slaveAddress, ushort startAddress, ushort numberOfPoints)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersResponse` class.
+
+- Parameter `slaveAddress`: The slave address.
+- Parameter `startAddress`: The start address.
+- Parameter `numberOfPoints`: The number of points.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersResponse.ToString`
+
+```csharp
+public string ToString()
+```
+Converts to string.
+
+- Returns: A `T:System.String` that represents this instance.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersResponse.MinimumFrameSize`
+
+```csharp
+public int MinimumFrameSize { get; }
+```
+Gets the minimum size of the frame.
+
+- Value: The minimum size of the frame.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersResponse.NumberOfPoints`
+
+```csharp
+public ushort NumberOfPoints { get; set; }
+```
+Gets or sets the number of points.
+
+- Value: The `NumberOfPoints` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.WriteMultipleRegistersResponse.StartAddress`
+
+```csharp
+public ushort StartAddress { get; set; }
+```
+Gets or sets the start address.
+
+- Value: The start address.
+
+#### `T:IoT.DriverCore.ModbusRx.Message.WriteSingleCoilRequestResponse`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Message.WriteSingleCoilRequestResponse
+```
+Provides WriteSingleCoilRequestResponse functionality.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteSingleCoilRequestResponse.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.WriteSingleCoilRequestResponse()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.WriteSingleCoilRequestResponse` class.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteSingleCoilRequestResponse.#ctor(System.Byte,System.UInt16,System.Boolean)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.WriteSingleCoilRequestResponse(byte slaveAddress, ushort startAddress, bool coilState)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.WriteSingleCoilRequestResponse` class.
+
+- Parameter `slaveAddress`: The slave address.
+- Parameter `startAddress`: The start address.
+- Parameter `coilState`: if set to true [coil state].
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteSingleCoilRequestResponse.ToString`
+
+```csharp
+public string ToString()
+```
+Converts to string.
+
+- Returns: A `T:System.String` that represents this instance.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteSingleCoilRequestResponse.ValidateResponse(IoT.DriverCore.ModbusRx.Message.IModbusMessage)`
+
+```csharp
+public void ValidateResponse(IoT.DriverCore.ModbusRx.Message.IModbusMessage response)
+```
+Validate the specified response against the current request.
+
+- Parameter `response`: The Modbus Message.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.WriteSingleCoilRequestResponse.MinimumFrameSize`
+
+```csharp
+public int MinimumFrameSize { get; }
+```
+Gets the minimum size of the frame.
+
+- Value: The minimum size of the frame.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.WriteSingleCoilRequestResponse.StartAddress`
+
+```csharp
+public ushort StartAddress { get; set; }
+```
+Gets or sets the start address.
+
+- Value: The start address.
+
+#### `T:IoT.DriverCore.ModbusRx.Message.WriteSingleRegisterRequestResponse`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Message.WriteSingleRegisterRequestResponse
+```
+Provides WriteSingleRegisterRequestResponse functionality.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteSingleRegisterRequestResponse.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.WriteSingleRegisterRequestResponse()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.WriteSingleRegisterRequestResponse` class.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteSingleRegisterRequestResponse.#ctor(System.Byte,System.UInt16,System.UInt16)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Message.WriteSingleRegisterRequestResponse(byte slaveAddress, ushort startAddress, ushort registerValue)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.Message.WriteSingleRegisterRequestResponse` class.
+
+- Parameter `slaveAddress`: The slave address.
+- Parameter `startAddress`: The start address.
+- Parameter `registerValue`: The register value.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteSingleRegisterRequestResponse.ToString`
+
+```csharp
+public string ToString()
+```
+Converts to string.
+
+- Returns: A `T:System.String` that represents this instance.
+
+###### `M:IoT.DriverCore.ModbusRx.Message.WriteSingleRegisterRequestResponse.ValidateResponse(IoT.DriverCore.ModbusRx.Message.IModbusMessage)`
+
+```csharp
+public void ValidateResponse(IoT.DriverCore.ModbusRx.Message.IModbusMessage response)
+```
+Validate the specified response against the current request.
+
+- Parameter `response`: The Modbus message.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.WriteSingleRegisterRequestResponse.MinimumFrameSize`
+
+```csharp
+public int MinimumFrameSize { get; }
+```
+Gets the minimum size of the frame.
+
+- Value: The minimum size of the frame.
+
+###### `P:IoT.DriverCore.ModbusRx.Message.WriteSingleRegisterRequestResponse.StartAddress`
+
+```csharp
+public ushort StartAddress { get; set; }
+```
+Gets or sets the start address.
+
+- Value: The start address.
+
+#### `T:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions
+```
+Async-observable adapters for Modbus reactive operations.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ObserveCoilsObservable(IoT.DriverCore.ModbusRx.Device.ModbusServer,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<bool[]> ObserveCoilsObservable(IoT.DriverCore.ModbusRx.Device.ModbusServer server, ushort startAddress, ushort count, double interval)
+```
+Observes coil changes as an async observable.
+
+- Parameter `server`: The extension receiver.
+- Parameter `startAddress`: The starting address to monitor.
+- Parameter `count`: The number of coils to monitor.
+- Parameter `interval`: The polling interval in milliseconds.
+- Returns: An async observable of coils.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ObserveDataChangesObservable(IoT.DriverCore.ModbusRx.Device.ModbusServer,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<ushort[], ushort[], bool[], bool[]>> ObserveDataChangesObservable(IoT.DriverCore.ModbusRx.Device.ModbusServer server, double interval)
+```
+Observes server data changes as an async observable.
+
+- Parameter `server`: The extension receiver.
+- Parameter `interval`: The polling interval in milliseconds.
+- Returns: An async observable of data snapshots.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ObserveDataStoreReadFromObservable(IoT.DriverCore.ModbusRx.Device.ModbusSlave)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Data.DataStoreEventArgs> ObserveDataStoreReadFromObservable(IoT.DriverCore.ModbusRx.Device.ModbusSlave slave)
+```
+Observes data-store reads as an async observable.
+
+- Parameter `slave`: The extension receiver.
+- Returns: An async observable of data-store events.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ObserveDataStoreWrittenToObservable(IoT.DriverCore.ModbusRx.Device.ModbusSlave)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Data.DataStoreEventArgs> ObserveDataStoreWrittenToObservable(IoT.DriverCore.ModbusRx.Device.ModbusSlave slave)
+```
+Observes data-store writes as an async observable.
+
+- Parameter `slave`: The extension receiver.
+- Returns: An async observable of data-store events.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ObserveDiscreteInputsObservable(IoT.DriverCore.ModbusRx.Device.ModbusServer,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<bool[]> ObserveDiscreteInputsObservable(IoT.DriverCore.ModbusRx.Device.ModbusServer server, ushort startAddress, ushort count, double interval)
+```
+Observes discrete input changes as an async observable.
+
+- Parameter `server`: The extension receiver.
+- Parameter `startAddress`: The starting address to monitor.
+- Parameter `count`: The number of inputs to monitor.
+- Parameter `interval`: The polling interval in milliseconds.
+- Returns: An async observable of discrete inputs.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ObserveHoldingRegistersObservable(IoT.DriverCore.ModbusRx.Device.ModbusServer,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<ushort[]> ObserveHoldingRegistersObservable(IoT.DriverCore.ModbusRx.Device.ModbusServer server, ushort startAddress, ushort count, double interval)
+```
+Observes holding-register changes as an async observable.
+
+- Parameter `server`: The extension receiver.
+- Parameter `startAddress`: The starting address to monitor.
+- Parameter `count`: The number of registers to monitor.
+- Parameter `interval`: The polling interval in milliseconds.
+- Returns: An async observable of holding registers.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ObserveInputRegistersObservable(IoT.DriverCore.ModbusRx.Device.ModbusServer,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<ushort[]> ObserveInputRegistersObservable(IoT.DriverCore.ModbusRx.Device.ModbusServer server, ushort startAddress, ushort count, double interval)
+```
+Observes input-register changes as an async observable.
+
+- Parameter `server`: The extension receiver.
+- Parameter `startAddress`: The starting address to monitor.
+- Parameter `count`: The number of registers to monitor.
+- Parameter `interval`: The polling interval in milliseconds.
+- Returns: An async observable of input registers.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ObserveRequestObservable(IoT.DriverCore.ModbusRx.Device.ModbusSlave)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusSlaveRequestEventArgs> ObserveRequestObservable(IoT.DriverCore.ModbusRx.Device.ModbusSlave slave)
+```
+Observes slave requests as an async observable.
+
+- Parameter `slave`: The extension receiver.
+- Returns: An async observable of request events.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ObserveWriteCompleteObservable(IoT.DriverCore.ModbusRx.Device.ModbusSlave)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusSlaveRequestEventArgs> ObserveWriteCompleteObservable(IoT.DriverCore.ModbusRx.Device.ModbusSlave slave)
+```
+Observes write completion as an async observable.
+
+- Parameter `slave`: The extension receiver.
+- Returns: An async observable of request events.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ReadCoils(ReactiveUI.Primitives.Async.IObservableAsync`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.Byte,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool[], System.Exception>> ReadCoils(ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, byte slaveAddress, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadCoils` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `slaveAddress`: The `slaveAddress` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ReadCoils(ReactiveUI.Primitives.Async.IObservableAsync`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.ModbusIpMaster}},System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool[], System.Exception>> ReadCoils(ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadCoils` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ReadCoilsObservable(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.Byte,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool[], System.Exception>> ReadCoilsObservable(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, byte slaveAddress, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadCoilsObservable` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `slaveAddress`: The `slaveAddress` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ReadCoilsObservable(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.ModbusIpMaster}},System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool[], System.Exception>> ReadCoilsObservable(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadCoilsObservable` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ReadHoldingRegisters(ReactiveUI.Primitives.Async.IObservableAsync`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.Byte,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<ushort[], System.Exception>> ReadHoldingRegisters(ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, byte slaveAddress, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadHoldingRegisters` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `slaveAddress`: The `slaveAddress` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<ushort[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ReadHoldingRegisters(ReactiveUI.Primitives.Async.IObservableAsync`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.ModbusIpMaster}},System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<ushort[], System.Exception>> ReadHoldingRegisters(ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadHoldingRegisters` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<ushort[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ReadHoldingRegistersObservable(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.Byte,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<ushort[], System.Exception>> ReadHoldingRegistersObservable(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, byte slaveAddress, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadHoldingRegistersObservable` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `slaveAddress`: The `slaveAddress` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<ushort[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ReadHoldingRegistersObservable(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.ModbusIpMaster}},System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<ushort[], System.Exception>> ReadHoldingRegistersObservable(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadHoldingRegistersObservable` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<ushort[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ReadInputRegisters(ReactiveUI.Primitives.Async.IObservableAsync`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.Byte,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<ushort[], System.Exception>> ReadInputRegisters(ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, byte slaveAddress, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadInputRegisters` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `slaveAddress`: The `slaveAddress` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<ushort[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ReadInputRegisters(ReactiveUI.Primitives.Async.IObservableAsync`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.ModbusIpMaster}},System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<ushort[], System.Exception>> ReadInputRegisters(ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadInputRegisters` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<ushort[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ReadInputRegistersObservable(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.Byte,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<ushort[], System.Exception>> ReadInputRegistersObservable(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, byte slaveAddress, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadInputRegistersObservable` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `slaveAddress`: The `slaveAddress` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<ushort[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ReadInputRegistersObservable(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.ModbusIpMaster}},System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<ushort[], System.Exception>> ReadInputRegistersObservable(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadInputRegistersObservable` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<ushort[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ReadInputs(ReactiveUI.Primitives.Async.IObservableAsync`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.Byte,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool[], System.Exception>> ReadInputs(ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, byte slaveAddress, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadInputs` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `slaveAddress`: The `slaveAddress` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ReadInputs(ReactiveUI.Primitives.Async.IObservableAsync`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.ModbusIpMaster}},System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool[], System.Exception>> ReadInputs(ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadInputs` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ReadInputsObservable(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}},System.Byte,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool[], System.Exception>> ReadInputsObservable(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source, byte slaveAddress, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadInputsObservable` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `slaveAddress`: The `slaveAddress` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ReadInputsObservable(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.ModbusIpMaster}},System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool[], System.Exception>> ReadInputsObservable(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> source, ushort startAddress, ushort numberOfPoints, double interval)
+```
+Executes the `ReadInputsObservable` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `numberOfPoints`: The `numberOfPoints` value.
+- Parameter `interval`: The `interval` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool[], System.Exception>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ToAsyncObservable``1(System.IObservable`1{``0})`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<T> ToAsyncObservable<T>(System.IObservable<T> source)
+```
+Executes the `ToAsyncObservable` operation.
+
+- Parameter `source`: The `source` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<T>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ToModbusObservable(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster}})`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> ToModbusObservable(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>> source)
+```
+Executes the `ToModbusObservable` operation.
+
+- Parameter `source`: The `source` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.IModbusSerialMaster>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ToModbusObservable(System.IObservable`1{System.ValueTuple`3{System.Boolean,System.Exception,IoT.DriverCore.ModbusRx.Device.ModbusIpMaster}})`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> ToModbusObservable(System.IObservable<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>> source)
+```
+Executes the `ToModbusObservable` operation.
+
+- Parameter `source`: The `source` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<bool, System.Exception, IoT.DriverCore.ModbusRx.Device.ModbusIpMaster>>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.ToObservable``1(ReactiveUI.Primitives.Async.IObservableAsync`1{``0})`
+
+```csharp
+public static System.IObservable<T> ToObservable<T>(ReactiveUI.Primitives.Async.IObservableAsync<T> source)
+```
+Executes the `ToObservable` operation.
+
+- Parameter `source`: The `source` value.
+- Returns: A `System.IObservable<T>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.WriteCoilDiscretes(ReactiveUI.Primitives.Async.IObservableAsync`1{IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave},System.UInt16,ReactiveUI.Primitives.Async.IObservableAsync`1{System.Boolean[]})`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave> WriteCoilDiscretes(ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave> slave, ushort startAddress, ReactiveUI.Primitives.Async.IObservableAsync<bool[]> valuesToWrite)
+```
+Executes the `WriteCoilDiscretes` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.WriteCoilDiscretes(ReactiveUI.Primitives.Async.IObservableAsync`1{IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave},System.UInt16,ReactiveUI.Primitives.Async.IObservableAsync`1{System.Boolean[]})`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave> WriteCoilDiscretes(ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave> slave, ushort startAddress, ReactiveUI.Primitives.Async.IObservableAsync<bool[]> valuesToWrite)
+```
+Executes the `WriteCoilDiscretes` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.WriteCoilDiscretes(ReactiveUI.Primitives.Async.IObservableAsync`1{IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave},System.UInt16,ReactiveUI.Primitives.Async.IObservableAsync`1{System.Boolean[]})`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave> WriteCoilDiscretes(ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave> slave, ushort startAddress, ReactiveUI.Primitives.Async.IObservableAsync<bool[]> valuesToWrite)
+```
+Executes the `WriteCoilDiscretes` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.WriteHoldingRegisters(ReactiveUI.Primitives.Async.IObservableAsync`1{IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave},System.UInt16,ReactiveUI.Primitives.Async.IObservableAsync`1{System.UInt16[]})`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave> WriteHoldingRegisters(ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave> slave, ushort startAddress, ReactiveUI.Primitives.Async.IObservableAsync<ushort[]> valuesToWrite)
+```
+Executes the `WriteHoldingRegisters` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.WriteHoldingRegisters(ReactiveUI.Primitives.Async.IObservableAsync`1{IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave},System.UInt16,ReactiveUI.Primitives.Async.IObservableAsync`1{System.UInt16[]})`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave> WriteHoldingRegisters(ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave> slave, ushort startAddress, ReactiveUI.Primitives.Async.IObservableAsync<ushort[]> valuesToWrite)
+```
+Executes the `WriteHoldingRegisters` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.WriteHoldingRegisters(ReactiveUI.Primitives.Async.IObservableAsync`1{IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave},System.UInt16,ReactiveUI.Primitives.Async.IObservableAsync`1{System.UInt16[]})`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave> WriteHoldingRegisters(ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave> slave, ushort startAddress, ReactiveUI.Primitives.Async.IObservableAsync<ushort[]> valuesToWrite)
+```
+Executes the `WriteHoldingRegisters` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.WriteInputDiscretes(ReactiveUI.Primitives.Async.IObservableAsync`1{IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave},System.UInt16,ReactiveUI.Primitives.Async.IObservableAsync`1{System.Boolean[]})`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave> WriteInputDiscretes(ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave> slave, ushort startAddress, ReactiveUI.Primitives.Async.IObservableAsync<bool[]> valuesToWrite)
+```
+Executes the `WriteInputDiscretes` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.WriteInputDiscretes(ReactiveUI.Primitives.Async.IObservableAsync`1{IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave},System.UInt16,ReactiveUI.Primitives.Async.IObservableAsync`1{System.Boolean[]})`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave> WriteInputDiscretes(ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave> slave, ushort startAddress, ReactiveUI.Primitives.Async.IObservableAsync<bool[]> valuesToWrite)
+```
+Executes the `WriteInputDiscretes` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.WriteInputDiscretes(ReactiveUI.Primitives.Async.IObservableAsync`1{IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave},System.UInt16,ReactiveUI.Primitives.Async.IObservableAsync`1{System.Boolean[]})`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave> WriteInputDiscretes(ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave> slave, ushort startAddress, ReactiveUI.Primitives.Async.IObservableAsync<bool[]> valuesToWrite)
+```
+Executes the `WriteInputDiscretes` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.WriteInputRegisters(ReactiveUI.Primitives.Async.IObservableAsync`1{IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave},System.UInt16,ReactiveUI.Primitives.Async.IObservableAsync`1{System.UInt16[]})`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave> WriteInputRegisters(ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave> slave, ushort startAddress, ReactiveUI.Primitives.Async.IObservableAsync<ushort[]> valuesToWrite)
+```
+Executes the `WriteInputRegisters` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.WriteInputRegisters(ReactiveUI.Primitives.Async.IObservableAsync`1{IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave},System.UInt16,ReactiveUI.Primitives.Async.IObservableAsync`1{System.UInt16[]})`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave> WriteInputRegisters(ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave> slave, ushort startAddress, ReactiveUI.Primitives.Async.IObservableAsync<ushort[]> valuesToWrite)
+```
+Executes the `WriteInputRegisters` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusAsyncObservableExtensions.WriteInputRegisters(ReactiveUI.Primitives.Async.IObservableAsync`1{IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave},System.UInt16,ReactiveUI.Primitives.Async.IObservableAsync`1{System.UInt16[]})`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave> WriteInputRegisters(ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave> slave, ushort startAddress, ReactiveUI.Primitives.Async.IObservableAsync<ushort[]> valuesToWrite)
+```
+Executes the `WriteInputRegisters` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave>` result.
+
+#### `T:IoT.DriverCore.ModbusRx.ModbusCommunicationException`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.ModbusCommunicationException
+```
+Modbus Communication Exception.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusCommunicationException.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.ModbusCommunicationException()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.ModbusCommunicationException` class.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusCommunicationException.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.ModbusCommunicationException(string message)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.ModbusCommunicationException` class.
+
+- Parameter `message`: The message that describes the error.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusCommunicationException.#ctor(System.String,System.Exception)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.ModbusCommunicationException(string message, System.Exception inner)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.ModbusCommunicationException` class.
+
+- Parameter `message`: The message.
+- Parameter `inner`: The inner.
+
+#### `T:IoT.DriverCore.ModbusRx.ModbusObservationMetrics`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.ModbusObservationMetrics
+```
+Provides deterministic work counters for event-driven Modbus server observation.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusObservationMetrics.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.ModbusObservationMetrics()
+```
+Initializes a new instance of `IoT.DriverCore.ModbusRx.ModbusObservationMetrics`.
+
+###### `P:IoT.DriverCore.ModbusRx.ModbusObservationMetrics.SnapshotsCreated`
+
+```csharp
+public long SnapshotsCreated { get; }
+```
+Gets the number of snapshots constructed from accepted notifications.
+
+- Value: The `SnapshotsCreated` value.
+
+###### `P:IoT.DriverCore.ModbusRx.ModbusObservationMetrics.SnapshotsEmitted`
+
+```csharp
+public long SnapshotsEmitted { get; }
+```
+Gets the number of snapshots emitted to observers.
+
+- Value: The `SnapshotsEmitted` value.
+
+###### `P:IoT.DriverCore.ModbusRx.ModbusObservationMetrics.WriteNotifications`
+
+```csharp
+public long WriteNotifications { get; }
+```
+Gets the number of accepted data-store write notifications.
+
+- Value: The `WriteNotifications` value.
+
+#### `T:IoT.DriverCore.ModbusRx.ModbusSerialSlaveExtensions`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.ModbusSerialSlaveExtensions
+```
+Writes observable values to serial slave data stores.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusSerialSlaveExtensions.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.ModbusSerialSlaveExtensions()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.ModbusSerialSlaveExtensions` class.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusSerialSlaveExtensions.#ctor(System.Byte)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.ModbusSerialSlaveExtensions(byte unitIdentifier)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.ModbusSerialSlaveExtensions` class.
+
+- Parameter `unitIdentifier`: The Modbus unit identifier used by write requests.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusSerialSlaveExtensions.WriteCoilDiscretes(System.IObservable`1{IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave},System.UInt16,System.IObservable`1{System.Boolean[]})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave> WriteCoilDiscretes(System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave> slave, ushort startAddress, System.IObservable<bool[]> valuesToWrite)
+```
+Executes the `WriteCoilDiscretes` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusSerialSlaveExtensions.WriteHoldingRegisters(System.IObservable`1{IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave},System.UInt16,System.IObservable`1{System.UInt16[]})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave> WriteHoldingRegisters(System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave> slave, ushort startAddress, System.IObservable<ushort[]> valuesToWrite)
+```
+Executes the `WriteHoldingRegisters` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusSerialSlaveExtensions.WriteInputDiscretes(System.IObservable`1{IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave},System.UInt16,System.IObservable`1{System.Boolean[]})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave> WriteInputDiscretes(System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave> slave, ushort startAddress, System.IObservable<bool[]> valuesToWrite)
+```
+Executes the `WriteInputDiscretes` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusSerialSlaveExtensions.WriteInputRegisters(System.IObservable`1{IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave},System.UInt16,System.IObservable`1{System.UInt16[]})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave> WriteInputRegisters(System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave> slave, ushort startAddress, System.IObservable<ushort[]> valuesToWrite)
+```
+Executes the `WriteInputRegisters` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusSerialSlave>` result.
+
+#### `T:IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot
+```
+Represents a snapshot of Modbus server data at a point in time.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot` class.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot.#ctor(System.UInt16[],System.UInt16[],System.Boolean[],System.Boolean[],System.DateTimeOffset)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot(ushort[] holdingRegisters, ushort[] inputRegisters, bool[] coils, bool[] inputs, System.DateTimeOffset timestamp)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot` class.
+
+- Parameter `holdingRegisters`: The holding-register values.
+- Parameter `inputRegisters`: The input-register values.
+- Parameter `coils`: The coil values.
+- Parameter `inputs`: The input values.
+- Parameter `timestamp`: The time at which the snapshot was captured.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot.Equals(IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot)`
+
+```csharp
+public bool Equals(IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot other)
+```
+Determines whether the specified snapshot is equal to the current snapshot.
+
+- Parameter `other`: The snapshot to compare with the current snapshot.
+- Returns: True if the specified snapshot is equal to the current snapshot; otherwise, false.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the specified object is equal to the current snapshot.
+
+- Parameter `obj`: The object to compare with the current snapshot.
+- Returns: True if the specified object is equal to the current snapshot; otherwise, false.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for this snapshot.
+
+- Returns: A hash code for this snapshot.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot.op_Equality(IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot,IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot left, IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot right)
+```
+Determines whether two snapshots are equal.
+
+- Parameter `left`: The first snapshot to compare.
+- Parameter `right`: The second snapshot to compare.
+- Returns: True if the snapshots are equal; otherwise, false.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot.op_Inequality(IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot,IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot left, IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot right)
+```
+Determines whether two snapshots are not equal.
+
+- Parameter `left`: The first snapshot to compare.
+- Parameter `right`: The second snapshot to compare.
+- Returns: True if the snapshots are not equal; otherwise, false.
+
+###### `P:IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot.Coils`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<bool> Coils { get; }
+```
+Gets the coils data.
+
+- Value: The `Coils` value.
+
+###### `P:IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot.HoldingRegisters`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<ushort> HoldingRegisters { get; }
+```
+Gets the holding registers data.
+
+- Value: The `HoldingRegisters` value.
+
+###### `P:IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot.InputRegisters`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<ushort> InputRegisters { get; }
+```
+Gets the input registers data.
+
+- Value: The `InputRegisters` value.
+
+###### `P:IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot.Inputs`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<bool> Inputs { get; }
+```
+Gets the inputs data.
+
+- Value: The `Inputs` value.
+
+###### `P:IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot.IsEmpty`
+
+```csharp
+public bool IsEmpty { get; }
+```
+Gets a value indicating whether this snapshot is empty.
+
+- Value: The `IsEmpty` value.
+
+###### `P:IoT.DriverCore.ModbusRx.ModbusServerDataSnapshot.Timestamp`
+
+```csharp
+public System.DateTimeOffset Timestamp { get; }
+```
+Gets the timestamp of this snapshot.
+
+- Value: The `Timestamp` value.
+
+#### `T:IoT.DriverCore.ModbusRx.ModbusServerExtensions`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.ModbusServerExtensions
+```
+Reactive extensions for ModbusServer.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusServerExtensions.CreateReactiveServer(System.Action`1{IoT.DriverCore.ModbusRx.Device.ModbusServer})`
+
+```csharp
+public static System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusServer> CreateReactiveServer(System.Action<IoT.DriverCore.ModbusRx.Device.ModbusServer> configureServer)
+```
+Executes the `CreateReactiveServer` operation.
+
+- Parameter `configureServer`: The `configureServer` value.
+- Returns: A `System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusServer>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusServerExtensions.ObserveCoils(IoT.DriverCore.ModbusRx.Device.ModbusServer,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static System.IObservable<bool[]> ObserveCoils(IoT.DriverCore.ModbusRx.Device.ModbusServer server, ushort startAddress, ushort count, double interval)
+```
+Observes changes to coils in the server data store.
+
+- Parameter `server`: The extension receiver.
+- Parameter `startAddress`: The starting address to monitor.
+- Parameter `count`: The number of coils to monitor.
+- Parameter `interval`: The polling interval in milliseconds.
+- Returns: An observable stream of coil values.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusServerExtensions.ObserveDataChanges(IoT.DriverCore.ModbusRx.Device.ModbusServer,System.Double)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<ushort[], ushort[], bool[], bool[]>> ObserveDataChanges(IoT.DriverCore.ModbusRx.Device.ModbusServer server, double interval)
+```
+Creates an observable stream of data changes from the server.
+
+- Parameter `server`: The extension receiver.
+- Parameter `interval`: The polling interval in milliseconds.
+- Returns: An observable stream of server data.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusServerExtensions.ObserveDiscreteInputs(IoT.DriverCore.ModbusRx.Device.ModbusServer,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static System.IObservable<bool[]> ObserveDiscreteInputs(IoT.DriverCore.ModbusRx.Device.ModbusServer server, ushort startAddress, ushort count, double interval)
+```
+Observes changes to discrete inputs in the server data store.
+
+- Parameter `server`: The extension receiver.
+- Parameter `startAddress`: The starting address to monitor.
+- Parameter `count`: The number of inputs to monitor.
+- Parameter `interval`: The polling interval in milliseconds.
+- Returns: An observable stream of discrete input values.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusServerExtensions.ObserveHoldingRegisters(IoT.DriverCore.ModbusRx.Device.ModbusServer,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static System.IObservable<ushort[]> ObserveHoldingRegisters(IoT.DriverCore.ModbusRx.Device.ModbusServer server, ushort startAddress, ushort count, double interval)
+```
+Observes changes to holding registers in the server data store.
+
+- Parameter `server`: The extension receiver.
+- Parameter `startAddress`: The starting address to monitor.
+- Parameter `count`: The number of registers to monitor.
+- Parameter `interval`: The polling interval in milliseconds.
+- Returns: An observable stream of holding register values.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusServerExtensions.ObserveInputRegisters(IoT.DriverCore.ModbusRx.Device.ModbusServer,System.UInt16,System.UInt16,System.Double)`
+
+```csharp
+public static System.IObservable<ushort[]> ObserveInputRegisters(IoT.DriverCore.ModbusRx.Device.ModbusServer server, ushort startAddress, ushort count, double interval)
+```
+Observes changes to input registers in the server data store.
+
+- Parameter `server`: The extension receiver.
+- Parameter `startAddress`: The starting address to monitor.
+- Parameter `count`: The number of registers to monitor.
+- Parameter `interval`: The polling interval in milliseconds.
+- Returns: An observable stream of input register values.
+
+#### `T:IoT.DriverCore.ModbusRx.ModbusTcpSlaveExtensions`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.ModbusTcpSlaveExtensions
+```
+Writes observable values to TCP slave data stores.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusTcpSlaveExtensions.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.ModbusTcpSlaveExtensions()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.ModbusTcpSlaveExtensions` class.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusTcpSlaveExtensions.#ctor(System.Byte)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.ModbusTcpSlaveExtensions(byte unitIdentifier)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.ModbusTcpSlaveExtensions` class.
+
+- Parameter `unitIdentifier`: The Modbus unit identifier used by write requests.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusTcpSlaveExtensions.WriteCoilDiscretes(System.IObservable`1{IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave},System.UInt16,System.IObservable`1{System.Boolean[]})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave> WriteCoilDiscretes(System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave> slave, ushort startAddress, System.IObservable<bool[]> valuesToWrite)
+```
+Executes the `WriteCoilDiscretes` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusTcpSlaveExtensions.WriteHoldingRegisters(System.IObservable`1{IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave},System.UInt16,System.IObservable`1{System.UInt16[]})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave> WriteHoldingRegisters(System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave> slave, ushort startAddress, System.IObservable<ushort[]> valuesToWrite)
+```
+Executes the `WriteHoldingRegisters` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusTcpSlaveExtensions.WriteInputDiscretes(System.IObservable`1{IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave},System.UInt16,System.IObservable`1{System.Boolean[]})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave> WriteInputDiscretes(System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave> slave, ushort startAddress, System.IObservable<bool[]> valuesToWrite)
+```
+Executes the `WriteInputDiscretes` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusTcpSlaveExtensions.WriteInputRegisters(System.IObservable`1{IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave},System.UInt16,System.IObservable`1{System.UInt16[]})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave> WriteInputRegisters(System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave> slave, ushort startAddress, System.IObservable<ushort[]> valuesToWrite)
+```
+Executes the `WriteInputRegisters` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusTcpSlave>` result.
+
+#### `T:IoT.DriverCore.ModbusRx.ModbusUdpSlaveExtensions`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.ModbusUdpSlaveExtensions
+```
+Writes observable values to UDP slave data stores.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusUdpSlaveExtensions.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.ModbusUdpSlaveExtensions()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.ModbusUdpSlaveExtensions` class.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusUdpSlaveExtensions.#ctor(System.Byte)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.ModbusUdpSlaveExtensions(byte unitIdentifier)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.ModbusUdpSlaveExtensions` class.
+
+- Parameter `unitIdentifier`: The Modbus unit identifier used by write requests.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusUdpSlaveExtensions.WriteCoilDiscretes(System.IObservable`1{IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave},System.UInt16,System.IObservable`1{System.Boolean[]})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave> WriteCoilDiscretes(System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave> slave, ushort startAddress, System.IObservable<bool[]> valuesToWrite)
+```
+Executes the `WriteCoilDiscretes` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusUdpSlaveExtensions.WriteHoldingRegisters(System.IObservable`1{IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave},System.UInt16,System.IObservable`1{System.UInt16[]})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave> WriteHoldingRegisters(System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave> slave, ushort startAddress, System.IObservable<ushort[]> valuesToWrite)
+```
+Executes the `WriteHoldingRegisters` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusUdpSlaveExtensions.WriteInputDiscretes(System.IObservable`1{IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave},System.UInt16,System.IObservable`1{System.Boolean[]})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave> WriteInputDiscretes(System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave> slave, ushort startAddress, System.IObservable<bool[]> valuesToWrite)
+```
+Executes the `WriteInputDiscretes` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave>` result.
+
+###### `M:IoT.DriverCore.ModbusRx.ModbusUdpSlaveExtensions.WriteInputRegisters(System.IObservable`1{IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave},System.UInt16,System.IObservable`1{System.UInt16[]})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave> WriteInputRegisters(System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave> slave, ushort startAddress, System.IObservable<ushort[]> valuesToWrite)
+```
+Executes the `WriteInputRegisters` operation.
+
+- Parameter `slave`: The `slave` value.
+- Parameter `startAddress`: The `startAddress` value.
+- Parameter `valuesToWrite`: The `valuesToWrite` value.
+- Returns: A `System.IObservable<IoT.DriverCore.ModbusRx.Device.ModbusUdpSlave>` result.
+
+#### `T:IoT.DriverCore.ModbusRx.SlaveException`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.SlaveException
+```
+Represents slave errors that occur during communication.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.SlaveException.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.SlaveException()
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.SlaveException` class.
+
+###### `M:IoT.DriverCore.ModbusRx.SlaveException.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.SlaveException(string message)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.SlaveException` class.
+
+- Parameter `message`: The message.
+
+###### `M:IoT.DriverCore.ModbusRx.SlaveException.#ctor(System.String,System.Exception)`
+
+```csharp
+public IoT.DriverCore.ModbusRx.SlaveException(string message, System.Exception innerException)
+```
+Initializes a new instance of the `T:IoT.DriverCore.ModbusRx.SlaveException` class.
+
+- Parameter `message`: The message.
+- Parameter `innerException`: The inner exception.
+
+###### `P:IoT.DriverCore.ModbusRx.SlaveException.FunctionCode`
+
+```csharp
+public byte FunctionCode { get; }
+```
+Gets the response function code that caused the exception to occur, or 0.
+
+- Value: The function code.
+
+###### `P:IoT.DriverCore.ModbusRx.SlaveException.Message`
+
+```csharp
+public string Message { get; }
+```
+Gets a message that describes the current exception.
+
+- Value: The error message that explains the reason for the exception, or an empty string.
+
+###### `P:IoT.DriverCore.ModbusRx.SlaveException.SlaveAddress`
+
+```csharp
+public byte SlaveAddress { get; }
+```
+Gets the slave address, or 0.
+
+- Value: The slave address.
+
+###### `P:IoT.DriverCore.ModbusRx.SlaveException.SlaveExceptionCode`
+
+```csharp
+public byte SlaveExceptionCode { get; }
+```
+Gets the slave exception code, or 0.
+
+- Value: The slave exception code.
+
+#### `T:IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnionOption`
+
+```csharp
+public enum IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnionOption
+```
+Possible options for `T:IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnion`2` .
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnionOption.A`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnionOption A
+```
+Option A.
+
+###### `F:IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnionOption.B`
+
+```csharp
+public static const IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnionOption B
+```
+Option B.
+
+#### `T:IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnion`2`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnion`2
+```
+A data type that can store one of two possible strongly typed options.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnion`2.#ctor`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnion<TA, TB>()
+```
+Initializes a new instance of `IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnion`2`.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnion`2.CreateA(`0)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnion<TA, TB> CreateA(TA a)
+```
+Factory method for creating DiscriminatedUnion with option A set.
+
+- Parameter `a`: a.
+- Returns: A DiscriminatedUnion.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnion`2.CreateB(`1)`
+
+```csharp
+public static IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnion<TA, TB> CreateB(TB b)
+```
+Factory method for creating DiscriminatedUnion with option B set.
+
+- Parameter `b`: The b.
+- Returns: A DiscriminatedUnion.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnion`2.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string that represents the current object.
+
+- Returns: A `T:System.String` that represents the current `T:System.Object` .
+
+###### `P:IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnion`2.A`
+
+```csharp
+public TA A { get; }
+```
+Gets the value of option A.
+
+- Value: The `A` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnion`2.B`
+
+```csharp
+public TB B { get; }
+```
+Gets the value of option B.
+
+- Value: The `B` value.
+
+###### `P:IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnion`2.Option`
+
+```csharp
+public IoT.DriverCore.ModbusRx.Utility.DiscriminatedUnionOption Option { get; }
+```
+Gets the discriminated value option set for this instance.
+
+- Value: The `Option` value.
+
+#### `T:IoT.DriverCore.ModbusRx.Utility.ModbusUtility`
+
+```csharp
+public class IoT.DriverCore.ModbusRx.Utility.ModbusUtility
+```
+Modbus utility methods with high-performance optimizations.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.ModbusUtility.CalculateCrc(System.Byte[])`
+
+```csharp
+public static byte[] CalculateCrc(byte[] data)
+```
+Calculate Cyclical Redundancy Check.
+
+- Parameter `data`: The data used in CRC.
+- Returns: CRC value as byte array.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.ModbusUtility.CalculateCrc(System.ReadOnlySpan`1{System.Byte},System.Span`1{System.Byte})`
+
+```csharp
+public static int CalculateCrc(System.ReadOnlySpan<byte> data, System.Span<byte> result)
+```
+Executes the `CalculateCrc` operation.
+
+- Parameter `data`: The `data` value.
+- Parameter `result`: The `result` value.
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.ModbusUtility.CalculateLrc(System.Byte[])`
+
+```csharp
+public static byte CalculateLrc(byte[] data)
+```
+Calculate Longitudinal Redundancy Check.
+
+- Parameter `data`: The data used in LRC.
+- Returns: LRC value.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.ModbusUtility.CalculateLrc(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static byte CalculateLrc(System.ReadOnlySpan<byte> data)
+```
+Executes the `CalculateLrc` operation.
+
+- Parameter `data`: The `data` value.
+- Returns: A `byte` result.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.ModbusUtility.GetAsciiBytes(System.Byte[])`
+
+```csharp
+public static byte[] GetAsciiBytes(byte[] numbers)
+```
+Converts an array of bytes to an ASCII byte array.
+
+- Parameter `numbers`: The byte array.
+- Returns: An array of ASCII byte values.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.ModbusUtility.GetAsciiBytes(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static byte[] GetAsciiBytes(System.ReadOnlySpan<byte> numbers)
+```
+Executes the `GetAsciiBytes` operation.
+
+- Parameter `numbers`: The `numbers` value.
+- Returns: A `byte[]` result.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.ModbusUtility.GetAsciiBytes(System.ReadOnlySpan`1{System.UInt16})`
+
+```csharp
+public static byte[] GetAsciiBytes(System.ReadOnlySpan<ushort> numbers)
+```
+Executes the `GetAsciiBytes` operation.
+
+- Parameter `numbers`: The `numbers` value.
+- Returns: A `byte[]` result.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.ModbusUtility.GetAsciiBytes(System.UInt16[])`
+
+```csharp
+public static byte[] GetAsciiBytes(ushort[] numbers)
+```
+Converts an array of UInt16 to an ASCII byte array.
+
+- Parameter `numbers`: The ushort array.
+- Returns: An array of ASCII byte values.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.ModbusUtility.GetDouble(System.UInt16,System.UInt16,System.UInt16,System.UInt16)`
+
+```csharp
+public static double GetDouble(ushort b3, ushort b2, ushort b1, ushort b0)
+```
+Converts four UInt16 values to an IEEE 64-bit floating-point value.
+
+- Parameter `b3`: Highest-order ushort value.
+- Parameter `b2`: Second-to-highest-order ushort value.
+- Parameter `b1`: Second-to-lowest-order ushort value.
+- Parameter `b0`: Lowest-order ushort value.
+- Returns: IEEE 64 floating point value.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.ModbusUtility.GetSingle(System.UInt16,System.UInt16)`
+
+```csharp
+public static float GetSingle(ushort highOrderValue, ushort lowOrderValue)
+```
+Converts two UInt16 values to an IEEE 32-bit floating-point value.
+
+- Parameter `highOrderValue`: High order ushort value.
+- Parameter `lowOrderValue`: Low order ushort value.
+- Returns: IEEE 32 floating point value.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.ModbusUtility.GetUInt32(System.UInt16,System.UInt16)`
+
+```csharp
+public static uint GetUInt32(ushort highOrderValue, ushort lowOrderValue)
+```
+Converts two UInt16 values into a UInt32 using optimized memory operations.
+
+- Parameter `highOrderValue`: The high order value.
+- Parameter `lowOrderValue`: The low order value.
+- Returns: A UInt32 value.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.ModbusUtility.HexToBytes(System.ReadOnlySpan`1{System.Char},System.Span`1{System.Byte})`
+
+```csharp
+public static int HexToBytes(System.ReadOnlySpan<char> hex, System.Span<byte> result)
+```
+Executes the `HexToBytes` operation.
+
+- Parameter `hex`: The `hex` value.
+- Parameter `result`: The `result` value.
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.ModbusUtility.HexToBytes(System.String)`
+
+```csharp
+public static byte[] HexToBytes(string hex)
+```
+Converts a hex string to a byte array.
+
+- Parameter `hex`: The hex string.
+- Returns: Array of bytes.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.ModbusUtility.NetworkBytesToHostUInt16(System.Byte[])`
+
+```csharp
+public static ushort[] NetworkBytesToHostUInt16(byte[] networkBytes)
+```
+Converts a network order byte array to an array of UInt16 values in host order.
+
+- Parameter `networkBytes`: The network order byte array.
+- Returns: The host order ushort array.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.ModbusUtility.NetworkBytesToHostUInt16(System.ReadOnlySpan`1{System.Byte},System.Span`1{System.UInt16})`
+
+```csharp
+public static int NetworkBytesToHostUInt16(System.ReadOnlySpan<byte> networkBytes, System.Span<ushort> result)
+```
+Executes the `NetworkBytesToHostUInt16` operation.
+
+- Parameter `networkBytes`: The `networkBytes` value.
+- Parameter `result`: The `result` value.
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.ModbusUtility.ReadDouble(System.ReadOnlySpan`1{System.UInt16},System.Boolean)`
+
+```csharp
+public static double ReadDouble(System.ReadOnlySpan<ushort> registers, bool swapWords)
+```
+Executes the `ReadDouble` operation.
+
+- Parameter `registers`: The `registers` value.
+- Parameter `swapWords`: The `swapWords` value.
+- Returns: A `double` result.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.ModbusUtility.ReadSingle(System.ReadOnlySpan`1{System.UInt16},System.Boolean)`
+
+```csharp
+public static float ReadSingle(System.ReadOnlySpan<ushort> registers, bool swapWords)
+```
+Executes the `ReadSingle` operation.
+
+- Parameter `registers`: The `registers` value.
+- Parameter `swapWords`: The `swapWords` value.
+- Returns: A `float` result.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.ModbusUtility.WriteDouble(System.Double,System.Span`1{System.UInt16},System.Boolean)`
+
+```csharp
+public static void WriteDouble(double value, System.Span<ushort> registers, bool swapWords)
+```
+Executes the `WriteDouble` operation.
+
+- Parameter `value`: The `value` value.
+- Parameter `registers`: The `registers` value.
+- Parameter `swapWords`: The `swapWords` value.
+
+###### `M:IoT.DriverCore.ModbusRx.Utility.ModbusUtility.WriteSingle(System.Single,System.Span`1{System.UInt16},System.Boolean)`
+
+```csharp
+public static void WriteSingle(float value, System.Span<ushort> registers, bool swapWords)
+```
+Executes the `WriteSingle` operation.
+
+- Parameter `value`: The `value` value.
+- Parameter `registers`: The `registers` value.
+- Parameter `swapWords`: The `swapWords` value.
+
+<!-- END GENERATED PUBLIC API -->

--- a/packagereadme/OmronPlcRx/README.md
+++ b/packagereadme/OmronPlcRx/README.md
@@ -1,966 +1,4154 @@
 # OmronPlcRx
 
-<div align="center">
-  <img src="Images/OmronPLCRx-icon.png" style="width:25%;" />
-</div>
+## Overview
 
-OmronPlcRx is a reactive Omron PLC communications library for .NET Framework and modern .NET. It targets `net462`, `net472`, `net481`, `net8.0`, `net9.0`, `net10.0`, and `net11.0`.
+`OmronPlcRx` is a typed, reactive .NET driver for Omron FINS over TCP, UDP, Host Link FINS serial, and Toolbus serial. Register a `PlcTag<T>`, address it through a `LogicalTagKey<T>`, then read, write, or observe it. The base package uses `ReactiveUI.Primitives`; `OmronPlcRx.Reactive` is the equivalent System.Reactive-oriented surface. Both are shared-source builds.
 
-The library provides high-level, strongly typed PLC tag access over Omron FINS using TCP, UDP, serial Host Link FINS, or serial Toolbus FINS. 
+The public namespaces are `IoT.DriverCore.OmronPlcRx` and its `.Core`, `.Core.Types`, `.Enums`, `.Results`, `.Tags`, and `.Async` children. The reactive package replaces the root with `IoT.DriverCore.OmronPlcRx.Reactive`.
 
-V2 is a breaking release: the core reactive implementation now uses `ReactiveUI.Primitives`, and Rx/System.Reactive-first applications should use the new `OmronPlcRx.Reactive` package surface.
+## Safety
 
-## Contents
+PLC writes can change machinery state. Validate addresses, types, interlocks, ownership, and the target controller in a non-production environment first. Subscribe to `Errors`, use cancellation tokens and bounded timeouts, and prefer `WriteValueAsync` when a command must be observed. `SetValue` queues a background write; failures are reported through `Errors` rather than returned to the caller.
 
-- [V2 Breaking Changes](#v2-breaking-changes)
-- [Packages](#packages)
-- [Installation](#installation)
-- [Quick Start](#quick-start)
-- [Rx Applications With OmronPlcRx.Reactive](#rx-applications-with-omronplcrxreactive)
-- [R3 Bridge](#r3-bridge)
-- [Addressing Guide](#addressing-guide)
-- [Supported Types And Encoding](#supported-types-and-encoding)
-- [Source Generators](#source-generators)
-- [Full API Reference](#full-api-reference)
-- [Error Handling](#error-handling)
-- [Testing](#testing)
-- [FAQ](#faq)
-- [License](#license)
+## Package matrix
 
-## V2 Breaking Changes
+| Package | Use |
+| --- | --- |
+| `OmronPlcRx` | Base API using ReactiveUI.Primitives and BCL `IObservable<T>`. |
+| `OmronPlcRx.Reactive` | Same driver shape for System.Reactive consumers; namespaces end in `.Reactive`. |
+| `OmronPlcRx.Generators` | Roslyn generator package; the runtime packages reference it as an analyzer. |
 
-V2 changes the reactive foundation and package layout.
+All runtime packages target `net462`, `net472`, `net481`, `net8.0`, `net9.0`, `net10.0`, and `net11.0`.
 
-- `OmronPlcRx` now depends on `ReactiveUI.Primitives`, `ReactiveUI.Primitives.Async`, and `SerialPortRx`.
-- `OmronPlcRx.Reactive` is a separate package for System.Reactive/Rx-based applications. It depends on `ReactiveUI.Primitives.Reactive`, `ReactiveUI.Primitives.Async.Reactive`, and `SerialPortRx.Reactive`.
-- `OmronPlcRx.Reactive` uses `OmronPlcRx.Reactive.*` namespaces. For example, `OmronPlcRx.IOmronPlcRx` becomes `OmronPlcRx.Reactive.IOmronPlcRx`.
-- Both package surfaces are built from shared source, but the reactive shim compiles with `REACTIVE_SHIM` and has its own namespaces, result types, enum types, tag types, and BCD wrapper types.
-- Source-generated async observable members are generated only for `net8.0` and later.
-- `Value<T>(tagName, value)` remains fire-and-forget. Write failures are delivered through `Errors`; they are not thrown synchronously by the setter call.
-
-Use `OmronPlcRx` for new applications that are comfortable with `ReactiveUI.Primitives` and BCL `IObservable<T>`. Use `OmronPlcRx.Reactive` when an existing application already uses System.Reactive operators, schedulers, and package conventions.
-
-## Packages
-
-| Package | Primary namespaces | Use when |
-| --- | --- | --- |
-| `OmronPlcRx` | `OmronPlcRx`, `OmronPlcRx.Enums`, `OmronPlcRx.Tags`, `OmronPlcRx.Results`, `OmronPlcRx.Async` | New or lean applications using `ReactiveUI.Primitives`. |
-| `OmronPlcRx.Reactive` | `OmronPlcRx.Reactive`, `OmronPlcRx.Reactive.Enums`, `OmronPlcRx.Reactive.Tags`, `OmronPlcRx.Reactive.Results`, `OmronPlcRx.Reactive.Async` | System.Reactive/Rx-first applications. |
-| `OmronPlcRx.SourceGenerators` | `OmronPlcRx.SourceGenerators` | Analyzer implementation used by the runtime packages to generate `[PlcTag]` members. Most consumers get it through `OmronPlcRx` or `OmronPlcRx.Reactive`. |
-
-## Installation
-
-Base package:
+## Install
 
 ```bash
 dotnet add package OmronPlcRx
-```
-
-Rx/System.Reactive package:
-
-```bash
+# Or, for System.Reactive applications:
 dotnet add package OmronPlcRx.Reactive
 ```
 
-Package Manager:
+## Quick start
 
-```powershell
-Install-Package OmronPlcRx
-Install-Package OmronPlcRx.Reactive
-```
-
-## Quick Start
+The public network constructor takes `OmronConnectionOptions` and an explicit nullable poll interval.
 
 ```csharp
-using OmronPlcRx;
-using OmronPlcRx.Core.Types;
-using OmronPlcRx.Enums;
-using ReactiveUI.Primitives;
-
-using var plc = new OmronPlcRx.OmronPlcRx(
-    localNodeId: 11,
-    remoteNodeId: 1,
-    connectionMethod: ConnectionMethod.UDP,
-    remoteHost: "192.168.250.1",
-    port: 9600,
-    timeout: 2000,
-    retries: 1,
-    pollInterval: TimeSpan.FromMilliseconds(200));
-
-plc.AddUpdateTagItem<bool>("D100.0", "MotorRun");
-plc.AddUpdateTagItem<short>("D200", "TemperatureRaw");
-plc.AddUpdateTagItem<int>("D300", "BatchCounter");
-plc.AddUpdateTagItem<float>("D400", "TankLevel");
-plc.AddUpdateTagItem<double>("D500", "TotalizedFlow");
-plc.AddUpdateTagItem<string>("D600[20]", "LineName");
-plc.AddUpdateTagItem<Bcd16>("D700", "BcdTemperature");
-
-using var motorSubscription = plc.Observe<bool>("MotorRun")
-    .DistinctUntilChanged()
-    .SubscribeSafe(
-        value => Console.WriteLine($"MotorRun -> {value}"),
-        error => Console.WriteLine(error.Message));
-
-using var allTagsSubscription = plc.ObserveAll.SubscribeSafe(
-    tag => Console.WriteLine($"{tag?.TagName} = {tag?.Value}"),
-    error => Console.WriteLine(error.Message));
-
-using var errorSubscription = plc.Errors.SubscribeSafe(
-    error => Console.WriteLine($"PLC error: {error?.Message}"),
-    error => Console.WriteLine(error.Message));
-
-plc.Value("MotorRun", true);
-plc.Value("LineName", "Filling Line 1");
-plc.Value("BcdTemperature", new Bcd16(235));
-
-short? cachedTemperature = plc.Value<short>("TemperatureRaw");
-Console.WriteLine($"Cached temperature = {cachedTemperature}");
-
-var clock = await plc.ReadClockAsync();
-Console.WriteLine($"PLC clock: {clock.Clock:o}");
-
-var cycle = await plc.ReadCycleTimeAsync();
-Console.WriteLine($"Cycle time min={cycle.MinimumCycleTime} max={cycle.MaximumCycleTime} avg={cycle.AverageCycleTime}");
-```
-
-## Serial Quick Start
-
-Host Link FINS:
-
-```csharp
-using System.IO.Ports;
-using OmronPlcRx;
-using OmronPlcRx.Enums;
-using ReactiveUI.Primitives;
-
-using var plc = new OmronPlcRx.OmronPlcRx(
-    localNodeId: 11,
-    remoteNodeId: 0,
-    serialOptions: new OmronSerialOptions("COM3")
-    {
-        BaudRate = 9600,
-        DataBits = 7,
-        Parity = Parity.Even,
-        StopBits = StopBits.Two,
-        Handshake = Handshake.None,
-        HostLinkUnitNumber = 0,
-        ResponseWaitTime = 0,
-        FrameMode = OmronHostLinkFinsFrameMode.Direct,
-    },
-    timeout: 2000,
-    retries: 1,
-    pollInterval: TimeSpan.FromMilliseconds(200));
-
-plc.AddUpdateTagItem<short>("D100", "LegacyValue");
-
-using var subscription = plc.Observe<short>("LegacyValue")
-    .SubscribeSafe(
-        value => Console.WriteLine($"D100 -> {value}"),
-        error => Console.WriteLine(error.Message));
-```
-
-Toolbus:
-
-```csharp
-using OmronPlcRx;
-using ReactiveUI.Primitives;
-
-using var plc = new OmronPlcRx.OmronPlcRx(
-    localNodeId: 11,
-    remoteNodeId: 0,
-    serialOptions: OmronSerialOptions.CreateToolbus("COM3"),
-    timeout: 2000,
-    retries: 1,
-    pollInterval: TimeSpan.FromMilliseconds(200));
-
-plc.AddUpdateTagItem<short>("D100", "ToolbusValue");
-
-using var subscription = plc.Observe<short>("ToolbusValue")
-    .SubscribeSafe(
-        value => Console.WriteLine($"D100 -> {value}"),
-        error => Console.WriteLine(error.Message));
-```
-
-Serial notes:
-
-- `OmronSerialOptions` defaults to Host Link FINS: `9600`, `7E2`, no handshake, direct frame mode, maximum frame length `1004`.
-- `OmronSerialOptions.CreateToolbus` applies common Toolbus settings: `115200`, `8N1`, no handshake, RTS enabled, maximum frame length `1004`.
-- `OmronHostLinkFinsFrameMode.Direct` uses direct CPU Host Link FINS framing.
-- `OmronHostLinkFinsFrameMode.Network` carries the complete FINS header for routed Host Link scenarios.
-- Classic C-mode Host Link commands are not implemented.
-
-## Rx Applications With OmronPlcRx.Reactive
-
-Use `OmronPlcRx.Reactive` when the consuming application is already based on System.Reactive and wants the Rx-oriented ReactiveUI.Primitives package variants.
-
-```csharp
-using OmronPlcRx.Reactive;
-using OmronPlcRx.Reactive.Enums;
-using OmronPlcRx.Reactive.Tags;
-using System.Reactive.Linq;
-
-using var plc = new OmronPlcRx.Reactive.OmronPlcRx(
-    localNodeId: 11,
-    remoteNodeId: 1,
-    connectionMethod: ConnectionMethod.TCP,
-    remoteHost: "192.168.250.1");
-
-plc.AddUpdateTagItem<bool>("D100.0", "MotorRun");
-plc.AddUpdateTagItem<short>("D200", "Speed");
-
-using var motorSubscription = plc.Observe<bool>("MotorRun")
-    .DistinctUntilChanged()
-    .Subscribe(
-        value => Console.WriteLine($"MotorRun -> {value}"),
-        error => Console.WriteLine(error.Message));
-
-using var allTagsSubscription = plc.ObserveAll
-    .Where(static tag => tag is not null)
-    .Subscribe(static tag => Console.WriteLine($"{tag!.TagName} = {tag.Value}"));
-
-IObservable<IPlcTag?> allChanges = plc.ObserveAll;
-IObservable<OmronPLCException?> errors = plc.Errors;
-```
-
-Namespace migration example:
-
-```csharp
-// Base package
-using OmronPlcRx;
-using OmronPlcRx.Enums;
-using OmronPlcRx.Tags;
-
-// Rx package
-using OmronPlcRx.Reactive;
-using OmronPlcRx.Reactive.Enums;
-using OmronPlcRx.Reactive.Tags;
-```
-
-The API shape is intentionally the same: `AddUpdateTagItem<T>`, `Observe<T>`, `ObserveAll`, `Errors`, `Value<T>(tagName)`, `Value<T>(tagName, value)`, `ReadClockAsync`, `WriteClockAsync`, `ReadCycleTimeAsync`, and `Dispose`.
-
-## R3 Bridge
-
-ReactiveUI.Primitives can generate R3 bridge extension methods in the consuming project when the required R3 symbols are visible. Use the bridge at application boundaries and keep the rest of a pipeline in one reactive model.
-
-Install the packages your app needs:
-
-```bash
-dotnet add package OmronPlcRx
-dotnet add package ReactiveUI.Primitives
-dotnet add package ReactiveUI.Primitives.Async
-dotnet add package R3
-```
-
-Convert PLC `IObservable<T>` streams to R3:
-
-```csharp
-using OmronPlcRx;
-using OmronPlcRx.Enums;
-using ReactiveUI.Primitives.R3Bridge;
-
-using var plc = new OmronPlcRx.OmronPlcRx(11, 1, ConnectionMethod.UDP, "192.168.250.1");
-plc.AddUpdateTagItem<short>("D200", "Speed");
-
-R3.Observable<short?> speedR3 = plc.Observe<short>("Speed").AsR3Observable();
-
-using var subscription = speedR3.Subscribe(value => Console.WriteLine($"Speed -> {value}"));
-```
-
-Convert R3 streams back to ReactiveUI.Primitives:
-
-```csharp
-using ReactiveUI.Primitives.R3Bridge;
-
-R3.Observable<bool> command = GetMotorCommandStream();
-IObservable<bool> primitivesSignal = command.AsPrimitivesSignal();
-```
-
-Bridge async PLC streams:
-
-```csharp
-using OmronPlcRx.Async;
-using ReactiveUI.Primitives.Async;
-using ReactiveUI.Primitives.R3Bridge;
-
-IObservableAsync<short?> speedAsync = plc.ObserveAsAsyncObservable<short>("Speed");
-R3.Observable<short?> speedR3 = speedAsync.AsR3Observable();
-IObservableAsync<short?> backToAsync = speedR3.AsPrimitivesAsyncObservable<short?>();
-```
-
-When using `R3Async`, the async bridge generator emits `AsPrimitivesAsyncObservable<T>(this R3Async.AsyncObservable<T>)` and `AsR3AsyncObservable<T>(this IObservableAsync<T>)` when the R3Async symbols and `ReactiveUI.Primitives.Async.IObservableAsync<T>` are visible.
-
-## Addressing Guide
-
-Supported memory area prefixes:
-
-| Prefix | Memory area |
-| --- | --- |
-| `D`, `DM` | Data Memory |
-| `C`, `CIO` | Common I/O |
-| `W` | Work |
-| `H` | Holding |
-| `A` | Auxiliary, restricted on some PLC models |
-
-Bit address syntax is `<Area><Word>.<Bit>`, where bit is `0` through `15`.
-
-```csharp
-plc.AddUpdateTagItem<bool>("D100.0", "MotorRun");
-plc.AddUpdateTagItem<bool>("W50.7", "WorkFlag");
-plc.AddUpdateTagItem<bool>("CIO200.15", "InputSignal");
-```
-
-Word address syntax is `<Area><Word>`.
-
-```csharp
-plc.AddUpdateTagItem<short>("D200", "TemperatureRaw");
-plc.AddUpdateTagItem<ushort>("H10", "HoldingWord");
-plc.AddUpdateTagItem<int>("CIO500", "Counter");
-```
-
-String address syntax is `<Area><Word>[<Length>]`, where length is character count. If the length suffix is omitted, the runtime uses `16` characters.
-
-```csharp
-plc.AddUpdateTagItem<string>("D600[20]", "LineName");
-plc.Value("LineName", "Filling Line 1");
-```
-
-Strings are ASCII and packed as two characters per PLC word, high byte first. Short values are null padded.
-
-## Supported Types And Encoding
-
-| C# type | PLC storage | Notes |
-| --- | --- | --- |
-| `bool` | 1 bit or 1 word | Bit address reads/writes one bit. Word address treats non-zero as `true`. |
-| `byte` | 1 word | Uses the low byte. |
-| `short` | 1 word | Signed 16-bit word. |
-| `ushort` | 1 word | Unsigned 16-bit word. |
-| `int` | 2 words | Low word first in PLC memory, high word second. |
-| `uint` | 2 words | Low word first in PLC memory, high word second. |
-| `float` | 2 words | IEEE 754 single. |
-| `double` | 4 words | IEEE 754 double. |
-| `string` | N words | ASCII, two characters per word, optional `[length]` suffix. |
-| `Bcd16` | 1 word | Signed packed BCD wrapper. |
-| `BcdU16` | 1 word | Unsigned packed BCD wrapper. |
-| `Bcd32` | 2 words | Signed packed BCD wrapper. |
-| `BcdU32` | 2 words | Unsigned packed BCD wrapper. |
-
-Example:
-
-```csharp
-plc.AddUpdateTagItem<uint>("D720", "UnsignedCounter");
-plc.AddUpdateTagItem<double>("D500", "TotalizedFlow");
-plc.AddUpdateTagItem<Bcd32>("D710", "BatchNumber");
-
-plc.Value("UnsignedCounter", 1234u);
-plc.Value("BatchNumber", new Bcd32(12345678));
-```
-
-## Source Generators
-
-The runtime packages include the OmronPlcRx source generator as an analyzer. Add `[PlcTag]` to fields in a partial class to generate strongly typed properties, observable streams, registration helpers, binding helpers, write helpers, and partial hooks.
-
-```csharp
-using OmronPlcRx;
-using OmronPlcRx.Core.Types;
-
-public sealed partial class MachineState
+using IoT.DriverCore.Core;
+using IoT.DriverCore.OmronPlcRx;
+using IoT.DriverCore.OmronPlcRx.Enums;
+using IoT.DriverCore.OmronPlcRx.Tags;
+
+var motorRun = new PlcTag<bool>("MotorRun", "D100.0");
+var temperature = new PlcTag<short>("Temperature", "D200");
+var options = new OmronConnectionOptions(11, 1, ConnectionMethod.UDP, "192.168.250.1")
 {
-    [PlcTag("D100", Writable = true)]
-    private short _tankLevel;
-
-    [PlcTag("D100.0", TagName = "PumpRun")]
-    private bool _pumpRunning;
-
-    [PlcTag("D600[20]")]
-    private string _lineName = string.Empty;
-
-    [PlcTag("D700")]
-    private Bcd16 _bcdTemperature;
-
-    partial void OnTankLevelReceived(short value)
-    {
-        Console.WriteLine($"Tank level changed to {value}");
-    }
-}
-```
-
-Generated members for the sample above:
-
-```csharp
-public short TankLevel { get; private set; }
-public bool PumpRunning { get; private set; }
-public string LineName { get; private set; }
-public Bcd16 BcdTemperature { get; private set; }
-
-public IObservable<short> TankLevelObservable { get; }
-public IObservable<bool> PumpRunningObservable { get; }
-public IObservable<string> LineNameObservable { get; }
-public IObservable<Bcd16> BcdTemperatureObservable { get; }
-
-// net8.0 and later only
-public IObservableAsync<short> TankLevelObservableAsync { get; }
-
-public void RegisterPlcTags(IOmronPlcRx plc);
-public IDisposable BindPlcTags(IOmronPlcRx plc);
-public void WriteTankLevel(IOmronPlcRx plc, short value);
-
-partial void OnTankLevelReceived(short value);
-partial void OnPumpRunningReceived(bool value);
-partial void OnLineNameReceived(string value);
-partial void OnBcdTemperatureReceived(Bcd16 value);
-```
-
-Use the generated API:
-
-```csharp
-using ReactiveUI.Primitives;
-
-var state = new MachineState();
-
-using var binding = state.BindPlcTags(plc);
-using var tankSubscription = state.TankLevelObservable.SubscribeSafe(
-    value => Console.WriteLine($"TankLevel -> {value}"),
-    error => Console.WriteLine(error.Message));
-
-state.WriteTankLevel(plc, 456);
-```
-
-Use generated async observable members on `net8.0+`:
-
-```csharp
-using ReactiveUI.Primitives.Async;
-
-IObservableAsync<short> tankLevelAsync = state.TankLevelObservableAsync;
-```
-
-Source generator attribute API:
-
-| Member | Description | Example |
-| --- | --- | --- |
-| `PlcTagAttribute(string address)` | Required PLC address. | `[PlcTag("D100.0")]` |
-| `TagName` | Optional logical PLC tag name. Defaults to generated property name. | `[PlcTag("D100.0", TagName = "PumpRun")]` |
-| `Register` | When `true`, `RegisterPlcTags` calls `AddUpdateTagItem<T>`. Default is `true`. | `[PlcTag("D100", Register = false)]` |
-| `Observe` | When `true`, `BindPlcTags` subscribes to `plc.Observe<T>`. Default is `true`. | `[PlcTag("D100", Observe = false)]` |
-| `Writable` | When `true`, the generator emits `Write<Property>(IOmronPlcRx plc, T value)`. Default is `false`. | `[PlcTag("D100", Writable = true)]` |
-
-Generator diagnostics:
-
-| Diagnostic | Meaning |
-| --- | --- |
-| `OPRX001` | The containing type must be `partial`. |
-| `OPRX002` | The field type is not a supported PLC tag type. |
-| `OPRX003` | The address argument is missing or empty. |
-| `OPRX004` | The generated property name collides with an existing member. |
-
-Reactive package source generation:
-
-```csharp
-using OmronPlcRx.Reactive;
-using ReactiveBcd16 = OmronPlcRx.Reactive.Core.Types.Bcd16;
-
-namespace OmronPlcRx.Reactive.Example;
-
-public sealed partial class ReactiveMachineState
-{
-    [PlcTag("D100", Writable = true)]
-    private short _tankLevel;
-
-    [PlcTag("D700")]
-    private ReactiveBcd16 _bcdTemperature;
-}
-```
-
-When the containing namespace is `OmronPlcRx.Reactive` or starts with `OmronPlcRx.Reactive.`, generated helper signatures use `global::OmronPlcRx.Reactive.IOmronPlcRx` and reactive async bridge helpers.
-
-## Full API Reference
-
-The public API is namespace-shifted between the base and reactive packages. Replace `OmronPlcRx` with `OmronPlcRx.Reactive` for the reactive package unless a section explicitly says otherwise.
-
-### `OmronPlcRx.OmronPlcRx`
-
-High-level facade for tag registration, polling, observation, cached values, writes, clock access, cycle time access, and disposal.
-
-#### Constructors
-
-```csharp
-public OmronPlcRx(
-    byte localNodeId,
-    byte remoteNodeId,
-    ConnectionMethod connectionMethod,
-    string remoteHost,
-    int port = 9600,
-    int timeout = 2000,
-    int retries = 1,
-    TimeSpan? pollInterval = null);
-```
-
-Creates a TCP or UDP PLC facade. `localNodeId` and `remoteNodeId` are FINS node identifiers. `remoteHost` is the PLC hostname or IP address. `timeout` is in milliseconds. `retries` controls transient retry attempts. `pollInterval` defaults to `100` ms.
-
-```csharp
-using var plc = new OmronPlcRx.OmronPlcRx(
-    11,
-    1,
-    ConnectionMethod.TCP,
-    "192.168.250.1",
-    port: 9600,
-    timeout: 2000,
-    retries: 1,
-    pollInterval: TimeSpan.FromMilliseconds(250));
-```
-
-```csharp
-public OmronPlcRx(
-    byte localNodeId,
-    byte remoteNodeId,
-    OmronSerialOptions serialOptions,
-    int timeout = 2000,
-    int retries = 1,
-    TimeSpan? pollInterval = null);
-```
-
-Creates a serial FINS PLC facade. The transport is selected by `serialOptions.Protocol`.
-
-```csharp
-using var plc = new OmronPlcRx.OmronPlcRx(
-    11,
-    0,
-    OmronSerialOptions.CreateToolbus("COM3"),
-    timeout: 2000,
-    retries: 1);
-```
-
-#### Properties
-
-| Property | Description | Example |
-| --- | --- | --- |
-| `IObservable<IPlcTag?> ObserveAll` | Emits each tag that changes during polling. | `using var sub = plc.ObserveAll.SubscribeSafe(tag => Console.WriteLine(tag?.TagName), ex => Console.WriteLine(ex.Message));` |
-| `IObservable<OmronPLCException?> Errors` | Emits initialization, polling, and write failures. | `using var sub = plc.Errors.SubscribeSafe(ex => Console.WriteLine(ex?.Message), ex => Console.WriteLine(ex.Message));` |
-| `bool IsDisposed` | Indicates whether the facade has been disposed. | `if (plc.IsDisposed) return;` |
-| `PLCType PLCType` | Detected controller type after initialization. | `Console.WriteLine(plc.PLCType);` |
-| `string? ControllerModel` | Controller model returned by CPU unit data. | `Console.WriteLine(plc.ControllerModel);` |
-| `string? ControllerVersion` | Controller version returned by CPU unit data. | `Console.WriteLine(plc.ControllerVersion);` |
-
-#### Methods
-
-`AddUpdateTagItem<T>(string variable, string tagName)` registers or replaces a tag definition.
-
-```csharp
-plc.AddUpdateTagItem<bool>("D100.0", "MotorRun");
-plc.AddUpdateTagItem<short>("D200", "TemperatureRaw");
-```
-
-`Observe<T>(string? tagName)` returns a typed observable for a registered tag. It throws `ArgumentNullException` when `tagName` is null.
-
-```csharp
-using var subscription = plc.Observe<short>("TemperatureRaw")
-    .SubscribeSafe(value => Console.WriteLine(value), error => Console.WriteLine(error.Message));
-```
-
-`Value<T>(string? tagName)` returns the last cached value for a registered tag, or `default` when the tag has not been read or the requested type does not match.
-
-```csharp
-short? cached = plc.Value<short>("TemperatureRaw");
-```
-
-`Value<T>(string? tagName, T? value)` writes a value to the PLC asynchronously in the background. The tag must already be registered with the same `T`.
-
-```csharp
-plc.Value("MotorRun", true);
-plc.Value("LineName", "Line 1");
-plc.Value("BcdTemperature", new Bcd16(235));
-```
-
-`ReadClockAsync(CancellationToken cancellationToken = default)` reads the PLC real-time clock.
-
-```csharp
-ReadClockResult clock = await plc.ReadClockAsync(cancellationToken);
-Console.WriteLine($"{clock.Clock:o}, day={clock.DayOfWeek}");
-```
-
-`WriteClockAsync(DateTime newDateTime, CancellationToken cancellationToken = default)` writes the PLC real-time clock and infers the day-of-week from `newDateTime`.
-
-```csharp
-WriteClockResult result = await plc.WriteClockAsync(DateTime.Now, cancellationToken);
-Console.WriteLine($"Clock write took {result.Duration} ms");
-```
-
-`WriteClockAsync(DateTime newDateTime, int newDayOfWeek, CancellationToken cancellationToken = default)` writes the PLC real-time clock with an explicit day-of-week value from `0` through `6`.
-
-```csharp
-await plc.WriteClockAsync(DateTime.Now, newDayOfWeek: 3, cancellationToken);
-```
-
-`ReadCycleTimeAsync(CancellationToken cancellationToken = default)` reads scan cycle time statistics.
-
-```csharp
-ReadCycleTimeResult cycle = await plc.ReadCycleTimeAsync(cancellationToken);
-Console.WriteLine($"{cycle.MinimumCycleTime}/{cycle.MaximumCycleTime}/{cycle.AverageCycleTime}");
-```
-
-`Dispose()` stops polling, completes observables, disposes signals, disposes the underlying PLC channel, and releases cancellation resources.
-
-```csharp
-plc.Dispose();
-```
-
-### `IOmronPlcRx`
-
-`IOmronPlcRx` defines the facade contract and inherits `ReactiveUI.Primitives.Disposables.IsDisposed`.
-
-```csharp
-public sealed class MachineService(IOmronPlcRx plc)
-{
-    public IDisposable Start()
-    {
-        plc.AddUpdateTagItem<bool>("D100.0", "MotorRun");
-        return plc.Observe<bool>("MotorRun")
-            .SubscribeSafe(value => Console.WriteLine(value), error => Console.WriteLine(error.Message));
-    }
-}
-```
-
-Interface members match the high-level facade: `ObserveAll`, `Errors`, `PLCType`, `ControllerModel`, `ControllerVersion`, `AddUpdateTagItem<T>`, `Observe<T>`, `Value<T>(tagName)`, `Value<T>(tagName, value)`, `ReadClockAsync`, `WriteClockAsync`, and `ReadCycleTimeAsync`.
-
-### Async Observable Extensions
-
-Namespace: `OmronPlcRx.Async` or `OmronPlcRx.Reactive.Async`.
-
-`ObserveAsAsyncObservable<T>(this IOmronPlcRx plc, string? tagName)` converts a typed tag stream to `IObservableAsync<T?>`.
-
-```csharp
-using OmronPlcRx.Async;
-using ReactiveUI.Primitives.Async;
-
-IObservableAsync<short?> speed = plc.ObserveAsAsyncObservable<short>("Speed");
-```
-
-`ObserveAllAsAsyncObservable(this IOmronPlcRx plc)` converts `ObserveAll` to `IObservableAsync<IPlcTag?>`.
-
-```csharp
-IObservableAsync<OmronPlcRx.Tags.IPlcTag?> all = plc.ObserveAllAsAsyncObservable();
-```
-
-`ErrorsAsAsyncObservable(this IOmronPlcRx plc)` converts `Errors` to `IObservableAsync<OmronPLCException?>`.
-
-```csharp
-IObservableAsync<OmronPLCException?> errors = plc.ErrorsAsAsyncObservable();
-```
-
-`ObserveValuesAsync<T>(this IOmronPlcRx plc, string? tagName, CancellationToken cancellationToken = default)` exposes a tag stream as `IAsyncEnumerable<T?>`.
-
-```csharp
-await foreach (short? value in plc.ObserveValuesAsync<short>("Speed", cancellationToken))
-{
-    Console.WriteLine(value);
-}
-```
-
-### Tags
-
-`IPlcTag` exposes tag metadata and the boxed latest value.
-
-| Member | Description |
-| --- | --- |
-| `string Address` | PLC address such as `D100`, `D100.0`, or `D600[20]`. |
-| `Type TagType` | CLR tag value type. |
-| `string TagName` | Logical tag name used by `Observe<T>` and `Value<T>`. |
-| `object? Value` | Latest cached value boxed as `object`. |
-
-```csharp
-using var sub = plc.ObserveAll.SubscribeSafe(tag =>
-{
-    Console.WriteLine($"{tag?.TagName} ({tag?.Address}) = {tag?.Value}");
-}, error => Console.WriteLine(error.Message));
-```
-
-`PlcTag<T>(string tagName, string address)` is the typed metadata implementation.
-
-```csharp
-var tag = new OmronPlcRx.Tags.PlcTag<short>("TemperatureRaw", "D200");
-Console.WriteLine($"{tag.TagName} -> {tag.Address} ({tag.TagType.Name})");
-```
-
-### Serial Options And Protocol Enums
-
-`OmronSerialOptions(string portName)` creates serial configuration for Host Link FINS by default.
-
-```csharp
-var options = new OmronSerialOptions("COM3")
-{
-    BaudRate = 9600,
-    DataBits = 7,
-    Parity = System.IO.Ports.Parity.Even,
-    StopBits = System.IO.Ports.StopBits.Two,
-    Protocol = OmronSerialProtocol.HostLinkFins,
-    HostLinkUnitNumber = 0,
-    ResponseWaitTime = 0,
-    FrameMode = OmronHostLinkFinsFrameMode.Direct,
-    MaximumFrameLength = 1004,
-};
-```
-
-`CreateToolbus(string portName)` creates Toolbus settings.
-
-```csharp
-OmronSerialOptions toolbus = OmronSerialOptions.CreateToolbus("COM3");
-```
-
-`Validate()` checks protocol, Host Link unit range, response wait range, baud rate, data bits, and frame length.
-
-```csharp
-options.Validate();
-```
-
-`OmronSerialOptions` properties:
-
-| Property | Default | Description |
-| --- | --- | --- |
-| `PortName` | Constructor argument | Serial port name. |
-| `BaudRate` | `9600` | Serial baud rate. |
-| `DataBits` | `7` | Serial data bits. |
-| `Parity` | `Even` | Serial parity. |
-| `StopBits` | `Two` | Serial stop bits. |
-| `Handshake` | `None` | Serial handshake. |
-| `RtsEnable` | `false` | RTS line state. |
-| `DtrEnable` | `false` | DTR line state. |
-| `Protocol` | `HostLinkFins` | `HostLinkFins` or `Toolbus`. |
-| `HostLinkUnitNumber` | `0` | Host Link unit number, `0` through `31`. |
-| `ResponseWaitTime` | `0` | Host Link response wait value, `0` through `15`. |
-| `FrameMode` | `Direct` | Host Link FINS frame layout. |
-| `MaximumFrameLength` | `1004` | Maximum serial frame length. |
-
-### Frame Codecs
-
-`HostLinkFinsFrameCodec` encodes and decodes Host Link FINS ASCII frames.
-
-```csharp
-var options = new OmronSerialOptions("COM3")
-{
-    HostLinkUnitNumber = 0,
-    FrameMode = OmronHostLinkFinsFrameMode.Direct,
+    Port = 9600,
+    Timeout = 2000,
+    Retries = 1,
 };
 
-var codec = new HostLinkFinsFrameCodec(options);
-string fcs = HostLinkFinsFrameCodec.CalculateFcs("@00FA000");
-string requestFrame = codec.EncodeRequest(finsRequestBytes);
-Memory<byte> finsResponse = codec.DecodeResponse(responseFrameText);
+using var plc = new OmronPlcRx(options, TimeSpan.FromMilliseconds(200));
+plc.AddUpdateTagItem(motorRun);
+plc.AddUpdateTagItem(temperature);
+
+var motor = new LogicalTagKey<bool>("MotorRun");
+using var subscription = plc.Observe(motor).Subscribe(value => Console.WriteLine(value));
+
+await plc.WriteValueAsync(motor, true, CancellationToken.None);
+short? value = await plc.ReadValueAsync(new LogicalTagKey<short>("Temperature"), CancellationToken.None);
 ```
 
-| Function | Description |
-| --- | --- |
-| `HostLinkFinsFrameCodec(OmronSerialOptions options)` | Stores and validates Host Link options. |
-| `CalculateFcs(string frameText)` | Calculates the two-character Host Link FCS over text from `@` through the final payload character, excluding FCS and terminator. |
-| `EncodeRequest(ReadOnlyMemory<byte> finsMessage)` | Encodes a binary FINS request to an ASCII Host Link frame with FCS and `*\r` terminator. |
-| `DecodeResponse(string frame)` | Validates FCS, terminator, unit, header, and end code, then returns the binary FINS response. |
+## Configuration
 
-`ToolbusFinsFrameCodec` encodes and decodes binary Toolbus frames.
+Create `OmronConnectionOptions(localNodeId, remoteNodeId, connectionMethod, remoteHost)`. Its init-only settings are `Port` (9600), `Timeout` milliseconds (2000), `Retries` (1), and optional `SerialOptions`.
+
+For serial, use the dedicated constructor and supply every parameter:
 
 ```csharp
-ReadOnlyMemory<byte> sync = ToolbusFinsFrameCodec.SynchronizationFrame;
-Memory<byte> requestFrame = ToolbusFinsFrameCodec.EncodeRequest(finsRequestBytes);
-Memory<byte> finsResponse = ToolbusFinsFrameCodec.DecodeResponse(toolbusResponseBytes);
-ushort checksum = ToolbusFinsFrameCodec.CalculateChecksum(requestFrame.Span[..^2]);
+using IoT.DriverCore.OmronPlcRx;
+
+var serial = OmronSerialOptions.CreateToolbus("COM3");
+using var plc = new OmronPlcRx(11, 0, serial, 2000, 1, TimeSpan.FromMilliseconds(250));
 ```
 
-| Function | Description |
-| --- | --- |
-| `SynchronizationFrame` | Returns the Toolbus synchronization frame `AC 01`. |
-| `EncodeRequest(ReadOnlyMemory<byte> finsMessage)` | Wraps a binary FINS request in a Toolbus `0xAB` frame with length and checksum. |
-| `DecodeResponse(ReadOnlyMemory<byte> frame)` | Validates Toolbus frame header, length, checksum, and FINS payload header, then returns the FINS payload. |
-| `CalculateChecksum(ReadOnlySpan<byte> data)` | Calculates the 16-bit additive Toolbus checksum. |
+`OmronSerialOptions` defaults to Host Link FINS (`9600`, `7E2`, no handshake). `CreateToolbus` sets Toolbus, `115200`, `8N1`, and RTS. Call `Validate()` before connecting when options are composed dynamically. Host Link supports `Direct` and `Network` `OmronHostLinkFinsFrameMode` values; classic C-mode Host Link is not the API exposed by this driver.
 
-### BCD Types And Converter
+FINS addresses supported by the typed tag codec include bit forms such as `D100.0` and word forms such as `D200`; strings use `D600[20]`. Use a tag type matching PLC storage: `bool`, integer types, `float`, `double`, `string`, and `Bcd16`, `BcdU16`, `Bcd32`, or `BcdU32`.
 
-BCD wrapper types live in `OmronPlcRx.Core.Types` or `OmronPlcRx.Reactive.Core.Types`.
+## Detailed features
+
+### Typed tags, polling, and fault handling
+
+`ObserveAll` emits changed `IPlcTag` instances and `Errors` emits `OmronPLCException`. Use a logical key whose type exactly matches the registered tag.
 
 ```csharp
-var signed16 = new Bcd16(235);
-var unsigned16 = new BcdU16(235);
-var signed32 = new Bcd32(12345678);
-var unsigned32 = new BcdU32(12345678);
+using IoT.DriverCore.Core;
+using IoT.DriverCore.OmronPlcRx.Tags;
 
-Console.WriteLine(signed16.Value);
-Console.WriteLine(signed32.ToString());
+var level = new PlcTag<float>("TankLevel", "D400");
+plc.AddUpdateTagItem(level);
+
+using var changes = plc.ObserveAll.Subscribe(tag =>
+    Console.WriteLine($"{tag?.TagName}: {tag?.Value}"));
+using var errors = plc.Errors.Subscribe(error => Console.Error.WriteLine(error?.Message));
+
+var levelKey = new LogicalTagKey<float>("TankLevel");
+plc.SetValue(levelKey, 12.5f);                 // fire-and-forget
+await plc.WriteValueAsync(levelKey, 12.5f, CancellationToken.None); // awaited command
+float? cached = plc.GetValue(levelKey);
+bool removed = plc.RemoveTagItem("TankLevel");
 ```
 
-`BCDConverter` lives in `OmronPlcRx.Core.Converters` or `OmronPlcRx.Reactive.Core.Converters`.
+### Clock and scan-time operations
 
-| Function | Description | Example |
+```csharp
+var clock = await plc.ReadClockAsync(CancellationToken.None);
+Console.WriteLine(clock.Clock);
+
+await plc.WriteClockAsync(DateTimeOffset.UtcNow, CancellationToken.None);
+var cycle = await plc.ReadCycleTimeAsync(CancellationToken.None);
+Console.WriteLine($"min={cycle.MinimumCycleTime}, max={cycle.MaximumCycleTime}");
+```
+
+`ReadClockResult`, `WriteClockResult`, `ReadCycleTimeResult`, `ReadBitsResult`, `ReadWordsResult`, `WriteBitsResult`, and `WriteWordsResult` expose transport counters, duration, and their operation-specific payload.
+
+### Async observation and simulation
+
+`OmronPlcRxAsyncObservableExtensions` provides `ObserveAsAsyncObservable`, `ObserveAllAsAsyncObservable`, `ErrorsAsAsyncObservable`, and `ObserveValuesAsync`. Use `OmronPlcSimulator` for deterministic application tests: construct it, `Seed(tag, value)`, optionally `QueueFault`, then exercise the same `IOmronPlcRx` API. It records `OmronSimulatorOperationRecord` values in `Operations`.
+
+### Source-generated bindings
+
+Apply `PlcTagAttribute` to a field in a partial class. The included analyzer generates registration, observation, and optional write helpers. Its configurable members are `TagName`, `Register`, `Observe`, and `Writable`; `PlcTagBindingAttribute` marks a binding target. Treat generated member names as analyzer output and keep the containing type partial.
+
+## Exhaustive feature guide and worked workflows
+
+The driver uses a *definition* (`PlcTag<T>`) and a *lookup key* (`LogicalTagKey<T>`). A definition has a logical `TagName` and FINS `Address`; a key contains only the logical name and must use the same `T`. This makes wrong address/type combinations visible at registration rather than allowing untyped strings to flow through every command. The reactive package has the same shape beneath `IoT.DriverCore.OmronPlcRx.Reactive`; do not mix base and reactive tag/key types.
+
+### Network constructors, serial constructors, and options validation
+
+`OmronConnectionOptions` is the network constructor input: local node ID, remote node ID, `ConnectionMethod.TCP` or `UDP`, remote host, optional port, timeout, retry count, and optional serial options. Its values are immutable after construction except through the initializer, so build and validate it before creating a long-lived client. The serial constructor takes `(localNodeId, remoteNodeId, OmronSerialOptions, timeout, retries, pollInterval)`. `pollInterval` is nullable: provide a positive interval for automatic tag polling; use `null` only when the application performs direct reads deliberately.
+
+```csharp
+using IoT.DriverCore.OmronPlcRx;
+using IoT.DriverCore.OmronPlcRx.Enums;
+
+var options = new OmronConnectionOptions(11, 1, ConnectionMethod.TCP, "192.168.250.1")
+{
+    Port = 9600,
+    Timeout = 2_000,
+    Retries = 2,
+};
+
+using var plc = new OmronPlcRx(options, TimeSpan.FromMilliseconds(250));
+
+var serialOptions = OmronSerialOptions.CreateToolbus("COM3");
+serialOptions.Validate();
+using var serialPlc = new OmronPlcRx(11, 0, serialOptions, 2_000, 1,
+    TimeSpan.FromMilliseconds(250));
+```
+
+`OmronSerialOptions` models COM port, baud rate, data bits, parity, stop bits, handshake, Host Link unit number, response wait, maximum frame length, protocol, and Host Link FINS frame mode. The default is Host Link FINS at `9600 7E2`. `CreateToolbus` changes the protocol and standard Toolbus framing (`115200 8N1` with RTS). `HostLinkFinsFrameMode.Direct` is direct CPU framing; `Network` carries the full routed FINS header. `Validate()` throws for invalid combinations before a connection is attempted; communication/PLC errors arrive as `OmronPLCException` through `Errors` or from awaited calls.
+
+### Addressing, supported values, BCD, and codec behaviour
+
+Use FINS addresses with the data area prefix: `D100.0` is one data-memory bit, `D200` one word, and `D600[20]` a string region. Match the tag generic type to the physical storage. Supported codecs include `bool`, signed/unsigned integral types, `float`, `double`, `string`, and `Bcd16`, `BcdU16`, `Bcd32`, `BcdU32`. BCD wrappers state that a value is decimal packed BCD rather than a normal signed binary integer; construct them from the logical numeric value. `BCDConverter` is the explicit conversion utility when an application must inspect raw BCD words. `MemoryBitDataType` and `MemoryWordDataType` describe areas used by lower-level FINS operations, while `PlcType` is detected controller metadata.
+
+```csharp
+using IoT.DriverCore.Core;
+using IoT.DriverCore.OmronPlcRx.Core.Types;
+using IoT.DriverCore.OmronPlcRx.Tags;
+
+plc.AddUpdateTagItem(new PlcTag<bool>("PumpEnabled", "D100.0"));
+plc.AddUpdateTagItem(new PlcTag<int>("BatchCount", "D300"));
+plc.AddUpdateTagItem(new PlcTag<string>("RecipeName", "D600[20]"));
+plc.AddUpdateTagItem(new PlcTag<Bcd16>("TemperatureBcd", "D700"));
+
+var bcdKey = new LogicalTagKey<Bcd16>("TemperatureBcd");
+await plc.WriteValueAsync(bcdKey, new Bcd16(235), CancellationToken.None);
+Bcd16? displayed = await plc.ReadValueAsync(bcdKey, CancellationToken.None);
+Console.WriteLine(displayed?.Value);
+```
+
+### Registration, cache, observations, and direct commands
+
+`AddUpdateTagItem(PlcTag<T>)` registers or updates the logical definition. `RemoveTagItem(name)` returns `true` only if a definition existed. `GetValue(key)` is cached and therefore never a substitute for a command read. `Observe(key)` emits changed values for one registered definition, while `ObserveAll` emits every changed `IPlcTag`. `SetValue(key, value)` starts a background write to preserve compatibility with reactive UIs; it has no completion result. Use `WriteValueAsync` for a command that requires acknowledgement, cancellation, or a catchable failure. `ReadValueAsync` directly reads and updates the cache. Keep `Errors` subscribed for polling/queued-write failures; error streams and subscriptions must be disposed independently of the facade.
+
+```csharp
+using IoT.DriverCore.Core;
+using IoT.DriverCore.OmronPlcRx.Tags;
+
+var pump = new LogicalTagKey<bool>("PumpEnabled");
+var batch = new LogicalTagKey<int>("BatchCount");
+using var changes = plc.Observe(pump).Subscribe(value => Console.WriteLine($"pump={value}"));
+using var all = plc.ObserveAll.Subscribe(tag => Console.WriteLine($"{tag?.TagName}={tag?.Value}"));
+using var errors = plc.Errors.Subscribe(error => Console.Error.WriteLine(error?.Message));
+
+plc.SetValue(pump, true); // queue-only: observe Errors for failure
+using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+try
+{
+    int? count = await plc.ReadValueAsync(batch, deadline.Token);
+    await plc.WriteValueAsync(pump, count is not null, deadline.Token);
+}
+catch (OperationCanceledException) { Console.Error.WriteLine("PLC command timed out."); }
+catch (OmronPLCException ex) { Console.Error.WriteLine(ex.Message); }
+```
+
+### PLC clock and cycle-time commands
+
+`ReadClockAsync(token)` returns `ReadClockResult`, whose clock value and operation metadata describe the reply. `WriteClockAsync(DateTimeOffset, token)` infers the day of week. `WriteClockAsync(DateTimeOffset, int dayOfWeek, token)` is the explicit overload; day of week must be 0–6. Both return `WriteClockResult`. `ReadCycleTimeAsync(token)` returns `ReadCycleTimeResult` with the controller's min/max/average cycle information. These calls operate directly on the controller and should be used sparingly during production; treat cancellation as an incomplete operation rather than proof it was not received.
+
+```csharp
+using var commandDeadline = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+try
+{
+    var before = await plc.ReadClockAsync(commandDeadline.Token);
+    Console.WriteLine($"PLC time: {before.Clock:O}");
+
+    var clockWrite = await plc.WriteClockAsync(DateTimeOffset.UtcNow, commandDeadline.Token);
+    var cycle = await plc.ReadCycleTimeAsync(commandDeadline.Token);
+    Console.WriteLine($"cycle min={cycle.MinimumCycleTime}, max={cycle.MaximumCycleTime}");
+}
+catch (OperationCanceledException) { Console.Error.WriteLine("Clock/cycle request cancelled."); }
+catch (FINSException ex) { Console.Error.WriteLine($"FINS rejected request: {ex.Message}"); }
+```
+
+### Async enumeration and logical tags
+
+`OmronPlcRxAsyncObservableExtensions` bridges `Observe`, `ObserveAll`, and `Errors` into `IObservableAsync<T>` through `ObserveAsAsyncObservable`, `ObserveAllAsAsyncObservable`, and `ErrorsAsAsyncObservable`; `ObserveValuesAsync` supplies asynchronous value enumeration. Each wrapper still owns/creates a subscription, so pass a cancellation token to consumers and dispose the client at application shutdown.
+
+`OmronLogicalTagClient` is a higher-level catalog that creates/registers tags, reads/writes one or many logical values, exposes observable and async enumeration, and supports store/import/export/group CRUD where configured. It adds planning/batching and persistence convenience; it does not change the atomicity guarantees of the physical PLC. Use the core facade when a physical address/type must be explicit at the call site, and use logical tags when a reviewed catalog owns that mapping.
+
+```csharp
+// A direct stream can be consumed as async enumeration with cancellation.
+using var readWindow = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+await foreach (var value in plc.ObserveValuesAsync(new LogicalTagKey<int>("BatchCount"), readWindow.Token))
+{
+    Console.WriteLine($"batch={value}");
+    if (value is > 1000) break;
+}
+```
+
+When an application is already built on `IObservableAsync<T>`, convert individual values, all-tag changes, or driver errors with `OmronPlcRxAsyncObservableExtensions`. Convert back with `ObservableAsyncBridgeExtensions.ToObservable` only at the boundary where a classic `IObservable<T>` subscriber is required. The async stream does not turn a queued `SetValue` into an acknowledged command; use `WriteValueAsync` for that.
+
+```csharp
+using IoT.DriverCore.Core;
+using IoT.DriverCore.OmronPlcRx.Async;
+using IoT.DriverCore.Serial;
+
+var levelKey = new LogicalTagKey<float>("TankLevel");
+var asyncLevels = plc.ObserveAsAsyncObservable(levelKey);
+using var levels = ObservableAsyncBridgeExtensions.ToObservable(asyncLevels)
+    .Subscribe(level => Console.WriteLine($"tank level={level}"));
+using var errors = ObservableAsyncBridgeExtensions.ToObservable(plc.ErrorsAsAsyncObservable())
+    .Subscribe(error => Console.Error.WriteLine(error?.Message));
+```
+
+Use `ObserveValuesAsync` when a sequential consumer is clearer than a callback. Cancellation ends the enumerable and the client still owns the polling/connection lifetime.
+
+```csharp
+using var stop = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+await foreach (float? level in plc.ObserveValuesAsync(levelKey, stop.Token))
+{
+    if (level is > 90f)
+        Console.WriteLine("High-level alarm policy should run here.");
+}
+```
+
+### Host Link and Toolbus codec testing
+
+`HostLinkFinsFrameCodec` and `ToolbusFinsFrameCodec` are framing utilities for serial adapters and protocol tests. Normal application traffic should use `OmronPlcRx` with `OmronSerialOptions`; do not send codec output through an arbitrary serial port without the expected serial protocol. Host Link validates FCS/unit/header/end-code on decode; Toolbus validates start byte, declared length, checksum, and the FINS response header.
+
+```csharp
+using IoT.DriverCore.OmronPlcRx;
+
+var hostLinkOptions = new OmronSerialOptions("COM3")
+{
+    FrameMode = OmronHostLinkFinsFrameMode.Network,
+};
+var hostLink = new HostLinkFinsFrameCodec(hostLinkOptions);
+
+// A FINS request always has a 10-byte header followed by a 2-byte command code.
+ReadOnlyMemory<byte> finsRequest = new byte[12] { 0x80, 0, 2, 0, 0, 1, 0, 0, 11, 1, 1, 1 };
+string hostLinkRequest = hostLink.EncodeRequest(finsRequest);
+Memory<byte> toolbusRequest = ToolbusFinsFrameCodec.EncodeRequest(finsRequest);
+Console.WriteLine(hostLinkRequest); // ends with FCS + "*\\r"
+Console.WriteLine(ToolbusFinsFrameCodec.CalculateChecksum(toolbusRequest.Span[..^2]));
+
+// Build minimal complete response frames for a codec unit test.
+var finsResponse = new byte[14];
+finsResponse[0] = 0xC0;
+string hostLinkBody = "@00FA00" + BitConverter.ToString(finsResponse).Replace("-", string.Empty);
+string hostLinkResponse = hostLinkBody + HostLinkFinsFrameCodec.CalculateFcs(hostLinkBody) + "*\r";
+Memory<byte> finsReply = hostLink.DecodeResponse(hostLinkResponse);
+
+var toolbusResponse = new byte[3 + finsResponse.Length + 2];
+toolbusResponse[0] = 0xAB;
+toolbusResponse[1] = 0;
+toolbusResponse[2] = (byte)(finsResponse.Length + 2);
+finsResponse.CopyTo(toolbusResponse, 3);
+ushort checksum = ToolbusFinsFrameCodec.CalculateChecksum(toolbusResponse.AsSpan(0, toolbusResponse.Length - 2));
+toolbusResponse[^2] = (byte)(checksum >> 8);
+toolbusResponse[^1] = (byte)checksum;
+Memory<byte> toolbusReply = ToolbusFinsFrameCodec.DecodeResponse(toolbusResponse);
+```
+
+### Explicit packed-BCD conversion
+
+`Bcd16`, `BcdU16`, `Bcd32`, and `BcdU32` are strongly typed PLC tag values. `BCDConverter` is for an explicit boundary conversion when a command or capture supplies raw BCD bytes/words. The value `0x0235` represents decimal `235`, not binary `565`; reject malformed BCD instead of treating it as a normal integer.
+
+```csharp
+using IoT.DriverCore.OmronPlcRx.Core.Converters;
+
+short encoded = BCDConverter.GetBCDWord(235);
+short decoded = BCDConverter.ToInt16(encoded);
+if (decoded != 235) throw new InvalidOperationException("Unexpected packed BCD conversion.");
+
+short[] encoded32 = BCDConverter.GetBCDWords(12_345_678);
+int decoded32 = BCDConverter.ToInt32(encoded32[0], encoded32[1]);
+Console.WriteLine(decoded32);
+```
+
+### Logical-tag persistence, CRUD, and combined batch command
+
+Construct `OmronLogicalTagClient` with a SQLite connection string when the reviewed tag map must persist. Initialize the store before CRUD, and remember that `UpsertTagAsync` also registers the tag with the PLC facade. `ReadManyAsync` / `WriteManyAsync` preserve caller order and use grouped FINS operations where the facade supports them; they are not a PLC transaction.
+
+```csharp
+using IoT.DriverCore.Core;
+
+var database = $"Data Source={Path.Combine(AppContext.BaseDirectory, "omron-tags.db")}";
+using var tags = new OmronLogicalTagClient(plc, database);
+await tags.InitializeStoreAsync(CancellationToken.None);
+
+var process = new LogicalTagGroup("Process");
+await tags.UpsertGroupAsync(process, CancellationToken.None);
+var temperature = tags.CreateTag(new PlcTag<short>("Temperature", "D200"),
+    groupName: "Process", description: "Product temperature", metadata: null,
+    accessMode: LogicalTagAccessMode.ReadWrite, scanInterval: TimeSpan.FromMilliseconds(250));
+await tags.UpsertTagAsync(temperature, CancellationToken.None);
+
+using var import = new StringReader(
+    "Name,Address,DataType,GroupName,Description,Metadata,AccessMode,ScanIntervalMilliseconds\n" +
+    "HighTemperature,D201,Int16,Process,High limit,,ReadWrite,250\n");
+IReadOnlyList<LogicalTag> imported = await tags.ImportCsvAsync(import, ',', CancellationToken.None);
+using var export = new StringWriter();
+await tags.ExportCsvAsync(export, ',', CancellationToken.None);
+Console.WriteLine($"Imported {imported.Count} tags; CSV length = {export.GetStringBuilder().Length}.");
+
+LogicalTag? stored = await tags.GetTagAsync("Temperature", CancellationToken.None);
+if (stored is not null)
+{
+    var options = stored.CurrentOptions();
+    options.Description = "Validated process temperature";
+    await tags.EditTagAsync(stored.WithOptions(options), CancellationToken.None);
+}
+
+var results = await tags.WriteManyAsync(
+    [new LogicalTagValue("Temperature", (short)185, TimeProvider.System.GetUtcNow())],
+    CancellationToken.None);
+if (!results.All(static result => result.Succeeded))
+    throw new InvalidOperationException("Logical write failed.");
+
+await tags.DeleteTagAsync("Temperature", CancellationToken.None);
+await tags.DeleteTagAsync("HighTemperature", CancellationToken.None);
+await tags.DeleteGroupAsync("Process", CancellationToken.None);
+```
+
+### Deterministic simulator workflow
+
+`OmronPlcSimulator` implements `IOmronPlcRx` so application code can be exercised without a network endpoint. Register the same `PlcTag<T>`, seed a value, optionally queue a fault, then read/write/observe through the normal interface. `Operations` returns `OmronSimulatorOperationRecord` entries, while `OmronSimulatorOperation` describes the recorded kind. Use this for timeout/error/UI tests; it is not a protocol emulator or safety certification.
+
+```csharp
+using var simulator = new OmronPlcSimulator();
+await simulator.ConnectAsync(CancellationToken.None); // useful after construction with initiallyConnected: false
+var simulatedPump = new PlcTag<bool>("PumpEnabled", "D100.0");
+simulator.AddUpdateTagItem(simulatedPump);
+simulator.Seed(simulatedPump, false);
+using var observed = simulator.Observe(new LogicalTagKey<bool>("PumpEnabled"))
+    .Subscribe(Console.WriteLine);
+await simulator.WriteValueAsync(new LogicalTagKey<bool>("PumpEnabled"), true, CancellationToken.None);
+Console.WriteLine(simulator.Operations.Count);
+simulator.Disconnect(); // retains registrations and seeded memory
+```
+
+Faults can deliberately disconnect the simulator. Handle the expected exception, call `ReconnectAsync`, and then repeat an awaited command; `ReconnectCount` and `Operations` make this recovery path assertable in application tests.
+
+```csharp
+using IoT.DriverCore.Core;
+using IoT.DriverCore.OmronPlcRx.Tags;
+
+using var simulator = new OmronPlcSimulator(initiallyConnected: true);
+var speed = new PlcTag<short>("Speed", "D100");
+simulator.AddUpdateTagItem(speed);
+simulator.Seed(speed, (short)25);
+var speedKey = new LogicalTagKey<short>("Speed");
+simulator.QueueFault(OmronSimulatorOperation.Read, new TimeoutException("Simulated cable loss"));
+try
+{
+    await simulator.ReadValueAsync(speedKey, CancellationToken.None);
+}
+catch (OmronPLCException)
+{
+    await simulator.ReconnectAsync(CancellationToken.None);
+}
+short? recovered = await simulator.ReadValueAsync(speedKey, CancellationToken.None);
+Console.WriteLine($"value={recovered}, reconnects={simulator.ReconnectCount}");
+```
+
+### Combined workflow 1: network polling with explicit command verification
+
+This keeps telemetry reactive, executes a command with an acknowledgement, and records failures without allowing a change stream to issue writes.
+
+```csharp
+var motor = new LogicalTagKey<bool>("PumpEnabled");
+var level = new LogicalTagKey<float>("TankLevel");
+using var telemetry = plc.Observe(level).Subscribe(v => Console.WriteLine($"level={v}"));
+using var faults = plc.Errors.Subscribe(e => Console.Error.WriteLine(e?.Message));
+using var commandCt = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+
+float? currentLevel = await plc.ReadValueAsync(level, commandCt.Token);
+if (currentLevel is < 85f)
+    await plc.WriteValueAsync(motor, true, commandCt.Token);
+```
+
+### Combined workflow 2: serial commissioning with clock check and BCD recipe
+
+```csharp
+var recipe = new LogicalTagKey<Bcd16>("TemperatureBcd");
+using var faults = serialPlc.Errors.Subscribe(e => Console.Error.WriteLine(e?.Message));
+using var commissioning = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+var cycle = await serialPlc.ReadCycleTimeAsync(commissioning.Token);
+if (cycle.MaximumCycleTime > 1_000d) // cycle-time values are milliseconds
+    throw new InvalidOperationException("Controller cycle time is outside commissioning limit.");
+
+await serialPlc.WriteValueAsync(recipe, new Bcd16(180), commissioning.Token);
+var verify = await serialPlc.ReadValueAsync(recipe, commissioning.Token);
+if (verify?.Value != 180) throw new InvalidOperationException("Recipe verification failed.");
+```
+
+### Complete generator workflow
+
+Install `OmronPlcRx.Generators` explicitly when a project needs analyzer pinning; runtime packages also carry the matching analyzer. Decorate a partial model with binding metadata and fields annotated by `PlcTagAttribute`. `TagName` selects the logical name; `Register` controls registration, `Observe` controls generated observation, and `Writable` requests write helpers. For each tag it generates the current value property, `<Property>Observable`, and—on .NET 8+—`<Property>ObservableAsync`; it also generates `Read<Property>Async`, `Write<Property>`, and `Write<Property>Async` for writable tags. Dispose the binding returned by `BindPlcTags`.
+
+```csharp
+using IoT.DriverCore.OmronPlcRx;
+
+[PlcTagBinding]
+public partial class MixerTags
+{
+    [PlcTag("D100.0", TagName = "MixerRun", Writable = true)]
+    private bool _mixerRun;
+
+    [PlcTag("D200", TagName = "MixerSpeed", Observe = true)]
+    private short _mixerSpeed;
+}
+
+var model = new MixerTags();
+model.RegisterPlcTags(plc);
+using var binding = model.BindPlcTags(plc);
+model.WriteMixerRun(plc, true);
+var written = await model.WriteMixerRunAsync(true, CancellationToken.None);
+if (!written.Succeeded) throw new InvalidOperationException(written.Error);
+using var speed = model.MixerSpeedObservable.Subscribe(Console.WriteLine);
+#if NET8_0_OR_GREATER
+using var asyncSpeed = ObservableAsyncBridgeExtensions.ToObservable(model.MixerSpeedObservableAsync)
+    .Subscribe(Console.WriteLine);
+#endif
+```
+
+## Complete public API reference
+
+The reactive package has the same inventory under `IoT.DriverCore.OmronPlcRx.Reactive`.
+
+| Area | Public types and primary members |
+| --- | --- |
+| Root | `IOmronPlcRx` and `OmronPlcRx`: `ObserveAll`, `Errors`, controller metadata, `AddUpdateTagItem`, `RemoveTagItem`, `Observe`, `GetValue`, `SetValue`, `ReadValueAsync`, `WriteValueAsync`, clock/cycle methods, and `Dispose`. `OmronConnectionOptions`, `OmronSerialOptions`, `OmronPlcSimulator`, `OmronSimulatorOperation`, `OmronSimulatorOperationRecord`, `OmronHostLinkFinsFrameMode`, and `OmronSerialProtocol`. |
+| Tags | `IPlcTag` and `PlcTag<T>` (`TagName`, `Address`, `Value`, `TagType`). |
+| Results | `ReadBitsResult`, `ReadWordsResult`, `ReadClockResult`, `ReadCycleTimeResult`, `WriteBitsResult`, `WriteWordsResult`, and `WriteClockResult`. |
+| Enums and exceptions | `ConnectionMethod`, `MemoryBitDataType`, `MemoryWordDataType`, `PlcType`, `FINSException`, and `OmronPLCException`. |
+| Core | `Bcd16`, `BcdU16`, `Bcd32`, `BcdU32`, `BCDConverter`, `HostLinkFinsFrameCodec`, and `ToolbusFinsFrameCodec`. |
+| Logical tags | `OmronLogicalTagClient`; use it for catalog-backed, batch logical-tag work. Its public catalog and persistence operations are documented below. |
+| Async and generation | `OmronPlcRxAsyncObservableExtensions`, `PlcTagAttribute`, `PlcTagBindingAttribute`, and the `OmronPlcRx.SourceGenerators.PlcTagSourceGenerator` analyzer. |
+
+### Member-by-member contract
+
+| Member family | Inputs and return | Failure, lifecycle, and use |
 | --- | --- | --- |
-| `ToByte(byte bcdByte)` | Converts one packed BCD byte to binary. | `byte value = BCDConverter.ToByte(0x42);` |
-| `ToInt16(short bcdWord)` | Converts one BCD word to signed 16-bit integer. | `short value = BCDConverter.ToInt16(0x1234);` |
-| `ToInt16(byte[] bcdBytes)` | Converts exactly two BCD bytes to signed 16-bit integer. | `short value = BCDConverter.ToInt16(new byte[] { 0x34, 0x12 });` |
-| `ToUInt16(short bcdWord)` | Converts one BCD word to unsigned 16-bit integer. | `ushort value = BCDConverter.ToUInt16(0x1234);` |
-| `ToUInt16(byte[] bcdBytes)` | Converts exactly two BCD bytes to unsigned 16-bit integer. | `ushort value = BCDConverter.ToUInt16(new byte[] { 0x34, 0x12 });` |
-| `ToInt32(short bcdWord1, short bcdWord2)` | Converts two BCD words to signed 32-bit integer. | `int value = BCDConverter.ToInt32(0x5678, 0x1234);` |
-| `ToInt32(byte[] bcdBytes)` | Converts exactly four BCD bytes to signed 32-bit integer. | `int value = BCDConverter.ToInt32(new byte[] { 0x78, 0x56, 0x34, 0x12 });` |
-| `ToUInt32(short bcdWord1, short bcdWord2)` | Converts two BCD words to unsigned 32-bit integer. | `uint value = BCDConverter.ToUInt32(0x5678, 0x1234);` |
-| `ToUInt32(byte[] bcdBytes)` | Converts exactly four BCD bytes to unsigned 32-bit integer. | `uint value = BCDConverter.ToUInt32(new byte[] { 0x78, 0x56, 0x34, 0x12 });` |
-| `GetBCDByte(byte binaryValue)` | Encodes a byte as one packed BCD byte. | `byte bcd = BCDConverter.GetBCDByte(42);` |
-| `GetBCDWord(short binaryValue)` | Encodes signed 16-bit integer as one BCD word. | `short bcd = BCDConverter.GetBCDWord((short)1234);` |
-| `GetBCDWord(ushort binaryValue)` | Encodes unsigned 16-bit integer as one BCD word. | `short bcd = BCDConverter.GetBCDWord((ushort)1234);` |
-| `GetBCDWords(int binaryValue)` | Encodes signed 32-bit integer as two BCD words. | `short[] words = BCDConverter.GetBCDWords(12345678);` |
-| `GetBCDWords(uint binaryValue)` | Encodes unsigned 32-bit integer as two BCD words. | `short[] words = BCDConverter.GetBCDWords(12345678u);` |
-| `GetBCDBytes(short binaryValue)` | Encodes signed 16-bit integer as two BCD bytes. | `byte[] bytes = BCDConverter.GetBCDBytes((short)1234);` |
-| `GetBCDBytes(ushort binaryValue)` | Encodes unsigned 16-bit integer as two BCD bytes. | `byte[] bytes = BCDConverter.GetBCDBytes((ushort)1234);` |
-| `GetBCDBytes(int binaryValue)` | Encodes signed 32-bit integer as four BCD bytes. | `byte[] bytes = BCDConverter.GetBCDBytes(12345678);` |
-| `GetBCDBytes(uint binaryValue)` | Encodes unsigned 32-bit integer as four BCD bytes. | `byte[] bytes = BCDConverter.GetBCDBytes(12345678u);` |
+| Construction/options | Network options or serial parameters; optional polling interval. | Validate serial settings first, use one client per endpoint, and dispose it after subscriptions. |
+| Tags/keys | `PlcTag<T>(tagName, address)`, `LogicalTagKey<T>(tagName)`, `AddUpdateTagItem`, `RemoveTagItem`. | The type/name must agree across all calls. Registration changes the polling set. |
+| Cache/streams | `GetValue`, `Observe`, `ObserveAll`, `Errors`. | Cache is not a direct read. Dispose subscriptions; errors from poll/background writes appear on `Errors`. |
+| Commands | `SetValue`, `ReadValueAsync`, `WriteValueAsync`. | `SetValue` is fire-and-forget. Await explicit methods with a cancellation token and catch FINS/Omron errors. |
+| Clock/cycle | `ReadClockAsync`, both `WriteClockAsync` overloads, `ReadCycleTimeAsync`. | Direct PLC commands return result records; day is inferred or must be 0–6. |
+| Options/protocol | `OmronConnectionOptions`, `OmronSerialOptions`, protocol/frame enums and codecs. | Select transport/framing to match the PLC; only FINS Host Link/Toolbus are exposed. |
+| Simulation/logical/generation | `OmronPlcSimulator`, operation records, `OmronLogicalTagClient`, async extensions, BCD values/codecs, generator attributes. | Simulator and catalog make tests/configuration repeatable; they do not create PLC transaction semantics. |
 
-### Result Types
+### Supporting public member index
 
-All result records include transmission metrics:
-
-| Property | Description |
+| Feature | Members and use |
 | --- | --- |
-| `BytesSent` | Number of bytes sent. |
-| `PacketsSent` | Number of packets sent. |
-| `BytesReceived` | Number of bytes received. |
-| `PacketsReceived` | Number of packets received. |
-| `Duration` | Request duration in milliseconds. |
+| Logical catalog and persistence | `CreateTag`, `RegisterTag`, `RemoveTag`, `ReadAsync`, `ReadManyAsync`, `WriteAsync`, `WriteManyAsync`, `ObserveAsync`, `ObserveMany`, `ObserveManyAsync`, `InitializeStoreAsync`, `LoadTagsAsync`, `GetTagAsync`, `ListTagsAsync`, `EditTagAsync`, `DeleteTagAsync`, `UpsertTagAsync`, `GetGroupAsync`, `ListGroupsAsync`, `UpsertGroupAsync`, `DeleteGroupAsync`, `ImportCsvAsync`, `ExportCsvAsync`. These are cancellation-aware catalog operations; check result success/error and remember that batch planning is not a PLC transaction. |
+| Simulator lifecycle and faults | `ConnectAsync`, `Disconnect`, `ReconnectAsync`, `QueueFault`, `Seed`, and operation records. A simulator fault may disconnect the simulated link; reconnect explicitly before the next command. |
+| FINS serial framing | `OpenAsync`, `Close`, `DiscardInBuffer`, `EncodeRequest`, `DecodeResponse`, `CalculateChecksum`, and `CalculateFcs`. Use the serial options/connection facade for normal traffic; these codec/frame methods are for adapter/protocol tests and require exact framing. |
+| BCD conversion | `GetBCDByte`, `GetBCDBytes`, `GetBCDWord`, `GetBCDWords`, `ToByte`, `ToInt16`, `ToUInt16`, `ToInt32`, and `ToUInt32`. They translate packed BCD, not normal binary; invalid BCD digits or an unsuitable width are caller errors. |
+| Value semantics | `Equals`, `GetHashCode`, `ToString`, and `Index` are value/compatibility members on records/wrappers. Use typed tags/results for PLC work rather than comparing formatted text. |
 
-Specific result payloads:
+## Operational guidance
 
-| Type | Payload properties | Used by |
-| --- | --- | --- |
-| `ReadBitsResult` | `bool[] Values` | Bit reads. |
-| `ReadWordsResult` | `short[] Values` | Word reads. |
-| `WriteBitsResult` | Metrics only. | Bit writes. |
-| `WriteWordsResult` | Metrics only. | Word writes. |
-| `ReadClockResult` | `DateTime Clock`, `int DayOfWeek` | `ReadClockAsync`. |
-| `WriteClockResult` | Metrics only. | `WriteClockAsync`. |
-| `ReadCycleTimeResult` | `MinimumCycleTime`, `MaximumCycleTime`, `AverageCycleTime` | `ReadCycleTimeAsync`. |
+Use one long-lived driver per endpoint; register all tags before relying on polling; keep subscriptions and the driver disposed with the application lifetime. Select a poll interval that the PLC, network, and number of tags can sustain. Keep command writes out of a high-frequency value stream, and monitor `Errors` plus controller metadata during commissioning. Do not expose the PLC network directly to untrusted networks.
 
-Example:
+## Troubleshooting
 
-```csharp
-ReadClockResult clock = await plc.ReadClockAsync();
-Console.WriteLine($"{clock.Clock:o} received in {clock.Duration} ms");
-```
-
-### Enums
-
-| Enum | Values |
+| Symptom | Check |
 | --- | --- |
-| `ConnectionMethod` | `TCP`, `UDP`, `Serial` |
-| `MemoryBitDataType` | `None`, `DataMemory`, `CommonIO`, `Work`, `Holding`, `Auxiliary` |
-| `MemoryWordDataType` | `None`, `DataMemory`, `CommonIO`, `Work`, `Holding`, `Auxiliary` |
-| `PLCType` | `NJ101`, `NJ301`, `NJ501`, `NX1P2`, `NX102`, `NX701`, `NY512`, `NY532`, `NJ_NX_NY_Series`, `CJ2`, `CP1`, `C_Series`, `Unknown` |
-| `OmronSerialProtocol` | `HostLinkFins`, `Toolbus` |
-| `OmronHostLinkFinsFrameMode` | `Direct`, `Network` |
+| No values arrive | Confirm FINS node IDs, transport/port, host, address syntax, tag registration, and subscription lifetime. |
+| `KeyNotFoundException` or default value | Use the same tag name and generic type in registration and logical key. |
+| Serial connection fails | Call `Validate()`, then verify protocol, framing, COM port, baud/parity/data/stop bits, and Host Link unit/wait values. |
+| Write did not take effect | Use `WriteValueAsync` to observe the operation; inspect `Errors`; verify PLC permissions and program interlocks. |
+| Generator diagnostics | Make the target type `partial`, use a supported field type/address, and remove generated-name collisions. |
 
-Example:
+## AI skill
 
-```csharp
-var method = ConnectionMethod.UDP;
-var wordArea = MemoryWordDataType.DataMemory;
-var bitArea = MemoryBitDataType.Work;
-var protocol = OmronSerialProtocol.Toolbus;
-```
+For implementation guidance, load [`skills/omron-plc-rx/SKILL.md`](../../skills/omron-plc-rx/SKILL.md). It directs an agent to this README for the detailed source-grounded reference.
 
-### Exceptions
+<!-- BEGIN GENERATED PUBLIC API -->
 
-`OmronPLCException` represents communication, processing, validation, initialization, polling, and write failures.
+## Exhaustive public API reference
 
-```csharp
-using var errors = plc.Errors.SubscribeSafe(
-    error => Console.WriteLine(error?.Message),
-    error => Console.WriteLine(error.Message));
-```
+This catalogue is generated from the packaged runtime assemblies and their XML documentation. It includes exported public types and their declared public members; inherited members and non-public implementation details are intentionally omitted.
 
-`FINSException` represents FINS protocol errors or invalid FINS responses.
+### `OmronPlcRx`
 
-Both exception types provide standard constructors:
+Exported public types: 35; declared public members: 352.
+
+#### `T:IoT.DriverCore.OmronPlcRx.Async.OmronPlcRxAsyncObservableExtensions`
 
 ```csharp
-throw new OmronPLCException();
-throw new OmronPLCException("PLC communication failed");
-throw new OmronPLCException("PLC communication failed", innerException);
-
-throw new FINSException();
-throw new FINSException("FINS response was invalid");
-throw new FINSException("FINS response was invalid", innerException);
+public class IoT.DriverCore.OmronPlcRx.Async.OmronPlcRxAsyncObservableExtensions
 ```
+Bridges Omron PLC classic Rx streams into ReactiveUI.Primitives.Async observables.
 
-### `OmronPlcRx.SourceGenerators.PlcTagSourceGenerator`
+##### Declared public members
 
-The generator implements Roslyn `ISourceGenerator`. It is an analyzer component, not a runtime API normally called by application code. It responds to `[PlcTag]` fields and emits `<ContainingType>.PlcReactiveStreams.g.cs` files during compilation.
+###### `M:IoT.DriverCore.OmronPlcRx.Async.OmronPlcRxAsyncObservableExtensions.ErrorsAsAsyncObservable(IoT.DriverCore.OmronPlcRx.IOmronPlcRx)`
 
 ```csharp
-// Application code uses the attribute, not the generator directly.
-[PlcTag("D100", Writable = true)]
-private short _tankLevel;
+public static ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.OmronPlcRx.OmronPLCException> ErrorsAsAsyncObservable(IoT.DriverCore.OmronPlcRx.IOmronPlcRx plc)
 ```
+Observes PLC operational errors as an async observable.
 
-## Error Handling
+- Parameter `plc`: The PLC reactive facade.
+- Returns: An async observable of PLC errors.
 
-Initialization, polling, unsupported type, address parsing, and write failures are published to `Errors`.
+###### `M:IoT.DriverCore.OmronPlcRx.Async.OmronPlcRxAsyncObservableExtensions.ObserveAllAsAsyncObservable(IoT.DriverCore.OmronPlcRx.IOmronPlcRx)`
 
 ```csharp
-using var errors = plc.Errors.SubscribeSafe(
-    error => Console.WriteLine($"PLC error: {error?.Message}"),
-    error => Console.WriteLine(error.Message));
+public static ReactiveUI.Primitives.Async.IObservableAsync<IoT.DriverCore.OmronPlcRx.Tags.IPlcTag> ObserveAllAsAsyncObservable(IoT.DriverCore.OmronPlcRx.IOmronPlcRx plc)
 ```
+Observes every changed PLC tag as an async observable.
 
-Synchronous validation still throws for invalid arguments. For example, `Observe<T>(null)` throws `ArgumentNullException`, and writing an unregistered tag throws `KeyNotFoundException`. The actual PLC write runs in the background and reports failures through `Errors`.
+- Parameter `plc`: The PLC reactive facade.
+- Returns: An async observable of all changed tags.
 
-## PLC Types And Limits
+###### `M:IoT.DriverCore.OmronPlcRx.Async.OmronPlcRxAsyncObservableExtensions.ObserveAsAsyncObservable``1(IoT.DriverCore.OmronPlcRx.IOmronPlcRx,IoT.DriverCore.Core.LogicalTagKey`1{``0})`
 
-Controller type is inferred during initialization from CPU unit data. It affects supported memory areas and maximum read/write word counts.
-
-- CP1 read limit: `499` words.
-- CP1 write limit: `496` words.
-- Other detected PLC types read limit: `999` words.
-- Other detected PLC types write limit: `996` words.
-- Auxiliary area is not supported on N-series PLCs.
-- Data memory bits are not supported on CP1 by the low-level validation rules.
-- `ReadCycleTimeAsync` is not supported on NX/NY series except NJ101/NJ301/NJ501.
-
-## Testing
-
-The test suite uses TUnit on Microsoft.Testing.Platform.
-
-```bash
-dotnet test tests/OmronPlcRx.Tests/OmronPlcRx.Tests.csproj --framework net10.0
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<T> ObserveAsAsyncObservable<T>(IoT.DriverCore.OmronPlcRx.IOmronPlcRx plc, IoT.DriverCore.Core.LogicalTagKey<T> tag)
 ```
+Executes the `ObserveAsAsyncObservable` operation.
 
-## FAQ
+- Parameter `plc`: The `plc` value.
+- Parameter `tag`: The `tag` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<T>` result.
 
-**Which package should I use for V2?**
+###### `M:IoT.DriverCore.OmronPlcRx.Async.OmronPlcRxAsyncObservableExtensions.ObserveValuesAsync``1(IoT.DriverCore.OmronPlcRx.IOmronPlcRx,IoT.DriverCore.Core.LogicalTagKey`1{``0},System.Threading.CancellationToken)`
 
-Use `OmronPlcRx` for new applications that do not need System.Reactive package conventions. Use `OmronPlcRx.Reactive` for Rx/System.Reactive applications.
+```csharp
+public static System.Collections.Generic.IAsyncEnumerable<T> ObserveValuesAsync<T>(IoT.DriverCore.OmronPlcRx.IOmronPlcRx plc, IoT.DriverCore.Core.LogicalTagKey<T> tag, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ObserveValuesAsync` operation.
 
-**Why did my namespaces break after moving to `OmronPlcRx.Reactive`?**
+- Parameter `plc`: The `plc` value.
+- Parameter `tag`: The `tag` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Collections.Generic.IAsyncEnumerable<T>` result.
 
-The reactive package uses `OmronPlcRx.Reactive.*` namespaces. Update the root namespace and dependent namespaces such as `Enums`, `Tags`, `Results`, `Async`, `Core.Types`, and `Core.Converters`.
+#### `T:IoT.DriverCore.OmronPlcRx.Core.Converters.BCDConverter`
 
-**Why does `Value<T>(tagName, value)` not throw when the PLC write fails?**
+```csharp
+public class IoT.DriverCore.OmronPlcRx.Core.Converters.BCDConverter
+```
+Converts between BCD encoded values and numeric values.
 
-It starts the write in the background. Subscribe to `Errors` for write failures.
+##### Declared public members
 
-**Why are generated `ObservableAsync` properties missing?**
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Converters.BCDConverter.GetBCDByte(System.Byte)`
 
-They are generated only for `net8.0` and later.
+```csharp
+public static byte GetBCDByte(byte binaryValue)
+```
+Gets the BCD byte.
 
-**Why do multi-word numeric values look swapped?**
+- Parameter `binaryValue`: The binary value.
+- Returns: A BCD-encoded byte.
 
-The runtime stores 32-bit and 64-bit values in low-word-first PLC order and reconstructs them accordingly. Confirm the PLC program uses the same word order.
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Converters.BCDConverter.GetBCDBytes(System.Int16)`
 
-**Why does a string contain unexpected characters?**
+```csharp
+public static byte[] GetBCDBytes(short binaryValue)
+```
+Gets the BCD bytes.
 
-Check the `[length]` suffix and confirm the PLC memory uses ASCII packed two characters per word.
+- Parameter `binaryValue`: The binary value.
+- Returns: A BCD-encoded byte array.
 
-**Can I change the polling interval after construction?**
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Converters.BCDConverter.GetBCDBytes(System.Int32)`
 
-No. Dispose the facade and create a new instance with a different `pollInterval`.
+```csharp
+public static byte[] GetBCDBytes(int binaryValue)
+```
+Gets the BCD bytes.
 
-## Contributing
+- Parameter `binaryValue`: The binary value.
+- Returns: A BCD-encoded byte array.
 
-Pull requests are welcome. Useful areas include additional PLC data types, reconnect and health monitoring, structured logging hooks, and broader source-generator diagnostics coverage.
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Converters.BCDConverter.GetBCDBytes(System.UInt16)`
 
-## License
+```csharp
+public static byte[] GetBCDBytes(ushort binaryValue)
+```
+Gets the BCD bytes.
 
-MIT License. See `LICENSE`.
+- Parameter `binaryValue`: The binary value.
+- Returns: A BCD-encoded byte array.
 
-## Disclaimer
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Converters.BCDConverter.GetBCDBytes(System.UInt32)`
 
-This project is not affiliated with Omron. Validate behavior in a safe test environment before using it with production equipment.
+```csharp
+public static byte[] GetBCDBytes(uint binaryValue)
+```
+Gets the BCD bytes.
+
+- Parameter `binaryValue`: The binary value.
+- Returns: A BCD-encoded byte array.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Converters.BCDConverter.GetBCDWord(System.Int16)`
+
+```csharp
+public static short GetBCDWord(short binaryValue)
+```
+Gets the BCD word.
+
+- Parameter `binaryValue`: The binary value.
+- Returns: A BCD-encoded word.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Converters.BCDConverter.GetBCDWord(System.UInt16)`
+
+```csharp
+public static short GetBCDWord(ushort binaryValue)
+```
+Gets the BCD word.
+
+- Parameter `binaryValue`: The binary value.
+- Returns: A BCD-encoded word.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Converters.BCDConverter.GetBCDWords(System.Int32)`
+
+```csharp
+public static short[] GetBCDWords(int binaryValue)
+```
+Gets the BCD words.
+
+- Parameter `binaryValue`: The binary value.
+- Returns: An array of two BCD-encoded words.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Converters.BCDConverter.GetBCDWords(System.UInt32)`
+
+```csharp
+public static short[] GetBCDWords(uint binaryValue)
+```
+Gets the BCD words.
+
+- Parameter `binaryValue`: The binary value.
+- Returns: An array of two BCD-encoded words.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Converters.BCDConverter.ToByte(System.Byte)`
+
+```csharp
+public static byte ToByte(byte bcdByte)
+```
+Converts to byte.
+
+- Parameter `bcdByte`: The BCD byte.
+- Returns: A byte representing the converted value.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Converters.BCDConverter.ToInt16(System.Byte[])`
+
+```csharp
+public static short ToInt16(byte[] bcdBytes)
+```
+Converts to int16.
+
+- Parameter `bcdBytes`: The BCD bytes.
+- Returns: A short.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Converters.BCDConverter.ToInt16(System.Int16)`
+
+```csharp
+public static short ToInt16(short bcdWord)
+```
+Converts to int16.
+
+- Parameter `bcdWord`: The BCD word.
+- Returns: A short.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Converters.BCDConverter.ToInt32(System.Byte[])`
+
+```csharp
+public static int ToInt32(byte[] bcdBytes)
+```
+Converts to int32.
+
+- Parameter `bcdBytes`: The BCD bytes.
+- Returns: An int.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Converters.BCDConverter.ToInt32(System.Int16,System.Int16)`
+
+```csharp
+public static int ToInt32(short bcdWord1, short bcdWord2)
+```
+Converts to int32.
+
+- Parameter `bcdWord1`: The BCD word1.
+- Parameter `bcdWord2`: The BCD word2.
+- Returns: An int.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Converters.BCDConverter.ToUInt16(System.Byte[])`
+
+```csharp
+public static ushort ToUInt16(byte[] bcdBytes)
+```
+Converts to uint16.
+
+- Parameter `bcdBytes`: The BCD bytes.
+- Returns: A ushort.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Converters.BCDConverter.ToUInt16(System.Int16)`
+
+```csharp
+public static ushort ToUInt16(short bcdWord)
+```
+Converts to uint16.
+
+- Parameter `bcdWord`: The BCD word.
+- Returns: A ushort.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Converters.BCDConverter.ToUInt32(System.Byte[])`
+
+```csharp
+public static uint ToUInt32(byte[] bcdBytes)
+```
+Converts to uint32.
+
+- Parameter `bcdBytes`: The BCD bytes.
+- Returns: A uint.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Converters.BCDConverter.ToUInt32(System.Int16,System.Int16)`
+
+```csharp
+public static uint ToUInt32(short bcdWord1, short bcdWord2)
+```
+Converts to uint32.
+
+- Parameter `bcdWord1`: The BCD word1.
+- Parameter `bcdWord2`: The BCD word2.
+- Returns: A uint.
+
+#### `T:IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16`
+
+```csharp
+public struct IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16
+```
+Signed 16-bit BCD numeric wrapper.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16.#ctor(System.Int16)`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16(short value)
+```
+Initializes a new instance of the `T:IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16` struct.
+
+- Parameter `value`: The signed value.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16.Equals(IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16)`
+
+```csharp
+public bool Equals(IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16 other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16.ToString`
+
+```csharp
+public string ToString()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16.op_Equality(IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16,IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16 left, IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16 right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16.op_Inequality(IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16,IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16 left, IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16 right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Core.Types.Bcd16.Value`
+
+```csharp
+public short Value { get; }
+```
+Gets the numeric value.
+
+- Value: The `Value` value.
+
+#### `T:IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32`
+
+```csharp
+public struct IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32
+```
+Signed 32-bit BCD numeric wrapper.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32.#ctor(System.Int32)`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32(int value)
+```
+Initializes a new instance of the `T:IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32` struct.
+
+- Parameter `value`: The signed value.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32.Equals(IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32)`
+
+```csharp
+public bool Equals(IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32 other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32.ToString`
+
+```csharp
+public string ToString()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32.op_Equality(IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32,IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32 left, IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32 right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32.op_Inequality(IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32,IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32 left, IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32 right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Core.Types.Bcd32.Value`
+
+```csharp
+public int Value { get; }
+```
+Gets the numeric value.
+
+- Value: The `Value` value.
+
+#### `T:IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16`
+
+```csharp
+public struct IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16
+```
+Unsigned 16-bit BCD numeric wrapper.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16.#ctor(System.UInt16)`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16(ushort value)
+```
+Initializes a new instance of the `T:IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16` struct.
+
+- Parameter `value`: The unsigned value.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16.Equals(IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16)`
+
+```csharp
+public bool Equals(IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16 other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16.ToString`
+
+```csharp
+public string ToString()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16.op_Equality(IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16,IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16 left, IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16 right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16.op_Inequality(IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16,IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16 left, IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16 right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Core.Types.BcdU16.Value`
+
+```csharp
+public ushort Value { get; }
+```
+Gets the numeric value.
+
+- Value: The `Value` value.
+
+#### `T:IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32`
+
+```csharp
+public struct IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32
+```
+Unsigned 32-bit BCD numeric wrapper.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32.#ctor(System.UInt32)`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32(uint value)
+```
+Initializes a new instance of the `T:IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32` struct.
+
+- Parameter `value`: The unsigned value.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32.Equals(IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32)`
+
+```csharp
+public bool Equals(IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32 other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32.ToString`
+
+```csharp
+public string ToString()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32.op_Equality(IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32,IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32 left, IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32 right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32.op_Inequality(IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32,IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32 left, IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32 right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Core.Types.BcdU32.Value`
+
+```csharp
+public uint Value { get; }
+```
+Gets the numeric value.
+
+- Value: The `Value` value.
+
+#### `T:IoT.DriverCore.OmronPlcRx.Enums.ConnectionMethod`
+
+```csharp
+public enum IoT.DriverCore.OmronPlcRx.Enums.ConnectionMethod
+```
+Transport protocol used for communication with the PLC.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.ConnectionMethod.Serial`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.ConnectionMethod Serial
+```
+Serial FINS protocol using Host Link FINS or Toolbus framing.
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.ConnectionMethod.TCP`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.ConnectionMethod TCP
+```
+Transmission Control Protocol.
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.ConnectionMethod.UDP`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.ConnectionMethod UDP
+```
+User Datagram Protocol.
+
+#### `T:IoT.DriverCore.OmronPlcRx.Enums.MemoryBitDataType`
+
+```csharp
+public enum IoT.DriverCore.OmronPlcRx.Enums.MemoryBitDataType
+```
+Bit-addressable PLC memory areas.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.MemoryBitDataType.Auxiliary`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.MemoryBitDataType Auxiliary
+```
+Auxiliary area (A).
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.MemoryBitDataType.CommonIO`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.MemoryBitDataType CommonIO
+```
+Common I/O area (CIO).
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.MemoryBitDataType.DataMemory`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.MemoryBitDataType DataMemory
+```
+Data memory area (DM).
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.MemoryBitDataType.Holding`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.MemoryBitDataType Holding
+```
+Holding area (H).
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.MemoryBitDataType.None`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.MemoryBitDataType None
+```
+No bit-addressable memory area.
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.MemoryBitDataType.Work`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.MemoryBitDataType Work
+```
+Work area (W).
+
+#### `T:IoT.DriverCore.OmronPlcRx.Enums.MemoryWordDataType`
+
+```csharp
+public enum IoT.DriverCore.OmronPlcRx.Enums.MemoryWordDataType
+```
+Word-addressable PLC memory areas.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.MemoryWordDataType.Auxiliary`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.MemoryWordDataType Auxiliary
+```
+Auxiliary area (A).
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.MemoryWordDataType.CommonIO`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.MemoryWordDataType CommonIO
+```
+Common I/O area (CIO).
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.MemoryWordDataType.DataMemory`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.MemoryWordDataType DataMemory
+```
+Data memory area (DM).
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.MemoryWordDataType.Holding`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.MemoryWordDataType Holding
+```
+Holding area (H).
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.MemoryWordDataType.None`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.MemoryWordDataType None
+```
+No word-addressable memory area.
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.MemoryWordDataType.Work`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.MemoryWordDataType Work
+```
+Work area (W).
+
+#### `T:IoT.DriverCore.OmronPlcRx.Enums.PlcType`
+
+```csharp
+public enum IoT.DriverCore.OmronPlcRx.Enums.PlcType
+```
+Supported Omron PLC types used to adjust message capabilities and limits.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.PlcType.CJ2`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.PlcType CJ2
+```
+Omron CJ2 series.
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.PlcType.CP1`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.PlcType CP1
+```
+Omron CP1 series.
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.PlcType.C_Series`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.PlcType C_Series
+```
+Omron C-series (legacy).
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.PlcType.NJ101`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.PlcType NJ101
+```
+Omron NJ101 series.
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.PlcType.NJ301`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.PlcType NJ301
+```
+Omron NJ301 series.
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.PlcType.NJ501`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.PlcType NJ501
+```
+Omron NJ501 series.
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.PlcType.NJ_NX_NY_Series`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.PlcType NJ_NX_NY_Series
+```
+Generic NJ/NX/NY series.
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.PlcType.NX102`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.PlcType NX102
+```
+Omron NX102 series.
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.PlcType.NX1P2`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.PlcType NX1P2
+```
+Omron NX1P2 series.
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.PlcType.NX701`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.PlcType NX701
+```
+Omron NX701 series.
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.PlcType.NY512`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.PlcType NY512
+```
+Omron NY512 series.
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.PlcType.NY532`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.PlcType NY532
+```
+Omron NY532 series.
+
+###### `F:IoT.DriverCore.OmronPlcRx.Enums.PlcType.Unknown`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.Enums.PlcType Unknown
+```
+Unknown or not yet identified.
+
+#### `T:IoT.DriverCore.OmronPlcRx.FINSException`
+
+```csharp
+public class IoT.DriverCore.OmronPlcRx.FINSException
+```
+An exception that represents a FINS protocol error or invalid response.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.FINSException.#ctor`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.FINSException()
+```
+Initializes a new instance of the `T:IoT.DriverCore.OmronPlcRx.FINSException` class.
+
+###### `M:IoT.DriverCore.OmronPlcRx.FINSException.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.FINSException(string message)
+```
+Initializes a new instance of the `T:IoT.DriverCore.OmronPlcRx.FINSException` class with a message.
+
+- Parameter `message`: The message that describes the error.
+
+###### `M:IoT.DriverCore.OmronPlcRx.FINSException.#ctor(System.String,System.Exception)`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.FINSException(string message, System.Exception innerException)
+```
+Initializes a new instance of the `T:IoT.DriverCore.OmronPlcRx.FINSException` class.
+
+- Parameter `message`: The error message that explains the reason for the exception.
+- Parameter `innerException`: The exception that caused the current exception.
+
+#### `T:IoT.DriverCore.OmronPlcRx.HostLinkFinsFrameCodec`
+
+```csharp
+public class IoT.DriverCore.OmronPlcRx.HostLinkFinsFrameCodec
+```
+Encodes and decodes Omron FINS frames carried in Host Link serial frames.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.HostLinkFinsFrameCodec.#ctor(IoT.DriverCore.OmronPlcRx.OmronSerialOptions)`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.HostLinkFinsFrameCodec(IoT.DriverCore.OmronPlcRx.OmronSerialOptions options)
+```
+Initializes a new instance of the `T:IoT.DriverCore.OmronPlcRx.HostLinkFinsFrameCodec` class.
+
+- Parameter `options`: Serial Host Link options.
+
+###### `M:IoT.DriverCore.OmronPlcRx.HostLinkFinsFrameCodec.CalculateFcs(System.String)`
+
+```csharp
+public static string CalculateFcs(string frameText)
+```
+Calculates the Host Link frame-check sequence.
+
+- Parameter `frameText`: Frame text from @ through the final text character, excluding FCS and terminator.
+- Returns: Two-character uppercase hexadecimal FCS.
+
+###### `M:IoT.DriverCore.OmronPlcRx.HostLinkFinsFrameCodec.DecodeResponse(System.String)`
+
+```csharp
+public System.Memory<byte> DecodeResponse(string frame)
+```
+Decodes an ASCII Host Link FINS response into a binary FINS response message.
+
+- Parameter `frame`: ASCII Host Link FINS response frame including FCS and terminator.
+- Returns: Binary FINS response message.
+
+###### `M:IoT.DriverCore.OmronPlcRx.HostLinkFinsFrameCodec.EncodeRequest(System.ReadOnlyMemory`1{System.Byte})`
+
+```csharp
+public string EncodeRequest(System.ReadOnlyMemory<byte> finsMessage)
+```
+Executes the `EncodeRequest` operation.
+
+- Parameter `finsMessage`: The `finsMessage` value.
+- Returns: A `string` result.
+
+#### `T:IoT.DriverCore.OmronPlcRx.IOmronPlcRx`
+
+```csharp
+public interface IoT.DriverCore.OmronPlcRx.IOmronPlcRx
+```
+Defines high-level Omron PLC operations and tag access.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.IOmronPlcRx.AddUpdateTagItem``1(IoT.DriverCore.OmronPlcRx.Tags.PlcTag`1{``0})`
+
+```csharp
+public void AddUpdateTagItem<T>(IoT.DriverCore.OmronPlcRx.Tags.PlcTag<T> tag)
+```
+Executes the `AddUpdateTagItem` operation.
+
+- Parameter `tag`: The `tag` value.
+
+###### `M:IoT.DriverCore.OmronPlcRx.IOmronPlcRx.GetValue``1(IoT.DriverCore.Core.LogicalTagKey`1{``0})`
+
+```csharp
+public T GetValue<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag)
+```
+Executes the `GetValue` operation.
+
+- Parameter `tag`: The `tag` value.
+- Returns: A `T` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.IOmronPlcRx.Observe``1(IoT.DriverCore.Core.LogicalTagKey`1{``0})`
+
+```csharp
+public System.IObservable<T> Observe<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag)
+```
+Executes the `Observe` operation.
+
+- Parameter `tag`: The `tag` value.
+- Returns: A `System.IObservable<T>` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.IOmronPlcRx.ReadClockAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.OmronPlcRx.Results.ReadClockResult> ReadClockAsync(System.Threading.CancellationToken cancellationToken)
+```
+Reads the PLC real-time clock.
+
+- Parameter `cancellationToken`: Cancellation token.
+- Returns: Clock read result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.IOmronPlcRx.ReadCycleTimeAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult> ReadCycleTimeAsync(System.Threading.CancellationToken cancellationToken)
+```
+Reads PLC scan cycle time statistics.
+
+- Parameter `cancellationToken`: Cancellation token.
+- Returns: Cycle time statistics.
+
+###### `M:IoT.DriverCore.OmronPlcRx.IOmronPlcRx.ReadValueAsync``1(IoT.DriverCore.Core.LogicalTagKey`1{``0},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<T> ReadValueAsync<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ReadValueAsync` operation.
+
+- Parameter `tag`: The `tag` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<T>` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.IOmronPlcRx.RemoveTagItem(System.String)`
+
+```csharp
+public bool RemoveTagItem(string tagName)
+```
+Removes a registered tag definition.
+
+- Parameter `tagName`: Logical tag name.
+- Returns: when a tag was removed.
+
+###### `M:IoT.DriverCore.OmronPlcRx.IOmronPlcRx.SetValue``1(IoT.DriverCore.Core.LogicalTagKey`1{``0},``0)`
+
+```csharp
+public void SetValue<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag, T value)
+```
+Executes the `SetValue` operation.
+
+- Parameter `tag`: The `tag` value.
+- Parameter `value`: The `value` value.
+
+###### `M:IoT.DriverCore.OmronPlcRx.IOmronPlcRx.WriteClockAsync(System.DateTimeOffset,System.Int32,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.OmronPlcRx.Results.WriteClockResult> WriteClockAsync(System.DateTimeOffset newDateTime, int newDayOfWeek, System.Threading.CancellationToken cancellationToken)
+```
+Writes the PLC real-time clock with explicit day-of-week.
+
+- Parameter `newDateTime`: New date/time.
+- Parameter `newDayOfWeek`: Day of week (0-6).
+- Parameter `cancellationToken`: Cancellation token.
+- Returns: Clock write result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.IOmronPlcRx.WriteClockAsync(System.DateTimeOffset,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.OmronPlcRx.Results.WriteClockResult> WriteClockAsync(System.DateTimeOffset newDateTime, System.Threading.CancellationToken cancellationToken)
+```
+Writes the PLC real-time clock (day-of-week inferred from date).
+
+- Parameter `newDateTime`: New date/time.
+- Parameter `cancellationToken`: Cancellation token.
+- Returns: Clock write result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.IOmronPlcRx.WriteValueAsync``1(IoT.DriverCore.Core.LogicalTagKey`1{``0},``0,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task WriteValueAsync<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag, T value, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `WriteValueAsync` operation.
+
+- Parameter `tag`: The `tag` value.
+- Parameter `value`: The `value` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task` result.
+
+###### `P:IoT.DriverCore.OmronPlcRx.IOmronPlcRx.ControllerModel`
+
+```csharp
+public string ControllerModel { get; }
+```
+Gets the PLC controller model string.
+
+- Value: The `ControllerModel` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.IOmronPlcRx.ControllerVersion`
+
+```csharp
+public string ControllerVersion { get; }
+```
+Gets the PLC controller version string.
+
+- Value: The `ControllerVersion` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.IOmronPlcRx.Errors`
+
+```csharp
+public System.IObservable<IoT.DriverCore.OmronPlcRx.OmronPLCException> Errors { get; }
+```
+Gets an observable of operational errors.
+
+- Value: The `Errors` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.IOmronPlcRx.ObserveAll`
+
+```csharp
+public System.IObservable<IoT.DriverCore.OmronPlcRx.Tags.IPlcTag> ObserveAll { get; }
+```
+Gets an observable of all tag change events.
+
+- Value: The `ObserveAll` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.IOmronPlcRx.PlcType`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.Enums.PlcType PlcType { get; }
+```
+Gets the detected PLC type.
+
+- Value: The `PlcType` value.
+
+#### `T:IoT.DriverCore.OmronPlcRx.OmronConnectionOptions`
+
+```csharp
+public class IoT.DriverCore.OmronPlcRx.OmronConnectionOptions
+```
+Configures an Omron PLC transport connection.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronConnectionOptions.#ctor(System.Byte,System.Byte,IoT.DriverCore.OmronPlcRx.Enums.ConnectionMethod,System.String)`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.OmronConnectionOptions(byte localNodeId, byte remoteNodeId, IoT.DriverCore.OmronPlcRx.Enums.ConnectionMethod connectionMethod, string remoteHost)
+```
+Configures an Omron PLC transport connection.
+
+- Parameter `localNodeId`: Local FINS node identifier.
+- Parameter `remoteNodeId`: Remote PLC FINS node identifier.
+- Parameter `connectionMethod`: Transport to use.
+- Parameter `remoteHost`: PLC hostname, IP address, or serial port name.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronConnectionOptions.ConnectionMethod`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.Enums.ConnectionMethod ConnectionMethod { get; }
+```
+Gets the transport to use.
+
+- Value: The `ConnectionMethod` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronConnectionOptions.LocalNodeId`
+
+```csharp
+public byte LocalNodeId { get; }
+```
+Gets the local FINS node identifier.
+
+- Value: The `LocalNodeId` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronConnectionOptions.Port`
+
+```csharp
+public int Port { get; set; }
+```
+Gets or initializes the network service port.
+
+- Value: The `Port` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronConnectionOptions.RemoteHost`
+
+```csharp
+public string RemoteHost { get; }
+```
+Gets the PLC hostname, IP address, or serial port name.
+
+- Value: The `RemoteHost` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronConnectionOptions.RemoteNodeId`
+
+```csharp
+public byte RemoteNodeId { get; }
+```
+Gets the remote PLC FINS node identifier.
+
+- Value: The `RemoteNodeId` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronConnectionOptions.Retries`
+
+```csharp
+public int Retries { get; set; }
+```
+Gets or initializes the transient retry count.
+
+- Value: The `Retries` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronConnectionOptions.SerialOptions`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.OmronSerialOptions SerialOptions { get; set; }
+```
+Gets or initializes serial transport settings.
+
+- Value: The `SerialOptions` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronConnectionOptions.Timeout`
+
+```csharp
+public int Timeout { get; set; }
+```
+Gets or initializes the request timeout in milliseconds.
+
+- Value: The `Timeout` value.
+
+#### `T:IoT.DriverCore.OmronPlcRx.OmronHostLinkFinsFrameMode`
+
+```csharp
+public enum IoT.DriverCore.OmronPlcRx.OmronHostLinkFinsFrameMode
+```
+Specifies the Host Link FINS frame layout used over serial communications.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.OmronPlcRx.OmronHostLinkFinsFrameMode.Direct`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.OmronHostLinkFinsFrameMode Direct
+```
+Directly connected host-computer-to-CPU format using ICF/DA2/SA2/SID fields.
+
+###### `F:IoT.DriverCore.OmronPlcRx.OmronHostLinkFinsFrameMode.Network`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.OmronHostLinkFinsFrameMode Network
+```
+Network-capable format using the complete FINS header.
+
+#### `T:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient`
+
+```csharp
+public class IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient
+```
+Contains grouped FINS operations for the logical-tag client.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.#ctor(IoT.DriverCore.OmronPlcRx.IOmronPlcRx)`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient(IoT.DriverCore.OmronPlcRx.IOmronPlcRx plc)
+```
+Initializes a new instance of the `T:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient` class.
+
+- Parameter `plc`: Omron PLC facade used for protocol operations.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.#ctor(IoT.DriverCore.OmronPlcRx.IOmronPlcRx,IoT.DriverCore.Core.ILogicalTagCatalog)`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient(IoT.DriverCore.OmronPlcRx.IOmronPlcRx plc, IoT.DriverCore.Core.ILogicalTagCatalog catalog)
+```
+Initializes a new instance of the `T:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient` class.
+
+- Parameter `plc`: Omron PLC facade used for protocol operations.
+- Parameter `catalog`: Logical-tag catalog.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.#ctor(IoT.DriverCore.OmronPlcRx.IOmronPlcRx,IoT.DriverCore.Core.ILogicalTagCatalog,IoT.DriverCore.Core.LogicalTagSqliteStore)`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient(IoT.DriverCore.OmronPlcRx.IOmronPlcRx plc, IoT.DriverCore.Core.ILogicalTagCatalog catalog, IoT.DriverCore.Core.LogicalTagSqliteStore store)
+```
+Initializes a new instance of the `T:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient` class.
+
+- Parameter `plc`: Omron PLC facade used for protocol operations.
+- Parameter `catalog`: Logical-tag catalog.
+- Parameter `store`: Optional SQLite store.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.#ctor(IoT.DriverCore.OmronPlcRx.IOmronPlcRx,System.String)`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient(IoT.DriverCore.OmronPlcRx.IOmronPlcRx plc, string sqliteConnectionString)
+```
+Initializes a new instance of the `T:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient` class.
+
+- Parameter `plc`: Omron PLC facade used for protocol operations.
+- Parameter `sqliteConnectionString`: SQLite connection string.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.CreateTag``1(IoT.DriverCore.OmronPlcRx.Tags.PlcTag`1{``0})`
+
+```csharp
+public IoT.DriverCore.Core.LogicalTag CreateTag<T>(IoT.DriverCore.OmronPlcRx.Tags.PlcTag<T> tag)
+```
+Executes the `CreateTag` operation.
+
+- Parameter `tag`: The `tag` value.
+- Returns: A `IoT.DriverCore.Core.LogicalTag` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.CreateTag``1(IoT.DriverCore.OmronPlcRx.Tags.PlcTag`1{``0},System.String,System.String,System.Collections.Generic.IReadOnlyDictionary`2{System.String,System.String},IoT.DriverCore.Core.LogicalTagAccessMode,System.Nullable`1{System.TimeSpan})`
+
+```csharp
+public IoT.DriverCore.Core.LogicalTag CreateTag<T>(IoT.DriverCore.OmronPlcRx.Tags.PlcTag<T> tag, string groupName, string description, System.Collections.Generic.IReadOnlyDictionary<string, string> metadata, IoT.DriverCore.Core.LogicalTagAccessMode accessMode, System.Nullable<System.TimeSpan> scanInterval)
+```
+Executes the `CreateTag` operation.
+
+- Parameter `tag`: The `tag` value.
+- Parameter `groupName`: The `groupName` value.
+- Parameter `description`: The `description` value.
+- Parameter `metadata`: The `metadata` value.
+- Parameter `accessMode`: The `accessMode` value.
+- Parameter `scanInterval`: The `scanInterval` value.
+- Returns: A `IoT.DriverCore.Core.LogicalTag` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.DeleteGroupAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> DeleteGroupAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Deletes a persisted tag group.
+
+- Parameter `name`: Logical tag group name.
+- Parameter `cancellationToken`: Token used to cancel the operation.
+- Returns: True when the persisted group existed; otherwise false.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.DeleteTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> DeleteTagAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Deletes a persisted and registered tag.
+
+- Parameter `name`: Logical tag name.
+- Parameter `cancellationToken`: Token used to cancel the operation.
+- Returns: True when the persisted tag existed; otherwise false.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.Dispose`
+
+```csharp
+public void Dispose()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.EditTagAsync(IoT.DriverCore.Core.LogicalTag,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> EditTagAsync(IoT.DriverCore.Core.LogicalTag tag, System.Threading.CancellationToken cancellationToken)
+```
+Edits an existing persisted tag and refreshes its registration.
+
+- Parameter `tag`: Logical tag definition.
+- Parameter `cancellationToken`: Token used to cancel the operation.
+- Returns: True when the persisted tag existed; otherwise false.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.ExportCsvAsync(System.IO.TextWriter,System.Char,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task ExportCsvAsync(System.IO.TextWriter writer, char delimiter, System.Threading.CancellationToken cancellationToken)
+```
+Exports the current catalog as RFC 4180 CSV.
+
+- Parameter `writer`: CSV destination writer.
+- Parameter `delimiter`: CSV delimiter.
+- Parameter `cancellationToken`: Token used to cancel the export.
+- Returns: A task representing the export.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.GetGroupAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.LogicalTagGroup> GetGroupAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Gets a persisted tag group.
+
+- Parameter `name`: Logical tag group name.
+- Parameter `cancellationToken`: Token used to cancel the query.
+- Returns: The matching group when present; otherwise null.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.GetTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.LogicalTag> GetTagAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Gets a persisted tag by name.
+
+- Parameter `name`: Logical tag name.
+- Parameter `cancellationToken`: Token used to cancel the query.
+- Returns: The matching tag when present; otherwise null.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.ImportCsvAsync(System.IO.TextReader,System.Char,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> ImportCsvAsync(System.IO.TextReader reader, char delimiter, System.Threading.CancellationToken cancellationToken)
+```
+Imports RFC 4180 CSV definitions and registers them dynamically.
+
+- Parameter `reader`: CSV source reader.
+- Parameter `delimiter`: CSV delimiter.
+- Parameter `cancellationToken`: Token used to cancel the import.
+- Returns: The imported logical tags.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.InitializeStoreAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task InitializeStoreAsync(System.Threading.CancellationToken cancellationToken)
+```
+Initializes the configured SQLite store.
+
+- Parameter `cancellationToken`: Token used to cancel initialization.
+- Returns: A task representing initialization.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.ListGroupsAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTagGroup>> ListGroupsAsync(System.Threading.CancellationToken cancellationToken)
+```
+Lists persisted tag groups.
+
+- Parameter `cancellationToken`: Token used to cancel the query.
+- Returns: The persisted groups.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.ListTagsAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> ListTagsAsync(System.Threading.CancellationToken cancellationToken)
+```
+Lists persisted tags.
+
+- Parameter `cancellationToken`: Token used to cancel the query.
+- Returns: The persisted logical tags.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.LoadTagsAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> LoadTagsAsync(System.Threading.CancellationToken cancellationToken)
+```
+Loads and dynamically registers all tags from the configured SQLite store.
+
+- Parameter `cancellationToken`: Token used to cancel the load.
+- Returns: The loaded logical tags.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.Observe(System.String)`
+
+```csharp
+public System.IObservable<IoT.DriverCore.Core.LogicalTagValue> Observe(string tagName)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Returns: A `System.IObservable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.ObserveAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue> ObserveAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.ObserveMany(System.Collections.Generic.IReadOnlyCollection`1{System.String})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.Core.LogicalTagValue> ObserveMany(System.Collections.Generic.IReadOnlyCollection<string> tagNames)
+```
+Executes the `ObserveMany` operation.
+
+- Parameter `tagNames`: The `tagNames` value.
+- Returns: A `System.IObservable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.ObserveManyAsync(System.Collections.Generic.IReadOnlyCollection`1{System.String},System.Threading.CancellationToken)`
+
+```csharp
+public System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue> ObserveManyAsync(System.Collections.Generic.IReadOnlyCollection<string> tagNames, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ObserveManyAsync` operation.
+
+- Parameter `tagNames`: The `tagNames` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.ReadAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>> ReadAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.ReadManyAsync(System.Collections.Generic.IReadOnlyCollection`1{System.String},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>> ReadManyAsync(System.Collections.Generic.IReadOnlyCollection<string> tagNames, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ReadManyAsync` operation.
+
+- Parameter `tagNames`: The `tagNames` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>>` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.RegisterTag(IoT.DriverCore.Core.LogicalTag)`
+
+```csharp
+public void RegisterTag(IoT.DriverCore.Core.LogicalTag tag)
+```
+Registers or replaces a logical tag in both the Omron facade and catalog.
+
+- Parameter `tag`: Logical tag to register.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.RemoveTag(System.String)`
+
+```csharp
+public bool RemoveTag(string name)
+```
+Removes a logical tag from the Omron facade and catalog.
+
+- Parameter `name`: Logical tag name.
+- Returns: True when either registration was removed; otherwise false.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.UpsertGroupAsync(IoT.DriverCore.Core.LogicalTagGroup,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task UpsertGroupAsync(IoT.DriverCore.Core.LogicalTagGroup group, System.Threading.CancellationToken cancellationToken)
+```
+Upserts a persisted tag group.
+
+- Parameter `group`: Logical tag group.
+- Parameter `cancellationToken`: Token used to cancel the operation.
+- Returns: A task representing the operation.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.UpsertTagAsync(IoT.DriverCore.Core.LogicalTag,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task UpsertTagAsync(IoT.DriverCore.Core.LogicalTag tag, System.Threading.CancellationToken cancellationToken)
+```
+Upserts a persisted tag and registers the resulting definition.
+
+- Parameter `tag`: Logical tag to upsert.
+- Parameter `cancellationToken`: Token used to cancel the operation.
+- Returns: A task representing the operation.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.WriteAsync(IoT.DriverCore.Core.LogicalTagValue,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>> WriteAsync(IoT.DriverCore.Core.LogicalTagValue value, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `value`: The `value` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.WriteManyAsync(System.Collections.Generic.IReadOnlyCollection`1{IoT.DriverCore.Core.LogicalTagValue},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>> WriteManyAsync(System.Collections.Generic.IReadOnlyCollection<IoT.DriverCore.Core.LogicalTagValue> values, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `WriteManyAsync` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>>` result.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronLogicalTagClient.Catalog`
+
+```csharp
+public IoT.DriverCore.Core.ILogicalTagCatalog Catalog { get; }
+```
+Gets the logical-tag catalog composed by this client.
+
+- Value: The `Catalog` value.
+
+#### `T:IoT.DriverCore.OmronPlcRx.OmronPLCException`
+
+```csharp
+public class IoT.DriverCore.OmronPlcRx.OmronPLCException
+```
+Represents errors that occur during Omron PLC communication or processing.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPLCException.#ctor`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.OmronPLCException()
+```
+Initializes a new instance of the `T:IoT.DriverCore.OmronPlcRx.OmronPLCException` class.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPLCException.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.OmronPLCException(string message)
+```
+Initializes a new instance of the `T:IoT.DriverCore.OmronPlcRx.OmronPLCException` class.
+
+- Parameter `message`: The message that describes the error.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPLCException.#ctor(System.String,System.Exception)`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.OmronPLCException(string message, System.Exception innerException)
+```
+Initializes a new instance of the `T:IoT.DriverCore.OmronPlcRx.OmronPLCException` class.
+
+- Parameter `message`: The error message that explains the reason for the exception.
+- Parameter `innerException`: The exception that is the cause of the current exception.
+
+#### `T:IoT.DriverCore.OmronPlcRx.OmronPlcRx`
+
+```csharp
+public class IoT.DriverCore.OmronPlcRx.OmronPlcRx
+```
+Contains PLC tag address parsing helpers.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcRx.#ctor(IoT.DriverCore.OmronPlcRx.OmronConnectionOptions,System.Nullable`1{System.TimeSpan})`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.OmronPlcRx(IoT.DriverCore.OmronPlcRx.OmronConnectionOptions options, System.Nullable<System.TimeSpan> pollInterval)
+```
+Initializes a new instance of `IoT.DriverCore.OmronPlcRx.OmronPlcRx`.
+
+- Parameter `options`: The `options` value.
+- Parameter `pollInterval`: The `pollInterval` value.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcRx.#ctor(System.Byte,System.Byte,IoT.DriverCore.OmronPlcRx.OmronSerialOptions,System.Int32,System.Int32,System.Nullable`1{System.TimeSpan})`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.OmronPlcRx(byte localNodeId, byte remoteNodeId, IoT.DriverCore.OmronPlcRx.OmronSerialOptions serialOptions, int timeout, int retries, System.Nullable<System.TimeSpan> pollInterval)
+```
+Initializes a new instance of `IoT.DriverCore.OmronPlcRx.OmronPlcRx`.
+
+- Parameter `localNodeId`: The `localNodeId` value.
+- Parameter `remoteNodeId`: The `remoteNodeId` value.
+- Parameter `serialOptions`: The `serialOptions` value.
+- Parameter `timeout`: The `timeout` value.
+- Parameter `retries`: The `retries` value.
+- Parameter `pollInterval`: The `pollInterval` value.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcRx.AddUpdateTagItem``1(IoT.DriverCore.OmronPlcRx.Tags.PlcTag`1{``0})`
+
+```csharp
+public void AddUpdateTagItem<T>(IoT.DriverCore.OmronPlcRx.Tags.PlcTag<T> tag)
+```
+Executes the `AddUpdateTagItem` operation.
+
+- Parameter `tag`: The `tag` value.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcRx.Dispose`
+
+```csharp
+public void Dispose()
+```
+Dispose pattern.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcRx.GetValue``1(IoT.DriverCore.Core.LogicalTagKey`1{``0})`
+
+```csharp
+public T GetValue<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag)
+```
+Executes the `GetValue` operation.
+
+- Parameter `tag`: The `tag` value.
+- Returns: A `T` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcRx.Observe``1(IoT.DriverCore.Core.LogicalTagKey`1{``0})`
+
+```csharp
+public System.IObservable<T> Observe<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag)
+```
+Executes the `Observe` operation.
+
+- Parameter `tag`: The `tag` value.
+- Returns: A `System.IObservable<T>` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcRx.ReadClockAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.OmronPlcRx.Results.ReadClockResult> ReadClockAsync(System.Threading.CancellationToken cancellationToken)
+```
+Reads the PLC real-time clock via the underlying connection.
+
+- Parameter `cancellationToken`: Cancellation token.
+- Returns: Clock read result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcRx.ReadCycleTimeAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult> ReadCycleTimeAsync(System.Threading.CancellationToken cancellationToken)
+```
+Reads PLC scan cycle time statistics via the underlying connection.
+
+- Parameter `cancellationToken`: Cancellation token.
+- Returns: Cycle time statistics.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcRx.ReadValueAsync``1(IoT.DriverCore.Core.LogicalTagKey`1{``0},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<T> ReadValueAsync<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ReadValueAsync` operation.
+
+- Parameter `tag`: The `tag` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<T>` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcRx.RemoveTagItem(System.String)`
+
+```csharp
+public bool RemoveTagItem(string tagName)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcRx.SetValue``1(IoT.DriverCore.Core.LogicalTagKey`1{``0},``0)`
+
+```csharp
+public void SetValue<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag, T value)
+```
+Executes the `SetValue` operation.
+
+- Parameter `tag`: The `tag` value.
+- Parameter `value`: The `value` value.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcRx.WriteClockAsync(System.DateTimeOffset,System.Int32,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.OmronPlcRx.Results.WriteClockResult> WriteClockAsync(System.DateTimeOffset newDateTime, int newDayOfWeek, System.Threading.CancellationToken cancellationToken)
+```
+Writes the PLC real-time clock with explicit day-of-week via the underlying connection.
+
+- Parameter `newDateTime`: New date/time.
+- Parameter `newDayOfWeek`: Day of week (0-6).
+- Parameter `cancellationToken`: Cancellation token.
+- Returns: Clock write result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcRx.WriteClockAsync(System.DateTimeOffset,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.OmronPlcRx.Results.WriteClockResult> WriteClockAsync(System.DateTimeOffset newDateTime, System.Threading.CancellationToken cancellationToken)
+```
+Writes the PLC real-time clock (day-of-week inferred) via the underlying connection.
+
+- Parameter `newDateTime`: New date/time.
+- Parameter `cancellationToken`: Cancellation token.
+- Returns: Clock write result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcRx.WriteValueAsync``1(IoT.DriverCore.Core.LogicalTagKey`1{``0},``0,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task WriteValueAsync<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag, T value, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `WriteValueAsync` operation.
+
+- Parameter `tag`: The `tag` value.
+- Parameter `value`: The `value` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task` result.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronPlcRx.ControllerModel`
+
+```csharp
+public string ControllerModel { get; }
+```
+Gets the controller model value.
+
+- Value: The `ControllerModel` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronPlcRx.ControllerVersion`
+
+```csharp
+public string ControllerVersion { get; }
+```
+Gets the controller version value.
+
+- Value: The `ControllerVersion` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronPlcRx.Errors`
+
+```csharp
+public System.IObservable<IoT.DriverCore.OmronPlcRx.OmronPLCException> Errors { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `Errors` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronPlcRx.IsDisposed`
+
+```csharp
+public bool IsDisposed { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `IsDisposed` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronPlcRx.ObserveAll`
+
+```csharp
+public System.IObservable<IoT.DriverCore.OmronPlcRx.Tags.IPlcTag> ObserveAll { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `ObserveAll` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronPlcRx.PlcType`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.Enums.PlcType PlcType { get; }
+```
+Gets the plc type value.
+
+- Value: The type of the PLC.
+
+#### `T:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator`
+
+```csharp
+public class IoT.DriverCore.OmronPlcRx.OmronPlcSimulator
+```
+Provides a deterministic, in-memory Omron PLC through `T:IoT.DriverCore.OmronPlcRx.IOmronPlcRx` .
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.#ctor`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.OmronPlcSimulator()
+```
+Initializes a new instance of the `T:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator` class.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.#ctor(IoT.DriverCore.OmronPlcRx.Enums.PlcType,System.String,System.String,System.Boolean,System.DateTimeOffset)`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.OmronPlcSimulator(IoT.DriverCore.OmronPlcRx.Enums.PlcType plcType, string controllerModel, string controllerVersion, bool initiallyConnected, System.DateTimeOffset initialClock)
+```
+Initializes a new instance of the `T:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator` class.
+
+- Parameter `plcType`: PLC model family reported to callers.
+- Parameter `controllerModel`: Controller model reported to callers.
+- Parameter `controllerVersion`: Controller version reported to callers.
+- Parameter `initiallyConnected`: Whether the simulated transport starts connected.
+- Parameter `initialClock`: Optional deterministic initial clock.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.#ctor(System.Boolean)`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.OmronPlcSimulator(bool initiallyConnected)
+```
+Initializes a new instance of the `T:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator` class.
+
+- Parameter `initiallyConnected`: Whether the simulated transport starts connected.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.AddUpdateTagItem``1(IoT.DriverCore.OmronPlcRx.Tags.PlcTag`1{``0})`
+
+```csharp
+public void AddUpdateTagItem<T>(IoT.DriverCore.OmronPlcRx.Tags.PlcTag<T> tag)
+```
+Executes the `AddUpdateTagItem` operation.
+
+- Parameter `tag`: The `tag` value.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.ConnectAsync`
+
+```csharp
+public System.Threading.Tasks.Task ConnectAsync()
+```
+Connects the simulated transport.
+
+- Returns: A task that represents the operation.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.ConnectAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task ConnectAsync(System.Threading.CancellationToken cancellationToken)
+```
+Connects the simulated transport.
+
+- Parameter `cancellationToken`: Cancellation token.
+- Returns: A task that represents the operation.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.Disconnect`
+
+```csharp
+public void Disconnect()
+```
+Disconnects the simulated transport while retaining memory and registrations.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.Dispose`
+
+```csharp
+public void Dispose()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.GetValue``1(IoT.DriverCore.Core.LogicalTagKey`1{``0})`
+
+```csharp
+public T GetValue<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag)
+```
+Executes the `GetValue` operation.
+
+- Parameter `tag`: The `tag` value.
+- Returns: A `T` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.Observe``1(IoT.DriverCore.Core.LogicalTagKey`1{``0})`
+
+```csharp
+public System.IObservable<T> Observe<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag)
+```
+Executes the `Observe` operation.
+
+- Parameter `tag`: The `tag` value.
+- Returns: A `System.IObservable<T>` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.QueueFault(IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation,System.Exception)`
+
+```csharp
+public void QueueFault(IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation operation, System.Exception exception)
+```
+Queues one disconnecting failure for the selected operation.
+
+- Parameter `operation`: Operation to fail.
+- Parameter `exception`: Failure to wrap and publish.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.QueueFault(IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation,System.Exception,System.Int32,System.Boolean)`
+
+```csharp
+public void QueueFault(IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation operation, System.Exception exception, int occurrences, bool disconnect)
+```
+Queues deterministic failures for the selected operation.
+
+- Parameter `operation`: Operation to fail.
+- Parameter `exception`: Failure to wrap and publish.
+- Parameter `occurrences`: Number of consecutive failures to queue.
+- Parameter `disconnect`: Whether each failure disconnects the simulated transport.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.ReadClockAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.OmronPlcRx.Results.ReadClockResult> ReadClockAsync(System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.OmronPlcRx.Results.ReadClockResult>` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.ReadCycleTimeAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult> ReadCycleTimeAsync(System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult>` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.ReadValueAsync``1(IoT.DriverCore.Core.LogicalTagKey`1{``0},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<T> ReadValueAsync<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ReadValueAsync` operation.
+
+- Parameter `tag`: The `tag` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<T>` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.ReconnectAsync`
+
+```csharp
+public System.Threading.Tasks.Task ReconnectAsync()
+```
+Reconnects the simulated transport while retaining memory and registrations.
+
+- Returns: A task that represents the operation.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.ReconnectAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task ReconnectAsync(System.Threading.CancellationToken cancellationToken)
+```
+Reconnects the simulated transport while retaining memory and registrations.
+
+- Parameter `cancellationToken`: Cancellation token.
+- Returns: A task that represents the operation.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.RemoveTagItem(System.String)`
+
+```csharp
+public bool RemoveTagItem(string tagName)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.Seed``1(IoT.DriverCore.OmronPlcRx.Tags.PlcTag`1{``0},``0)`
+
+```csharp
+public void Seed<T>(IoT.DriverCore.OmronPlcRx.Tags.PlcTag<T> tag, T value)
+```
+Executes the `Seed` operation.
+
+- Parameter `tag`: The `tag` value.
+- Parameter `value`: The `value` value.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.SetValue``1(IoT.DriverCore.Core.LogicalTagKey`1{``0},``0)`
+
+```csharp
+public void SetValue<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag, T value)
+```
+Executes the `SetValue` operation.
+
+- Parameter `tag`: The `tag` value.
+- Parameter `value`: The `value` value.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.WriteClockAsync(System.DateTimeOffset,System.Int32,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.OmronPlcRx.Results.WriteClockResult> WriteClockAsync(System.DateTimeOffset newDateTime, int newDayOfWeek, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `newDateTime`: The `newDateTime` value.
+- Parameter `newDayOfWeek`: The `newDayOfWeek` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.OmronPlcRx.Results.WriteClockResult>` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.WriteClockAsync(System.DateTimeOffset,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.OmronPlcRx.Results.WriteClockResult> WriteClockAsync(System.DateTimeOffset newDateTime, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `newDateTime`: The `newDateTime` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.OmronPlcRx.Results.WriteClockResult>` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.WriteValueAsync``1(IoT.DriverCore.Core.LogicalTagKey`1{``0},``0,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task WriteValueAsync<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag, T value, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `WriteValueAsync` operation.
+
+- Parameter `tag`: The `tag` value.
+- Parameter `value`: The `value` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task` result.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.AverageCycleTime`
+
+```csharp
+public double AverageCycleTime { get; set; }
+```
+Gets or sets simulated average cycle time in milliseconds.
+
+- Value: The `AverageCycleTime` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.ControllerModel`
+
+```csharp
+public string ControllerModel { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `ControllerModel` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.ControllerVersion`
+
+```csharp
+public string ControllerVersion { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `ControllerVersion` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.Errors`
+
+```csharp
+public System.IObservable<IoT.DriverCore.OmronPlcRx.OmronPLCException> Errors { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `Errors` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.IsConnected`
+
+```csharp
+public bool IsConnected { get; }
+```
+Gets a value indicating whether the simulated transport is connected.
+
+- Value: The `IsConnected` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.IsDisposed`
+
+```csharp
+public bool IsDisposed { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `IsDisposed` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.MaximumCycleTime`
+
+```csharp
+public double MaximumCycleTime { get; set; }
+```
+Gets or sets simulated maximum cycle time in milliseconds.
+
+- Value: The `MaximumCycleTime` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.MinimumCycleTime`
+
+```csharp
+public double MinimumCycleTime { get; set; }
+```
+Gets or sets simulated minimum cycle time in milliseconds.
+
+- Value: The `MinimumCycleTime` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.ObserveAll`
+
+```csharp
+public System.IObservable<IoT.DriverCore.OmronPlcRx.Tags.IPlcTag> ObserveAll { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `ObserveAll` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.Operations`
+
+```csharp
+public System.Collections.Generic.IReadOnlyList<IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord> Operations { get; }
+```
+Gets a snapshot of completed simulator operations.
+
+- Value: The `Operations` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.PlcType`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.Enums.PlcType PlcType { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `PlcType` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator.ReconnectCount`
+
+```csharp
+public int ReconnectCount { get; }
+```
+Gets the number of successful reconnections.
+
+- Value: The `ReconnectCount` value.
+
+#### `T:IoT.DriverCore.OmronPlcRx.OmronSerialOptions`
+
+```csharp
+public class IoT.DriverCore.OmronPlcRx.OmronSerialOptions
+```
+Gets or sets the omron serial options value.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.OmronSerialOptions(string portName)
+```
+Initializes a new instance of the `T:IoT.DriverCore.OmronPlcRx.OmronSerialOptions` class.
+
+- Parameter `portName`: Serial port name, e.g. COM1 or /dev/ttyUSB0.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.CreateToolbus(System.String)`
+
+```csharp
+public static IoT.DriverCore.OmronPlcRx.OmronSerialOptions CreateToolbus(string portName)
+```
+Creates Toolbus serial options using common Omron Toolbus port settings.
+
+- Parameter `portName`: Serial port name, e.g. COM1 or /dev/ttyUSB0.
+- Returns: Serial options configured for Toolbus FINS framing.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.Equals(IoT.DriverCore.OmronPlcRx.OmronSerialOptions)`
+
+```csharp
+public bool Equals(IoT.DriverCore.OmronPlcRx.OmronSerialOptions other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.Validate`
+
+```csharp
+public void Validate()
+```
+Validates this options instance.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.op_Equality(IoT.DriverCore.OmronPlcRx.OmronSerialOptions,IoT.DriverCore.OmronPlcRx.OmronSerialOptions)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.OmronPlcRx.OmronSerialOptions left, IoT.DriverCore.OmronPlcRx.OmronSerialOptions right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.op_Inequality(IoT.DriverCore.OmronPlcRx.OmronSerialOptions,IoT.DriverCore.OmronPlcRx.OmronSerialOptions)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.OmronPlcRx.OmronSerialOptions left, IoT.DriverCore.OmronPlcRx.OmronSerialOptions right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.BaudRate`
+
+```csharp
+public int BaudRate { get; set; }
+```
+Gets or sets the baud rate value.
+
+- Value: The `BaudRate` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.DataBits`
+
+```csharp
+public int DataBits { get; set; }
+```
+Gets or sets the data bits value.
+
+- Value: The `DataBits` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.DtrEnable`
+
+```csharp
+public bool DtrEnable { get; set; }
+```
+Gets or sets the dtr enable value.
+
+- Value: The `DtrEnable` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.FrameMode`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.OmronHostLinkFinsFrameMode FrameMode { get; set; }
+```
+Gets or sets the frame mode value.
+
+- Value: The `FrameMode` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.Handshake`
+
+```csharp
+public System.IO.Ports.Handshake Handshake { get; set; }
+```
+Gets or sets the handshake value.
+
+- Value: The `Handshake` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.HostLinkUnitNumber`
+
+```csharp
+public byte HostLinkUnitNumber { get; set; }
+```
+Gets or sets the host link unit number value.
+
+- Value: The `HostLinkUnitNumber` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.MaximumFrameLength`
+
+```csharp
+public int MaximumFrameLength { get; set; }
+```
+Gets or sets the maximum frame length value.
+
+- Value: The `MaximumFrameLength` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.Parity`
+
+```csharp
+public System.IO.Ports.Parity Parity { get; set; }
+```
+Gets or sets the parity value.
+
+- Value: The `Parity` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.PortName`
+
+```csharp
+public string PortName { get; set; }
+```
+Gets or sets the port name value.
+
+- Value: The `PortName` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.Protocol`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.OmronSerialProtocol Protocol { get; set; }
+```
+Gets or sets the protocol value.
+
+- Value: The `Protocol` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.ResponseWaitTime`
+
+```csharp
+public byte ResponseWaitTime { get; set; }
+```
+Gets or sets the response wait time value.
+
+- Value: The `ResponseWaitTime` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.RtsEnable`
+
+```csharp
+public bool RtsEnable { get; set; }
+```
+Gets or sets the rts enable value.
+
+- Value: The `RtsEnable` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronSerialOptions.StopBits`
+
+```csharp
+public System.IO.Ports.StopBits StopBits { get; set; }
+```
+Gets or sets the stop bits value.
+
+- Value: The `StopBits` value.
+
+#### `T:IoT.DriverCore.OmronPlcRx.OmronSerialProtocol`
+
+```csharp
+public enum IoT.DriverCore.OmronPlcRx.OmronSerialProtocol
+```
+Specifies the serial protocol used to carry FINS messages.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.OmronPlcRx.OmronSerialProtocol.HostLinkFins`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.OmronSerialProtocol HostLinkFins
+```
+Host Link FINS using ASCII FA frames.
+
+###### `F:IoT.DriverCore.OmronPlcRx.OmronSerialProtocol.Toolbus`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.OmronSerialProtocol Toolbus
+```
+Omron Toolbus using binary 0xAB frames carrying binary FINS messages.
+
+#### `T:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation`
+
+```csharp
+public enum IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation
+```
+Identifies an operation that can be faulted by `T:IoT.DriverCore.OmronPlcRx.OmronPlcSimulator` .
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation.Connect`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation Connect
+```
+Opening or reopening the simulated connection.
+
+###### `F:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation.Read`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation Read
+```
+Reading a registered tag.
+
+###### `F:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation.ReadClock`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation ReadClock
+```
+Reading the simulated real-time clock.
+
+###### `F:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation.ReadCycleTime`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation ReadCycleTime
+```
+Reading simulated cycle-time statistics.
+
+###### `F:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation.Write`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation Write
+```
+Writing a registered tag.
+
+###### `F:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation.WriteClock`
+
+```csharp
+public static const IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation WriteClock
+```
+Writing the simulated real-time clock.
+
+#### `T:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord`
+
+```csharp
+public class IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord
+```
+Describes one completed simulator operation.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord.#ctor(System.Int64,IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation,System.String,System.Object,System.Boolean)`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord(long Sequence, IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation Operation, string TagName, object Value, bool Succeeded)
+```
+Describes one completed simulator operation.
+
+- Parameter `Sequence`: Monotonic operation sequence number.
+- Parameter `Operation`: Operation kind.
+- Parameter `TagName`: Optional logical tag name.
+- Parameter `Value`: Optional operation value.
+- Parameter `Succeeded`: Whether the operation succeeded.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord.Deconstruct(System.Int64@,IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation@,System.String@,System.Object@,System.Boolean@)`
+
+```csharp
+public void Deconstruct(out long Sequence, out IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation Operation, out string TagName, out object Value, out bool Succeeded)
+```
+Deconstructs the value into its component values.
+
+- Parameter `Sequence`: The `Sequence` value.
+- Parameter `Operation`: The `Operation` value.
+- Parameter `TagName`: The `TagName` value.
+- Parameter `Value`: The `Value` value.
+- Parameter `Succeeded`: The `Succeeded` value.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord.Equals(IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord)`
+
+```csharp
+public bool Equals(IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord.op_Equality(IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord,IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord left, IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord.op_Inequality(IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord,IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord left, IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord.Operation`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.OmronSimulatorOperation Operation { get; set; }
+```
+Operation kind.
+
+- Value: The `Operation` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord.Sequence`
+
+```csharp
+public long Sequence { get; set; }
+```
+Monotonic operation sequence number.
+
+- Value: The `Sequence` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord.Succeeded`
+
+```csharp
+public bool Succeeded { get; set; }
+```
+Whether the operation succeeded.
+
+- Value: The `Succeeded` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord.TagName`
+
+```csharp
+public string TagName { get; set; }
+```
+Optional logical tag name.
+
+- Value: The `TagName` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.OmronSimulatorOperationRecord.Value`
+
+```csharp
+public object Value { get; set; }
+```
+Optional operation value.
+
+- Value: The `Value` value.
+
+#### `T:IoT.DriverCore.OmronPlcRx.PlcTagAttribute`
+
+```csharp
+public class IoT.DriverCore.OmronPlcRx.PlcTagAttribute
+```
+Marks a field or property for PLC reactive stream source generation.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.PlcTagAttribute.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.PlcTagAttribute(string address)
+```
+Marks a field or property for PLC reactive stream source generation.
+
+- Parameter `address`: The a dd re ss value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.PlcTagAttribute.Address`
+
+```csharp
+public string Address { get; }
+```
+Gets the address value.
+
+- Value: The `Address` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.PlcTagAttribute.Observe`
+
+```csharp
+public bool Observe { get; set; }
+```
+Gets or sets the observe value.
+
+- Value: The `Observe` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.PlcTagAttribute.Register`
+
+```csharp
+public bool Register { get; set; }
+```
+Gets or sets the register value.
+
+- Value: The `Register` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.PlcTagAttribute.TagName`
+
+```csharp
+public string TagName { get; set; }
+```
+Gets or sets the tag name value.
+
+- Value: The `TagName` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.PlcTagAttribute.Writable`
+
+```csharp
+public bool Writable { get; set; }
+```
+Gets or sets the writable value.
+
+- Value: The `Writable` value.
+
+#### `T:IoT.DriverCore.OmronPlcRx.PlcTagBindingAttribute`
+
+```csharp
+public class IoT.DriverCore.OmronPlcRx.PlcTagBindingAttribute
+```
+Marks a partial class as a generated PLC tag binding container.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.PlcTagBindingAttribute.#ctor`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.PlcTagBindingAttribute()
+```
+Initializes a new instance of `IoT.DriverCore.OmronPlcRx.PlcTagBindingAttribute`.
+
+#### `T:IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult`
+
+```csharp
+public struct IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult
+```
+Result of a Read Bits operation.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult.Equals(IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult)`
+
+```csharp
+public bool Equals(IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult.op_Equality(IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult,IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult left, IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult.op_Inequality(IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult,IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult left, IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult.BytesReceived`
+
+```csharp
+public int BytesReceived { get; set; }
+```
+Gets or sets the bytes received value.
+
+- Value: The `BytesReceived` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult.BytesSent`
+
+```csharp
+public int BytesSent { get; set; }
+```
+Gets or sets the bytes sent value.
+
+- Value: The `BytesSent` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult.Duration`
+
+```csharp
+public double Duration { get; set; }
+```
+Gets or sets the duration value.
+
+- Value: The `Duration` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult.PacketsReceived`
+
+```csharp
+public int PacketsReceived { get; set; }
+```
+Gets or sets the packets received value.
+
+- Value: The `PacketsReceived` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult.PacketsSent`
+
+```csharp
+public int PacketsSent { get; set; }
+```
+Gets or sets the packets sent value.
+
+- Value: The `PacketsSent` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadBitsResult.Values`
+
+```csharp
+public bool[] Values { get; set; }
+```
+Gets or sets the values value.
+
+- Value: The `Values` value.
+
+#### `T:IoT.DriverCore.OmronPlcRx.Results.ReadClockResult`
+
+```csharp
+public struct IoT.DriverCore.OmronPlcRx.Results.ReadClockResult
+```
+Result of a Read Clock operation.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadClockResult.Equals(IoT.DriverCore.OmronPlcRx.Results.ReadClockResult)`
+
+```csharp
+public bool Equals(IoT.DriverCore.OmronPlcRx.Results.ReadClockResult other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadClockResult.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadClockResult.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadClockResult.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadClockResult.op_Equality(IoT.DriverCore.OmronPlcRx.Results.ReadClockResult,IoT.DriverCore.OmronPlcRx.Results.ReadClockResult)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.OmronPlcRx.Results.ReadClockResult left, IoT.DriverCore.OmronPlcRx.Results.ReadClockResult right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadClockResult.op_Inequality(IoT.DriverCore.OmronPlcRx.Results.ReadClockResult,IoT.DriverCore.OmronPlcRx.Results.ReadClockResult)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.OmronPlcRx.Results.ReadClockResult left, IoT.DriverCore.OmronPlcRx.Results.ReadClockResult right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadClockResult.BytesReceived`
+
+```csharp
+public int BytesReceived { get; set; }
+```
+Gets or sets the bytes received value.
+
+- Value: The `BytesReceived` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadClockResult.BytesSent`
+
+```csharp
+public int BytesSent { get; set; }
+```
+Gets or sets the bytes sent value.
+
+- Value: The `BytesSent` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadClockResult.Clock`
+
+```csharp
+public System.DateTimeOffset Clock { get; set; }
+```
+Gets or sets the clock value.
+
+- Value: The `Clock` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadClockResult.DayOfWeek`
+
+```csharp
+public int DayOfWeek { get; set; }
+```
+Gets or sets the day of week value.
+
+- Value: The `DayOfWeek` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadClockResult.Duration`
+
+```csharp
+public double Duration { get; set; }
+```
+Gets or sets the duration value.
+
+- Value: The `Duration` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadClockResult.PacketsReceived`
+
+```csharp
+public int PacketsReceived { get; set; }
+```
+Gets or sets the packets received value.
+
+- Value: The `PacketsReceived` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadClockResult.PacketsSent`
+
+```csharp
+public int PacketsSent { get; set; }
+```
+Gets or sets the packets sent value.
+
+- Value: The `PacketsSent` value.
+
+#### `T:IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult`
+
+```csharp
+public struct IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult
+```
+Result of a Read Cycle Time operation.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult.Equals(IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult)`
+
+```csharp
+public bool Equals(IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult.op_Equality(IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult,IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult left, IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult.op_Inequality(IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult,IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult left, IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult.AverageCycleTime`
+
+```csharp
+public double AverageCycleTime { get; set; }
+```
+Gets or sets the average cycle time value.
+
+- Value: The `AverageCycleTime` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult.BytesReceived`
+
+```csharp
+public int BytesReceived { get; set; }
+```
+Gets or sets the bytes received value.
+
+- Value: The `BytesReceived` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult.BytesSent`
+
+```csharp
+public int BytesSent { get; set; }
+```
+Gets or sets the bytes sent value.
+
+- Value: The `BytesSent` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult.Duration`
+
+```csharp
+public double Duration { get; set; }
+```
+Gets or sets the duration value.
+
+- Value: The `Duration` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult.MaximumCycleTime`
+
+```csharp
+public double MaximumCycleTime { get; set; }
+```
+Gets or sets the maximum cycle time value.
+
+- Value: The `MaximumCycleTime` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult.MinimumCycleTime`
+
+```csharp
+public double MinimumCycleTime { get; set; }
+```
+Gets or sets the minimum cycle time value.
+
+- Value: The `MinimumCycleTime` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult.PacketsReceived`
+
+```csharp
+public int PacketsReceived { get; set; }
+```
+Gets or sets the packets received value.
+
+- Value: The `PacketsReceived` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadCycleTimeResult.PacketsSent`
+
+```csharp
+public int PacketsSent { get; set; }
+```
+Gets or sets the packets sent value.
+
+- Value: The `PacketsSent` value.
+
+#### `T:IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult`
+
+```csharp
+public struct IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult
+```
+Result of a Read Words operation.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult.Equals(IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult)`
+
+```csharp
+public bool Equals(IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult.op_Equality(IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult,IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult left, IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult.op_Inequality(IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult,IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult left, IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult.BytesReceived`
+
+```csharp
+public int BytesReceived { get; set; }
+```
+Gets or sets the bytes received value.
+
+- Value: The `BytesReceived` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult.BytesSent`
+
+```csharp
+public int BytesSent { get; set; }
+```
+Gets or sets the bytes sent value.
+
+- Value: The `BytesSent` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult.Duration`
+
+```csharp
+public double Duration { get; set; }
+```
+Gets or sets the duration value.
+
+- Value: The `Duration` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult.PacketsReceived`
+
+```csharp
+public int PacketsReceived { get; set; }
+```
+Gets or sets the packets received value.
+
+- Value: The `PacketsReceived` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult.PacketsSent`
+
+```csharp
+public int PacketsSent { get; set; }
+```
+Gets or sets the packets sent value.
+
+- Value: The `PacketsSent` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.ReadWordsResult.Values`
+
+```csharp
+public short[] Values { get; set; }
+```
+Gets or sets the values value.
+
+- Value: The `Values` value.
+
+#### `T:IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult`
+
+```csharp
+public struct IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult
+```
+Result of a Write Bits operation.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult.Equals(IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult)`
+
+```csharp
+public bool Equals(IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult.op_Equality(IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult,IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult left, IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult.op_Inequality(IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult,IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult left, IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult.BytesReceived`
+
+```csharp
+public int BytesReceived { get; set; }
+```
+Gets or sets the bytes received value.
+
+- Value: The `BytesReceived` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult.BytesSent`
+
+```csharp
+public int BytesSent { get; set; }
+```
+Gets or sets the bytes sent value.
+
+- Value: The `BytesSent` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult.Duration`
+
+```csharp
+public double Duration { get; set; }
+```
+Gets or sets the duration value.
+
+- Value: The `Duration` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult.PacketsReceived`
+
+```csharp
+public int PacketsReceived { get; set; }
+```
+Gets or sets the packets received value.
+
+- Value: The `PacketsReceived` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.WriteBitsResult.PacketsSent`
+
+```csharp
+public int PacketsSent { get; set; }
+```
+Gets or sets the packets sent value.
+
+- Value: The `PacketsSent` value.
+
+#### `T:IoT.DriverCore.OmronPlcRx.Results.WriteClockResult`
+
+```csharp
+public struct IoT.DriverCore.OmronPlcRx.Results.WriteClockResult
+```
+Result of a Write Clock operation.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.WriteClockResult.Equals(IoT.DriverCore.OmronPlcRx.Results.WriteClockResult)`
+
+```csharp
+public bool Equals(IoT.DriverCore.OmronPlcRx.Results.WriteClockResult other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.WriteClockResult.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.WriteClockResult.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.WriteClockResult.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.WriteClockResult.op_Equality(IoT.DriverCore.OmronPlcRx.Results.WriteClockResult,IoT.DriverCore.OmronPlcRx.Results.WriteClockResult)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.OmronPlcRx.Results.WriteClockResult left, IoT.DriverCore.OmronPlcRx.Results.WriteClockResult right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.WriteClockResult.op_Inequality(IoT.DriverCore.OmronPlcRx.Results.WriteClockResult,IoT.DriverCore.OmronPlcRx.Results.WriteClockResult)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.OmronPlcRx.Results.WriteClockResult left, IoT.DriverCore.OmronPlcRx.Results.WriteClockResult right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.WriteClockResult.BytesReceived`
+
+```csharp
+public int BytesReceived { get; set; }
+```
+Gets or sets the bytes received value.
+
+- Value: The `BytesReceived` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.WriteClockResult.BytesSent`
+
+```csharp
+public int BytesSent { get; set; }
+```
+Gets or sets the bytes sent value.
+
+- Value: The `BytesSent` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.WriteClockResult.Duration`
+
+```csharp
+public double Duration { get; set; }
+```
+Gets or sets the duration value.
+
+- Value: The `Duration` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.WriteClockResult.PacketsReceived`
+
+```csharp
+public int PacketsReceived { get; set; }
+```
+Gets or sets the packets received value.
+
+- Value: The `PacketsReceived` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.WriteClockResult.PacketsSent`
+
+```csharp
+public int PacketsSent { get; set; }
+```
+Gets or sets the packets sent value.
+
+- Value: The `PacketsSent` value.
+
+#### `T:IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult`
+
+```csharp
+public struct IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult
+```
+Result of a Write Words operation.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult.Equals(IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult)`
+
+```csharp
+public bool Equals(IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult.op_Equality(IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult,IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult left, IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult.op_Inequality(IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult,IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult left, IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult.BytesReceived`
+
+```csharp
+public int BytesReceived { get; set; }
+```
+Gets or sets the bytes received value.
+
+- Value: The `BytesReceived` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult.BytesSent`
+
+```csharp
+public int BytesSent { get; set; }
+```
+Gets or sets the bytes sent value.
+
+- Value: The `BytesSent` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult.Duration`
+
+```csharp
+public double Duration { get; set; }
+```
+Gets or sets the duration value.
+
+- Value: The `Duration` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult.PacketsReceived`
+
+```csharp
+public int PacketsReceived { get; set; }
+```
+Gets or sets the packets received value.
+
+- Value: The `PacketsReceived` value.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Results.WriteWordsResult.PacketsSent`
+
+```csharp
+public int PacketsSent { get; set; }
+```
+Gets or sets the packets sent value.
+
+- Value: The `PacketsSent` value.
+
+#### `T:IoT.DriverCore.OmronPlcRx.Tags.IPlcTag`
+
+```csharp
+public interface IoT.DriverCore.OmronPlcRx.Tags.IPlcTag
+```
+Defines metadata and value access for a PLC tag.
+
+##### Declared public members
+
+###### `P:IoT.DriverCore.OmronPlcRx.Tags.IPlcTag.Address`
+
+```csharp
+public string Address { get; }
+```
+Gets the address.
+
+- Value: The address.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Tags.IPlcTag.TagName`
+
+```csharp
+public string TagName { get; }
+```
+Gets the name of the tag.
+
+- Value: The name of the tag.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Tags.IPlcTag.TagType`
+
+```csharp
+public System.Type TagType { get; }
+```
+Gets a value indicating whether this instance is bit address.
+
+- Value: true if this instance is bit address; otherwise, false .
+
+###### `P:IoT.DriverCore.OmronPlcRx.Tags.IPlcTag.Value`
+
+```csharp
+public object Value { get; }
+```
+Gets the value.
+
+- Value: The value.
+
+#### `T:IoT.DriverCore.OmronPlcRx.Tags.PlcTag`1`
+
+```csharp
+public class IoT.DriverCore.OmronPlcRx.Tags.PlcTag`1
+```
+Represents a typed PLC tag binding.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.Tags.PlcTag`1.#ctor(System.String,System.String)`
+
+```csharp
+public IoT.DriverCore.OmronPlcRx.Tags.PlcTag<T>(string tagName, string address)
+```
+Represents a typed PLC tag binding.
+
+- Parameter `tagName`: The tag Name.
+- Parameter `address`: The address.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Tags.PlcTag`1.Address`
+
+```csharp
+public string Address { get; }
+```
+Gets the address.
+
+- Value: The address.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Tags.PlcTag`1.TagName`
+
+```csharp
+public string TagName { get; }
+```
+Gets the Tag Name.
+
+- Value: The name.
+
+###### `P:IoT.DriverCore.OmronPlcRx.Tags.PlcTag`1.TagType`
+
+```csharp
+public System.Type TagType { get; }
+```
+Gets a value indicating whether this instance is bit address.
+
+- Value: true if this instance is bit address; otherwise, false .
+
+###### `P:IoT.DriverCore.OmronPlcRx.Tags.PlcTag`1.Value`
+
+```csharp
+public T Value { get; }
+```
+Gets the tag value.
+
+- Value: The value.
+
+#### `T:IoT.DriverCore.OmronPlcRx.ToolbusFinsFrameCodec`
+
+```csharp
+public class IoT.DriverCore.OmronPlcRx.ToolbusFinsFrameCodec
+```
+Encodes and decodes Omron Toolbus serial frames carrying binary FINS messages.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.OmronPlcRx.ToolbusFinsFrameCodec.CalculateChecksum(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static ushort CalculateChecksum(System.ReadOnlySpan<byte> data)
+```
+Executes the `CalculateChecksum` operation.
+
+- Parameter `data`: The `data` value.
+- Returns: A `ushort` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.ToolbusFinsFrameCodec.DecodeResponse(System.ReadOnlyMemory`1{System.Byte})`
+
+```csharp
+public static System.Memory<byte> DecodeResponse(System.ReadOnlyMemory<byte> frame)
+```
+Executes the `DecodeResponse` operation.
+
+- Parameter `frame`: The `frame` value.
+- Returns: A `System.Memory<byte>` result.
+
+###### `M:IoT.DriverCore.OmronPlcRx.ToolbusFinsFrameCodec.EncodeRequest(System.ReadOnlyMemory`1{System.Byte})`
+
+```csharp
+public static System.Memory<byte> EncodeRequest(System.ReadOnlyMemory<byte> finsMessage)
+```
+Executes the `EncodeRequest` operation.
+
+- Parameter `finsMessage`: The `finsMessage` value.
+- Returns: A `System.Memory<byte>` result.
+
+###### `P:IoT.DriverCore.OmronPlcRx.ToolbusFinsFrameCodec.SynchronizationFrame`
+
+```csharp
+public System.ReadOnlyMemory<byte> SynchronizationFrame { get; }
+```
+Gets the synchronization frame value.
+
+- Value: The `SynchronizationFrame` value.
+
+<!-- END GENERATED PUBLIC API -->

--- a/packagereadme/S7PlcRx/README.md
+++ b/packagereadme/S7PlcRx/README.md
@@ -1,16 +1,52 @@
-![License](https://img.shields.io/github/license/ChrisPulman/S7PlcRx.svg) [![Build](https://github.com/ChrisPulman/S7PlcRx/actions/workflows/BuildOnly.yml/badge.svg)](https://github.com/ChrisPulman/S7PlcRx/actions/workflows/BuildOnly.yml) ![Nuget](https://img.shields.io/nuget/dt/S7PlcRx?color=pink&style=plastic) [![NuGet](https://img.shields.io/nuget/v/S7PlcRx.svg?style=plastic)](https://www.nuget.org/packages/S7PlcRx)
-
-<p align="left">
-  <a href="https://github.com/ChrisPulman/S7PlcRx">
-    <img alt="S7PlcRx" src="./Images/S7PlcRx.png" width="200"/>
-  </a>
-</p>
-
 # S7PlcRx
 
 Reactive Siemens S7 PLC communication for .NET. S7PlcRx provides tag-based S7 reads/writes, Primitives-based observable streams, optimized batch helpers, caching, diagnostics, production reliability helpers, high-availability helpers, PLC byte conversion utilities, and source-generator assisted property bindings. Version 3 moves the core package to ReactiveUI.Primitives and adds a companion `S7PlcRx.Reactive` package for System.Reactive-compatible applications.
 
 > Siemens and S7 are trademarks of Siemens AG. This project is independent and is not affiliated with or endorsed by Siemens AG. Test all automation code against a simulator or safe test rig before using production equipment.
+
+## Overview
+
+The NuGet package is named `S7PlcRx`, while the migrated runtime namespace is `IoT.DriverCore.S7PlcRx`; the compatibility package uses `IoT.DriverCore.S7PlcRx.Reactive`. This guide is the contract for both packages: the reactive variant has the same PLC, tag, binding, optimisation, production, and logical-tag features, with its namespace segment `.Reactive` and ReactiveUI.Primitives Reactive dependencies.
+
+Every read is asynchronous or observable, and every write is a command sent to a PLC. A tag must be registered before it can be observed, read by name, batched, bound, cached, or written. A nullable read result means that the operation did not yield a value; it is not a safe substitute for inspecting connection and error streams.
+
+## Safety
+
+1. Prove IP, CPU model, rack/slot, PUT/GET permissions, address, data type, byte order, and machine interlocks in a simulator or isolated cell first.
+2. Treat `Value`, generated property setters, batch writes, and watchdog configuration as potentially actuating operations. Validate an acknowledgement/tag read after a command and always subscribe to `LastError` and `LastErrorCode`.
+3. Use a bounded cancellation token for each call path that accepts one. Dispose the `IRxS7` connection, subscriptions, binding sessions, pools, tag groups, and manager objects you create.
+4. Do not enable the watchdog until the PLC program explicitly owns its DB word, validates its value/range, and defines the safe result when communication stops.
+
+## Package matrix and variant choice
+
+| Package | Runtime namespace | Use it when | Generator delivery |
+|---|---|---|---|
+| `S7PlcRx` | `IoT.DriverCore.S7PlcRx` | New Primitives-based code | Install `S7PlcRx.Generators` separately when generated bindings are required. |
+| `S7PlcRx.Reactive` | `IoT.DriverCore.S7PlcRx.Reactive` | Existing System.Reactive-oriented applications | Install the standalone generator separately when generated bindings are required. |
+| `S7PlcRx.Generators` | `IoT.DriverCore.S7PlcRx.SourceGenerators` | Explicit analyzer dependency or generator development | Add as an analyzer, not as a normal runtime service. |
+
+The runtime packages target `net462`, `net472`, `net481`, `net8.0`, `net9.0`, `net10.0`, and `net11.0`. Do not pass core-package objects to the reactive-package API or vice versa.
+
+## Lifecycle and error model
+
+`IRxS7` exposes connection and operation state as `IsConnected`, `IsConnectedValue`, `IsPaused`, `Status`, `LastError`, `LastErrorCode`, and `ReadTime`. Subscribe before starting command traffic. A failed/invalid operation is reported by its return value, the nullable result of an async read, and/or these streams; do not infer success merely because a write was queued.
+
+`IRxS7` inherits `ReactiveUI.Primitives.Disposables.ICancelable`, which in turn is disposable. Therefore factory results must be disposed: `using IRxS7 plc = S71500.Create(...)` is the preferred scope. Dispose subscriptions before the PLC scope ends, pass cancellation tokens to the supported read and logical-tag operations, and scope owned auxiliary objects (`S7TagBindingSession`, `ConnectionPool`, `HighPerformanceTagGroup<T>`, and high-availability managers) with their own documented disposal contracts.
+
+```csharp
+using IoT.DriverCore.Core;
+using IoT.DriverCore.S7PlcRx;
+
+using IRxS7 plc = S71500.Create("192.168.10.20", rack: 0, slot: 1, interval: 100);
+using var errors = plc.LastError.Subscribe(message => Console.Error.WriteLine(message));
+using var codes = plc.LastErrorCode.Subscribe(code => Console.Error.WriteLine($"S7: {code}"));
+using var state = plc.IsConnected.Subscribe(connected => Console.WriteLine($"Connected: {connected}"));
+
+using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+var level = await plc.ReadAsync(new LogicalTagKey<float>("Level"), timeout.Token);
+if (level is null)
+    throw new InvalidOperationException("No level value; inspect LastError/LastErrorCode.");
+```
 
 ## Contents
 
@@ -41,8 +77,8 @@ Reactive Siemens S7 PLC communication for .NET. S7PlcRx provides tag-based S7 re
 V3 is a reactive dependency migration release. The PLC API surface remains tag-oriented, but the package model is now explicit:
 
 - `S7PlcRx` is the lean package for new code. It uses `ReactiveUI.Primitives`, `ReactiveUI.Primitives.Async`, and `ReactiveUI.Primitives.Extensions`; it no longer depends on `System.Reactive` or `ReactiveUI.Extensions`.
-- `S7PlcRx.Reactive` is the System.Reactive-compatible package for existing Rx consumers. It shares the same implementation sources, compiles them with `REACTIVE_SHIM`, and publishes the API under `S7PlcRx.Reactive.*` namespaces.
-- The source generator supports both namespace families. Generated attributes are emitted under `S7PlcRx.SourceGeneration` for the core package and `S7PlcRx.Reactive.SourceGeneration` for the reactive package.
+- `S7PlcRx.Reactive` is the System.Reactive-compatible package for existing Rx consumers. It shares the same implementation sources, compiles them with `REACTIVE_SHIM`, and publishes the API under `IoT.DriverCore.S7PlcRx.Reactive.*` namespaces.
+- The source generator supports both namespace families. Generated attributes are emitted under `IoT.DriverCore.S7PlcRx.SourceGeneration` for the core package and `IoT.DriverCore.S7PlcRx.Reactive.SourceGeneration` for the reactive package.
 - The core package uses Primitives conventions such as `ReactiveUI.Primitives.RxVoid` and `ISequencer`. The reactive package uses the `.Reactive` package variants and intentionally exposes System.Reactive conventions such as `System.Reactive.Unit`.
 - Both runtime packages now target `net462`, `net472`, `net481`, `net8.0`, `net9.0`, `net10.0`, and `net11.0`.
 - Analyzer coverage is stricter in V3. StyleSharp.Analyzers and the existing analyzer set are expected to run cleanly without `NoWarn` suppressions for fixable issues.
@@ -50,7 +86,7 @@ V3 is a reactive dependency migration release. The PLC API surface remains tag-o
 Breaking changes to check during migration:
 
 - Replace `ReactiveUI.Extensions` package references in consuming projects with the relevant `ReactiveUI.Primitives.Extensions` package family.
-- If application code imports `System.Reactive.Linq`, `System.Reactive.Disposables`, `System.Reactive.Subjects`, `System.Reactive.Concurrency`, or depends on `System.Reactive.Unit`, reference `S7PlcRx.Reactive` and update namespaces to `S7PlcRx.Reactive.*`.
+- If application code imports `System.Reactive.Linq`, `System.Reactive.Disposables`, `System.Reactive.Subjects`, `System.Reactive.Concurrency`, or depends on `System.Reactive.Unit`, reference `S7PlcRx.Reactive` and update namespaces to `IoT.DriverCore.S7PlcRx.Reactive.*`.
 - If application code only consumes `IObservable<T>` streams and Primitives extension methods, reference `S7PlcRx` and use `ReactiveUI.Primitives` / `ReactiveUI.Primitives.Extensions` imports.
 - Do not mix `S7PlcRx` and `S7PlcRx.Reactive` objects in the same object graph. They are compiled as separate assemblies with parallel namespaces.
 
@@ -67,7 +103,7 @@ Breaking changes to check during migration:
 
 `S7PlcRx` and `S7PlcRx.Reactive` target `net462`, `net472`, `net481`, `net8.0`, `net9.0`, `net10.0`, and `net11.0`.
 
-`S7PlcRx.SourceGenerators` targets `netstandard2.0` and runs as a Roslyn analyzer/source generator.
+`S7PlcRx.Generators` targets `netstandard2.0` and runs as a Roslyn analyzer/source generator. Install it explicitly only when using generated bindings.
 
 ## PLC prerequisites
 
@@ -89,6 +125,8 @@ Install-Package S7PlcRx
 
 ```bash
 dotnet add package S7PlcRx
+# Add this separately only when using [S7PlcBinding]/[S7Tag] generated bindings.
+dotnet add package S7PlcRx.Generators
 ```
 
 System.Reactive-compatible package:
@@ -104,7 +142,7 @@ dotnet add package S7PlcRx.Reactive
 Repository/analyzer usage for the source generator:
 
 ```xml
-<ProjectReference Include="..\S7PlcRx.SourceGenerators\S7PlcRx.SourceGenerators.csproj"
+<ProjectReference Include="..\S7PlcRx.Generators\S7PlcRx.Generators.csproj"
                   OutputItemType="Analyzer"
                   ReferenceOutputAssembly="false"
                   PrivateAssets="all" />
@@ -114,8 +152,8 @@ Use this package split deliberately:
 
 | Package | Main namespaces | Reactive model | Choose when |
 |---|---|---|---|
-| `S7PlcRx` | `S7PlcRx`, `S7PlcRx.Advanced`, `S7PlcRx.PlcTypes` | Lean ReactiveUI.Primitives over `System.IObservable<T>` | New applications, libraries that should avoid a `System.Reactive` runtime dependency, or code already using Primitives operators. |
-| `S7PlcRx.Reactive` | `S7PlcRx.Reactive`, `S7PlcRx.Reactive.Advanced`, `S7PlcRx.Reactive.PlcTypes` | ReactiveUI.Primitives `.Reactive` packages and System.Reactive conventions | Existing Rx applications that need System.Reactive `Unit`, scheduler conventions, or minimal migration churn. |
+| `S7PlcRx` | `IoT.DriverCore.S7PlcRx`, `IoT.DriverCore.S7PlcRx.Advanced`, `IoT.DriverCore.S7PlcRx.PlcTypes` | Lean ReactiveUI.Primitives over `System.IObservable<T>` | New applications, libraries that should avoid a `System.Reactive` runtime dependency, or code already using Primitives operators. |
+| `S7PlcRx.Reactive` | `IoT.DriverCore.S7PlcRx.Reactive`, `IoT.DriverCore.S7PlcRx.Reactive.Advanced`, `IoT.DriverCore.S7PlcRx.Reactive.PlcTypes` | ReactiveUI.Primitives `.Reactive` packages and System.Reactive conventions | Existing Rx applications that need System.Reactive `Unit`, scheduler conventions, or minimal migration churn. |
 
 If an application also uses R3, reference `R3` plus the relevant Primitives package. Do not add `ReactiveUI.Primitives.R3Bridge.Generator` directly; the bridge generator is packed by `ReactiveUI.Primitives` and `ReactiveUI.Primitives.Async`.
 
@@ -133,15 +171,17 @@ Use the core package when the application can standardize on ReactiveUI.Primitiv
 
 ```csharp
 using ReactiveUI.Primitives;
+using IoT.DriverCore.Core;
 using ReactiveUI.Primitives.Extensions;
-using S7PlcRx;
-using S7PlcRx.Enums;
+using IoT.DriverCore.Core;
+using IoT.DriverCore.S7PlcRx;
+using IoT.DriverCore.S7PlcRx.Enums;
 
-using var plc = S71500.Create("192.168.1.100", rack: 0, slot: 1, interval: 100);
+using IRxS7 plc = S71500.Create("192.168.1.100", rack: 0, slot: 1, interval: 100);
 
-plc.AddUpdateTagItem<float>("Temperature", "DB1.DBD0");
+TagOperations.AddUpdateTagItem(plc, typeof(float), "Temperature", "DB1.DBD0");
 
-using var subscription = plc.Observe<float>("Temperature")
+using var subscription = plc.Observe(new LogicalTagKey<float>("Temperature"))
     .Where(value => value.HasValue)
     .Subscribe(value => Console.WriteLine(value));
 ```
@@ -151,14 +191,15 @@ Use the reactive package when the consuming application is still System.Reactive
 ```csharp
 using ReactiveUI.Primitives.Extensions.Reactive;
 using ReactiveUI.Primitives.Reactive;
-using S7PlcRx.Reactive;
-using S7PlcRx.Reactive.Enums;
+using IoT.DriverCore.Core;
+using IoT.DriverCore.S7PlcRx.Reactive;
+using IoT.DriverCore.S7PlcRx.Reactive.Enums;
 
-using var plc = S71500.Create("192.168.1.100", rack: 0, slot: 1, interval: 100);
+using IRxS7 plc = S71500.Create("192.168.1.100", rack: 0, slot: 1, interval: 100);
 
-plc.AddUpdateTagItem<float>("Temperature", "DB1.DBD0");
+TagOperations.AddUpdateTagItem(plc, typeof(float), "Temperature", "DB1.DBD0");
 
-using var subscription = plc.Observe<float>("Temperature")
+using var subscription = plc.Observe(new LogicalTagKey<float>("Temperature"))
     .Where(value => value.HasValue)
     .Subscribe(value => Console.WriteLine(value));
 ```
@@ -168,8 +209,8 @@ The two packages expose the same PLC concepts and helper methods. The difference
 | Concern | `S7PlcRx` | `S7PlcRx.Reactive` |
 |---|---|---|
 | Assembly/package | `S7PlcRx` | `S7PlcRx.Reactive` |
-| Root namespace | `S7PlcRx` | `S7PlcRx.Reactive` |
-| Extension namespaces | `S7PlcRx.Advanced`, `S7PlcRx.Optimization`, `S7PlcRx.Production` | `S7PlcRx.Reactive.Advanced`, `S7PlcRx.Reactive.Optimization`, `S7PlcRx.Reactive.Production` |
+| Root namespace | `IoT.DriverCore.S7PlcRx` | `IoT.DriverCore.S7PlcRx.Reactive` |
+| Extension namespaces | `IoT.DriverCore.S7PlcRx.Advanced`, `IoT.DriverCore.S7PlcRx.Optimization`, `IoT.DriverCore.S7PlcRx.Production` | `IoT.DriverCore.S7PlcRx.Reactive.Advanced`, `IoT.DriverCore.S7PlcRx.Reactive.Optimization`, `IoT.DriverCore.S7PlcRx.Reactive.Production` |
 | Reactive packages | `ReactiveUI.Primitives`, `.Async`, `.Extensions` | `ReactiveUI.Primitives.Reactive`, `.Async.Reactive`, `.Extensions.Reactive` |
 | Unit convention | `ReactiveUI.Primitives.RxVoid` | `System.Reactive.Unit` |
 | Scheduler/sequencer convention | `ReactiveUI.Primitives.Concurrency.ISequencer` | System.Reactive scheduler-compatible `.Reactive` conventions |
@@ -185,15 +226,16 @@ Core `S7PlcRx` stream to R3:
 using R3;
 using ReactiveUI.Primitives;
 using ReactiveUI.Primitives.R3Bridge;
-using S7PlcRx;
-using S7PlcRx.Enums;
+using IoT.DriverCore.Core;
+using IoT.DriverCore.S7PlcRx;
+using IoT.DriverCore.S7PlcRx.Enums;
 
 var options = new RxS7Options(new S7ConnectionOptions(CpuType.S71500, "192.168.1.100", rack: 0, slot: 1));
 using var plc = new RxS7(options);
 
-plc.AddUpdateTagItem<float>("Temperature", "DB1.DBD0");
+TagOperations.AddUpdateTagItem(plc, typeof(float), "Temperature", "DB1.DBD0");
 
-System.IObservable<float?> primitivesTemperature = plc.Observe<float>("Temperature");
+System.IObservable<float?> primitivesTemperature = plc.Observe(new LogicalTagKey<float>("Temperature"));
 Observable<float?> r3Temperature = primitivesTemperature.AsR3Observable();
 
 using var subscription = r3Temperature.Subscribe(value =>
@@ -220,9 +262,9 @@ Async observable bridge:
 using R3;
 using ReactiveUI.Primitives.Async;
 using ReactiveUI.Primitives.R3Bridge;
-using S7PlcRx.Advanced;
+using IoT.DriverCore.S7PlcRx.Advanced;
 
-IObservableAsync<float?> asyncTemperature = plc.ObserveValue<float>("Temperature");
+IObservableAsync<float?> asyncTemperature = AsyncExtensions.ObserveValue(plc, default(float), "Temperature");
 Observable<float?> r3Temperature = asyncTemperature.AsR3Observable();
 IObservableAsync<float?> backToAsync = r3Temperature.AsPrimitivesAsyncObservable();
 ```
@@ -233,9 +275,9 @@ R3Async bridge:
 using R3Async;
 using ReactiveUI.Primitives.Async;
 using ReactiveUI.Primitives.R3Bridge;
-using S7PlcRx.Advanced;
+using IoT.DriverCore.S7PlcRx.Advanced;
 
-IObservableAsync<float?> asyncTemperature = plc.ObserveValue<float>("Temperature");
+IObservableAsync<float?> asyncTemperature = AsyncExtensions.ObserveValue(plc, default(float), "Temperature");
 AsyncObservable<float?> r3AsyncTemperature = asyncTemperature.AsR3AsyncObservable();
 IObservableAsync<float?> backToPrimitives = r3AsyncTemperature.AsPrimitivesAsyncObservable();
 ```
@@ -252,21 +294,22 @@ Generated bridge methods:
 
 ```csharp
 using ReactiveUI.Primitives;
-using S7PlcRx;
-using S7PlcRx.Enums;
+using IoT.DriverCore.Core;
+using IoT.DriverCore.S7PlcRx;
+using IoT.DriverCore.S7PlcRx.Enums;
 
 var options = new RxS7Options(new S7ConnectionOptions(CpuType.S71500, "192.168.1.100", rack: 0, slot: 1));
 using var plc = new RxS7(options);
 
-plc.AddUpdateTagItem<float>("Temperature", "DB1.DBD0");
-plc.AddUpdateTagItem<bool>("Running", "DB1.DBX4.0");
-plc.AddUpdateTagItem<float>("TemperatureSetPoint", "DB1.DBD8");
+TagOperations.AddUpdateTagItem(plc, typeof(float), "Temperature", "DB1.DBD0");
+TagOperations.AddUpdateTagItem(plc, typeof(bool), "Running", "DB1.DBX4.0");
+TagOperations.AddUpdateTagItem(plc, typeof(float), "TemperatureSetPoint", "DB1.DBD8");
 
 using var connected = plc.IsConnected
     .DistinctUntilChanged()
     .Subscribe(x => Console.WriteLine($"Connected: {x}"));
 
-using var temperature = plc.Observe<float>("Temperature")
+using var temperature = plc.Observe(new LogicalTagKey<float>("Temperature"))
     .Where(x => x.HasValue)
     .Subscribe(x => Console.WriteLine($"Temperature: {x:F1} deg C"));
 
@@ -312,36 +355,36 @@ using IRxS7 plc = S71500.Create("192.168.1.100", rack: 0, slot: 1, interval: 100
 Register tags:
 
 ```csharp
-plc.AddUpdateTagItem<float>("Temperature", "DB1.DBD0");
-plc.AddUpdateTagItem<bool>("Running", "DB1.DBX4.0");
-plc.AddUpdateTagItem<byte[]>("RecipeBytes", "DB10.DBB0", arrayLength: 64);
-plc.AddUpdateTagItem<float[]>("Curve", "DB20.DBD0", arrayLength: 16);
+TagOperations.AddUpdateTagItem(plc, typeof(float), "Temperature", "DB1.DBD0");
+TagOperations.AddUpdateTagItem(plc, typeof(bool), "Running", "DB1.DBX4.0");
+TagOperations.AddUpdateTagItem(plc, typeof(byte[]), "RecipeBytes", "DB10.DBB0", 64);
+TagOperations.AddUpdateTagItem(plc, typeof(float[]), "Curve", "DB20.DBD0", 16);
 ```
 
 Fluent registration and polling control:
 
 ```csharp
-plc.AddUpdateTagItem<float>("Temp1", "DB1.DBD0")
-   .AddUpdateTagItem<float>("Temp2", "DB1.DBD4")
-   .AddUpdateTagItem<bool>("Alarm", "DB1.DBX8.0")
-   .SetTagPollIng(false); // disables polling on the last tag
+TagOperations.AddUpdateTagItem(plc, typeof(float), "Temp1", "DB1.DBD0");
+TagOperations.AddUpdateTagItem(plc, typeof(float), "Temp2", "DB1.DBD4");
+TagOperations.AddUpdateTagItem(plc, typeof(bool), "Alarm", "DB1.DBX8.0")
+    .SetPolling(false); // disables polling for Alarm
 
-plc.GetTag("Temp1").SetTagPollIng(false);
-plc.GetTag("Temp1").SetTagPollIng(true);
-plc.RemoveTagItem("Temp1");
+TagOperations.GetTag(plc, "Temp1").SetPolling(false);
+TagOperations.GetTag(plc, "Temp1").SetPolling(true);
+TagOperations.RemoveTagItem(plc, "Temp1");
 ```
 
 Tag stream projections:
 
 ```csharp
-using S7PlcRx;
+using IoT.DriverCore.S7PlcRx;
 
-using var dictionary = plc.ObserveAll
-    .TagToDictionary<object>()
+using var dictionary = TagOperations.TagToDictionary(plc.ObserveAll)
     .Subscribe(values => Console.WriteLine(values.Count));
 
-using var namedValue = plc.Observe<float>("Temperature")
-    .ToTagValue("Temperature")
+using var namedValue = TagOperations.ToTagValue(
+        plc.Observe(new IoT.DriverCore.Core.LogicalTagKey<float>("Temperature")),
+        "Temperature")
     .Subscribe(item => Console.WriteLine($"{item.Tag}={item.Value}"));
 ```
 
@@ -349,16 +392,17 @@ using var namedValue = plc.Observe<float>("Temperature")
 
 ```csharp
 using ReactiveUI.Primitives;
+using IoT.DriverCore.Core;
 
-using var highTemp = plc.Observe<float>("Temperature")
+using var highTemp = plc.Observe(new LogicalTagKey<float>("Temperature"))
     .Where(x => x > 80.0f)
     .Subscribe(x => Console.WriteLine($"High temperature: {x:F1}"));
 
-using var sampledPressure = plc.Observe<float>("Pressure")
+using var sampledPressure = plc.Observe(new LogicalTagKey<float>("Pressure"))
     .Sample(TimeSpan.FromSeconds(5))
     .Subscribe(x => Console.WriteLine($"Pressure: {x:F2}"));
 
-using var averageFlow = plc.Observe<float>("FlowRate")
+using var averageFlow = plc.Observe(new LogicalTagKey<float>("FlowRate"))
     .Buffer(TimeSpan.FromMinutes(1))
     .Where(values => values.Count > 0)
     .Select(values => values.Average())
@@ -388,10 +432,12 @@ Console.WriteLine($"AS name: {cpuInfo[0]}, Module: {cpuInfo[1]}");
 ## Manual reads and writes
 
 ```csharp
-var temperature = await plc.Value<float>("Temperature");
+using IoT.DriverCore.Core;
+
+var temperature = await plc.ReadAsync(new LogicalTagKey<float>("Temperature"));
 
 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-var pressure = await plc.ValueAsync<float>("Pressure", cts.Token);
+var pressure = await plc.ReadAsync(new LogicalTagKey<float>("Pressure"), cts.Token);
 
 plc.Value("SetPoint", 72.5f);
 plc.Value("Enabled", true);
@@ -416,17 +462,17 @@ plcWithWatchdog.ShowWatchDogWriting = true;
 Advanced batch helpers:
 
 ```csharp
-using S7PlcRx.Advanced;
+using IoT.DriverCore.S7PlcRx.Advanced;
 
-var values = await plc.ValueBatch<float>("Temp1", "Temp2", "Temp3");
+var values = await AdvancedExtensions.ValueBatchAsync(plc, default(float), "Temp1", "Temp2", "Temp3");
 
-await plc.ValueBatch(new Dictionary<string, float>
+await AdvancedExtensions.ValueBatchAsync(plc, new Dictionary<string, float>
 {
     ["SetPoint1"] = 70.0f,
     ["SetPoint2"] = 75.0f,
 });
 
-using var batchSub = plc.ObserveBatch<float>("Temp1", "Temp2")
+using var batchSub = AdvancedExtensions.ObserveBatch(plc, default(float), "Temp1", "Temp2")
     .Subscribe(snapshot => Console.WriteLine(snapshot.Count));
 ```
 
@@ -439,8 +485,8 @@ var tagMap = new Dictionary<string, string>
     ["Pressure"] = "DB1.DBD4",
 };
 
-var read = await plc.ReadBatchOptimized<float>(tagMap, timeoutMs: 5000);
-var write = await plc.WriteBatchOptimized(
+var read = await AdvancedExtensions.ReadBatchOptimizedAsync(plc, default(float), tagMap, timeoutMs: 5000);
+var write = await AdvancedExtensions.WriteBatchOptimizedAsync(plc,
     new Dictionary<string, float> { ["Temperature"] = 22.5f },
     verifyWrites: false,
     enableRollback: false);
@@ -449,16 +495,18 @@ var write = await plc.WriteBatchOptimized(
 Async-first `ValueTask` helpers:
 
 ```csharp
-using S7PlcRx.Advanced;
+using IoT.DriverCore.S7PlcRx.Advanced;
 
-var current = await plc.ReadValueAsync<float>("Temperature");
-var many = await plc.ReadValuesAsync<float>("Temp1", "Temp2");
+using var readCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+var current = await AsyncExtensions.ReadValueAsync(plc, default(float), "Temperature", readCancellation.Token);
+var many = await AsyncExtensions.ReadValuesAsync(
+    plc, default(float), new[] { "Temp1", "Temp2" }, readCancellation.Token);
 
-await plc.WriteValuesAsync(new Dictionary<string, float>
+await AsyncExtensions.WriteValuesAsync(plc, new Dictionary<string, float>
 {
     ["SetPoint1"] = 72.5f,
     ["SetPoint2"] = 73.0f,
-});
+}, readCancellation.Token);
 ```
 
 .NET 8+ async observable helpers:
@@ -466,7 +514,7 @@ await plc.WriteValuesAsync(new Dictionary<string, float>
 ```csharp
 using ReactiveUI.Primitives.Async;
 using ReactiveUI.Primitives.Async.Advanced;
-using S7PlcRx.Advanced;
+using IoT.DriverCore.S7PlcRx.Advanced;
 
 var observer = new CallbackWitnessAsync<float>(
     async (value, cancellationToken) =>
@@ -477,7 +525,7 @@ var observer = new CallbackWitnessAsync<float>(
     static (error, cancellationToken) => ValueTask.FromException(error),
     static result => ValueTask.CompletedTask);
 
-await using var sub = await plc.ObserveValue<float>("Temperature")
+await using var sub = await AsyncExtensions.ObserveValue(plc, default(float), "Temperature")
     .SubscribeAsync(
         observer,
         CancellationToken.None);
@@ -485,14 +533,14 @@ await using var sub = await plc.ObserveValue<float>("Temperature")
 
 ## Source generator property binding
 
-`S7PlcRx.SourceGenerators` generates PLC-bound properties from attributes. It removes repetitive tag registration, polling assignment, and setter write hooks.
+`S7PlcRx.Generators` generates PLC-bound properties from attributes. It removes repetitive tag registration, polling assignment, and setter write hooks.
 
 ### Generated compile-time attributes
 
 The generator injects this namespace into the consuming compilation:
 
 ```csharp
-namespace S7PlcRx.SourceGeneration;
+namespace IoT.DriverCore.S7PlcRx.SourceGeneration;
 
 [AttributeUsage(AttributeTargets.Class)]
 public sealed class S7PlcBindingAttribute : Attribute;
@@ -518,8 +566,8 @@ public enum S7TagDirection
 ### Generated binding example
 
 ```csharp
-using S7PlcRx;
-using S7PlcRx.SourceGeneration;
+using IoT.DriverCore.S7PlcRx;
+using IoT.DriverCore.S7PlcRx.SourceGeneration;
 
 [S7PlcBinding]
 public partial class MachineTags
@@ -537,7 +585,7 @@ public partial class MachineTags
     public partial float SetPoint { get; set; }
 }
 
-using var plc = S71500.Create("192.168.1.100");
+using IRxS7 plc = S71500.Create("192.168.1.100");
 var tags = new MachineTags();
 using var binding = tags.Bind(plc);
 
@@ -547,8 +595,8 @@ tags.SetPoint = 72.5f; // queues a PLC write
 Reactive package source-generator usage is the same shape with reactive namespaces:
 
 ```csharp
-using S7PlcRx.Reactive;
-using S7PlcRx.Reactive.SourceGeneration;
+using IoT.DriverCore.S7PlcRx.Reactive;
+using IoT.DriverCore.S7PlcRx.Reactive.SourceGeneration;
 
 [S7PlcBinding]
 public partial class ReactiveMachineTags
@@ -557,7 +605,7 @@ public partial class ReactiveMachineTags
     public partial float Temperature { get; set; }
 }
 
-using var plc = S71500.Create("192.168.1.100", rack: 0, slot: 1, interval: 100);
+using IRxS7 plc = S71500.Create("192.168.1.100", rack: 0, slot: 1, interval: 100);
 var tags = new ReactiveMachineTags();
 using var binding = tags.Bind(plc);
 ```
@@ -587,7 +635,7 @@ DB1.DBX8.0 Running      bool   byte 8 bit 0
 Runtime range tag:
 
 ```csharp
-plc.AddUpdateTagItem<byte[]>("__s7_binding_db1_0_9", "DB1.DBB0", arrayLength: 9);
+TagOperations.AddUpdateTagItem(plc, typeof(byte[]), "__s7_binding_db1_0_9", "DB1.DBB0", 9);
 ```
 
 Writes are coalesced on a short flush timer. The runtime performs read-modify-write byte-array writes so unrelated bytes/bits in the same range are preserved.
@@ -595,7 +643,7 @@ Writes are coalesced on a short flush timer. The runtime performs read-modify-wr
 ### Manual runtime binding API
 
 ```csharp
-using S7PlcRx.Binding;
+using IoT.DriverCore.S7PlcRx.Binding;
 
 var definitions = new[]
 {
@@ -614,47 +662,50 @@ runtime.Write("Temperature", 25.5f);
 ## Performance and cache features
 
 ```csharp
-using S7PlcRx.Optimization;
-using S7PlcRx.Performance;
+using IoT.DriverCore.S7PlcRx.Optimization;
+using IoT.DriverCore.S7PlcRx.Performance;
 
-var cached = await plc.ValueCached<float>("Temperature", TimeSpan.FromSeconds(1));
-var cacheStats = plc.GetCacheStatistics();
-plc.ClearCache("Temperature");
+var cached = await OptimizationExtensions.ValueCachedAsync(
+    plc, "Temperature", fallbackValue: default(float), cacheTimeout: TimeSpan.FromSeconds(1));
+var cacheStats = OptimizationExtensions.GetCacheStatistics(plc);
+OptimizationExtensions.ClearCache(plc, "Temperature");
 
-using var smart = plc.MonitorTagSmart<float>("Temperature", changeThreshold: 0.5, debounceMs: 100)
+using var smart = OptimizationExtensions.MonitorTagSmart(
+        plc, "Temperature", EqualityComparer<float>.Default, changeThreshold: 0.5, debounceMs: 100)
     .Subscribe(change => Console.WriteLine($"{change.TagName}: {change.PreviousValue} -> {change.CurrentValue}"));
 
-using var perf = plc.MonitorPerformance(TimeSpan.FromSeconds(30))
+using var perf = PerformanceExtensions.MonitorPerformance(plc, TimeSpan.FromSeconds(30))
     .Subscribe(metrics => Console.WriteLine($"{metrics.OperationsPerSecond:F1} ops/sec"));
 
-var optimizedReads = await plc.ReadOptimized<float>(new[] { "Temp1", "Temp2" });
-var optimizedWrite = await plc.WriteOptimized(new Dictionary<string, float>
+var optimizedReads = await PerformanceExtensions.ReadOptimizedAsync(
+    plc, new[] { "Temp1", "Temp2" }, typeMarker: default(float), optimizationConfig: null);
+var optimizedWrite = await PerformanceExtensions.WriteOptimizedAsync(plc, new Dictionary<string, float>
 {
     ["SetPoint1"] = 72.5f,
     ["SetPoint2"] = 73.0f,
-});
+}, optimizationConfig: null);
 
-var benchmark = await plc.RunBenchmark(new BenchmarkConfig
+var benchmark = await PerformanceExtensions.RunBenchmarkAsync(plc, new BenchmarkConfig
 {
     LatencyTestCount = 10,
     ThroughputTestDuration = TimeSpan.FromSeconds(10),
     ReliabilityTestCount = 20,
 });
 
-var stats = plc.GetPerformanceStatistics();
+var stats = PerformanceExtensions.GetPerformanceStatistics(plc);
 ```
 
 High-performance tag groups:
 
 ```csharp
-using S7PlcRx.Advanced;
-using S7PlcRx.Performance;
+using IoT.DriverCore.S7PlcRx.Advanced;
+using IoT.DriverCore.S7PlcRx.Performance;
 
-using var group = plc.CreateTagGroup<float>("Process", "Temperature", "Pressure", "Flow");
+using var group = AdvancedExtensions.CreateTagGroup(plc, default(float), "Process", "Temperature", "Pressure", "Flow");
 using var groupSub = group.ObserveGroup().Subscribe(snapshot => Console.WriteLine(snapshot.Count));
 
-var allValues = await group.ReadAll();
-await group.WriteAll(new Dictionary<string, float>
+var allValues = await group.ReadAllAsync();
+await group.WriteAllAsync(new Dictionary<string, float>
 {
     ["Temperature"] = 21.0f,
     ["Pressure"] = 1.2f,
@@ -666,7 +717,7 @@ await group.WriteAll(new Dictionary<string, float>
 Symbol tables:
 
 ```csharp
-using S7PlcRx.Enterprise;
+using IoT.DriverCore.S7PlcRx.Enterprise;
 
 var csv = """
 Name,Address,DataType,Length,Description
@@ -675,17 +726,17 @@ Running,DB1.DBX4.0,BOOL,1,Machine running
 Recipe,DB10.DBB0,ARRAY,64,Recipe bytes
 """;
 
-var table = await plc.LoadSymbolTable(csv, SymbolTableFormat.Csv);
-var temperature = await plc.ReadSymbol<float>("Temperature");
-plc.WriteSymbol("Running", true);
+var table = await EnterpriseExtensions.LoadSymbolTableAsync(plc, csv, SymbolTableFormat.Csv);
+var temperature = await EnterpriseExtensions.ReadSymbolAsync(plc, "Temperature");
+EnterpriseExtensions.WriteSymbol(plc, "Running", true);
 ```
 
 High availability:
 
 ```csharp
-using S7PlcRx.Enterprise;
+using IoT.DriverCore.S7PlcRx.Enterprise;
 
-using var primary = S71500.Create("192.168.1.100");
+using IRxS7 primary = S71500.Create("192.168.1.100");
 var backups = new List<IRxS7>
 {
     S71500.Create("192.168.1.101"),
@@ -695,15 +746,15 @@ var backups = new List<IRxS7>
 using var ha = EnterpriseExtensions.CreateHighAvailabilityConnection(primary, backups, TimeSpan.FromSeconds(10));
 using var failoverSub = ha.FailoverEvents.Subscribe(evt => Console.WriteLine(evt.Reason));
 IRxS7 active = ha.ActivePLC;
-await ha.TriggerFailover();
+await ha.TriggerFailoverAsync();
 ```
 
 Connection pool:
 
 ```csharp
-using S7PlcRx.Core;
-using S7PlcRx.Enterprise;
-using S7PlcRx.Enums;
+using IoT.DriverCore.S7PlcRx.Core;
+using IoT.DriverCore.S7PlcRx.Enterprise;
+using IoT.DriverCore.S7PlcRx.Enums;
 
 using var pool = EnterpriseExtensions.CreateConnectionPool(
     new[]
@@ -724,22 +775,23 @@ using var pool = EnterpriseExtensions.CreateConnectionPool(
         HealthCheckInterval = TimeSpan.FromMinutes(1),
     });
 
-IRxS7 connection = pool.GetConnection;
+IRxS7 connection = pool.Connection;
 ```
 
 ## Production reliability and diagnostics
 
 ```csharp
-using S7PlcRx.Advanced;
-using S7PlcRx.Production;
+using IoT.DriverCore.Core;
+using IoT.DriverCore.S7PlcRx.Advanced;
+using IoT.DriverCore.S7PlcRx.Production;
 
-var diagnostics = await plc.GetDiagnostics();
+var diagnostics = await AdvancedExtensions.GetDiagnosticsAsync(plc);
 Console.WriteLine($"Connected: {diagnostics.IsConnected}, latency: {diagnostics.ConnectionLatencyMs:F0} ms");
 
-var analysis = await plc.AnalyzePerformance(TimeSpan.FromMinutes(5));
+var analysis = await AdvancedExtensions.AnalyzePerformanceAsync(plc, TimeSpan.FromMinutes(5));
 Console.WriteLine($"Total changes: {analysis.TotalTagChanges}" );
 
-var validation = await plc.ValidateProductionReadiness(new ProductionValidationConfig
+var validation = await ProductionExtensions.ValidateProductionReadinessAsync(plc, new ProductionValidationConfig
 {
     MaxAcceptableResponseTime = TimeSpan.FromMilliseconds(500),
     MinimumReliabilityRate = 0.95,
@@ -747,8 +799,9 @@ var validation = await plc.ValidateProductionReadiness(new ProductionValidationC
     MinimumProductionScore = 80.0,
 });
 
-var result = await plc.ExecuteWithErrorHandling(
-    () => plc.Value<float>("CriticalSensor"),
+var result = await ProductionExtensions.ExecuteWithErrorHandlingAsync(
+    plc,
+    () => plc.ReadAsync(new LogicalTagKey<float>("CriticalSensor")),
     new ProductionErrorConfig
     {
         MaxRetryAttempts = 3,
@@ -758,8 +811,8 @@ var result = await plc.ExecuteWithErrorHandling(
         CircuitBreakerTimeout = TimeSpan.FromMinutes(1),
     });
 
-var handler = plc.EnableProductionErrorHandling(new ProductionErrorConfig());
-var guarded = await handler.ExecuteAsync(() => plc.Value<float>("Temperature"));
+var handler = ProductionExtensions.EnableProductionErrorHandling(plc, new ProductionErrorConfig());
+var guarded = await handler.ExecuteAsync(() => plc.ReadAsync(new LogicalTagKey<float>("Temperature")));
 ```
 
 ## PLC type conversion helpers
@@ -782,7 +835,7 @@ All conversion helpers use Siemens S7 byte ordering and are useful for codecs, t
 | `Struct`, `Class` | Reflection-based complex type conversion | `GetStructSize`/`GetClassSize`, `FromBytes`, `ToBytes` |
 
 ```csharp
-using S7PlcRx.PlcTypes;
+using IoT.DriverCore.S7PlcRx.PlcTypes;
 
 Span<byte> bytes = stackalloc byte[4];
 Real.ToSpan(12.5f, bytes);
@@ -807,50 +860,44 @@ The examples above cover the public API groups used by most applications. Use th
 
 | API group | Main namespaces | Example section |
 |---|---|---|
-| PLC factories, `IRxS7`, `RxS7`, tags, lifecycle | `S7PlcRx` | [Quick start](#quick-start), [Core tag API](#core-tag-api), lifecycle example below |
-| Reactive streams and diagnostics | `S7PlcRx`, `ReactiveUI.Primitives` | [Reactive reading](#reactive-reading), [R3 ReactiveUI.Primitives bridge](#r3-reactiveuiprimitives-bridge) |
-| Manual reads, writes, cancellation | `S7PlcRx` | [Manual reads and writes](#manual-reads-and-writes), lifecycle example below |
-| Batch and async observables | `S7PlcRx.Advanced`, `ReactiveUI.Primitives.Async` | [Batch, async, and optimized APIs](#batch-async-and-optimized-apis) |
-| Source generator and runtime binding | `S7PlcRx.SourceGeneration`, `S7PlcRx.Binding` | [Source generator property binding](#source-generator-property-binding) |
-| Optimization and cache | `S7PlcRx.Optimization`, `S7PlcRx.Cache`, `S7PlcRx.Performance` | [Performance and cache features](#performance-and-cache-features), optimization config example below |
-| Enterprise, symbols, failover, pooling | `S7PlcRx.Enterprise`, `S7PlcRx.Core` | [Enterprise features](#enterprise-features), connection pool example below |
-| Production reliability | `S7PlcRx.Production` | [Production reliability and diagnostics](#production-reliability-and-diagnostics) |
-| PLC type conversion | `S7PlcRx.PlcTypes` | [PLC type conversion helpers](#plc-type-conversion-helpers) |
-| Reactive shim package | `S7PlcRx.Reactive.*` | [Choosing S7PlcRx or S7PlcRx.Reactive](#choosing-s7plcrx-or-s7plcrxreactive) |
+| PLC factories, `IRxS7`, `RxS7`, tags, lifecycle | `IoT.DriverCore.S7PlcRx` | [Quick start](#quick-start), [Core tag API](#core-tag-api), lifecycle example below |
+| Reactive streams and diagnostics | `IoT.DriverCore.S7PlcRx`, `ReactiveUI.Primitives` | [Reactive reading](#reactive-reading), [R3 ReactiveUI.Primitives bridge](#r3-reactiveuiprimitives-bridge) |
+| Manual reads, writes, cancellation | `IoT.DriverCore.S7PlcRx` | [Manual reads and writes](#manual-reads-and-writes), lifecycle example below |
+| Batch and async observables | `IoT.DriverCore.S7PlcRx.Advanced`, `ReactiveUI.Primitives.Async` | [Batch, async, and optimized APIs](#batch-async-and-optimized-apis) |
+| Source generator and runtime binding | `IoT.DriverCore.S7PlcRx.SourceGeneration`, `IoT.DriverCore.S7PlcRx.Binding` | [Source generator property binding](#source-generator-property-binding) |
+| Optimization and cache | `IoT.DriverCore.S7PlcRx.Optimization`, `IoT.DriverCore.S7PlcRx.Cache`, `IoT.DriverCore.S7PlcRx.Performance` | [Performance and cache features](#performance-and-cache-features), optimization config example below |
+| Enterprise, symbols, failover, pooling | `IoT.DriverCore.S7PlcRx.Enterprise`, `IoT.DriverCore.S7PlcRx.Core` | [Enterprise features](#enterprise-features), connection pool example below |
+| Production reliability | `IoT.DriverCore.S7PlcRx.Production` | [Production reliability and diagnostics](#production-reliability-and-diagnostics) |
+| PLC type conversion | `IoT.DriverCore.S7PlcRx.PlcTypes` | [PLC type conversion helpers](#plc-type-conversion-helpers) |
+| Reactive shim package | `IoT.DriverCore.S7PlcRx.Reactive.*` | [Choosing S7PlcRx or S7PlcRx.Reactive](#choosing-s7plcrx-or-s7plcrxreactive) |
 
 Lifecycle and cancellation:
 
 ```csharp
 using ReactiveUI.Primitives;
-using S7PlcRx;
+using IoT.DriverCore.Core;
+using IoT.DriverCore.S7PlcRx;
 
-IRxS7 plc = S71500.Create("192.168.1.100", rack: 0, slot: 1, interval: 100);
+using IRxS7 plc = S71500.Create("192.168.1.100", rack: 0, slot: 1, interval: 100);
 
-try
-{
-    using var status = plc.Status.Subscribe(Console.WriteLine);
-    using var errors = plc.LastError.Subscribe(error => Console.WriteLine($"PLC error: {error}"));
+using var status = plc.Status.Subscribe(Console.WriteLine);
+using var errors = plc.LastError.Subscribe(error => Console.WriteLine($"PLC error: {error}"));
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
 
-    using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-    float? temperature = await plc.ValueAsync<float>("Temperature", cts.Token);
+float? temperature = await plc.ReadAsync(new LogicalTagKey<float>("Temperature"), cts.Token);
+Console.WriteLine($"Temperature: {temperature}");
 
-    Console.WriteLine($"Temperature: {temperature}");
-    Console.WriteLine($"Disposed before cleanup: {plc.IsDisposed}");
-}
-finally
-{
-    plc.Dispose();
-    Console.WriteLine($"Disposed after cleanup: {plc.IsDisposed}");
-}
+// Dispose every subscription and cancellation source that the application owns.
+// `using IRxS7` disposes the factory result through ICancelable/IDisposable.
 ```
 
 Direct connection pool:
 
 ```csharp
-using S7PlcRx;
-using S7PlcRx.Core;
-using S7PlcRx.Enterprise;
-using S7PlcRx.Enums;
+using IoT.DriverCore.S7PlcRx;
+using IoT.DriverCore.S7PlcRx.Core;
+using IoT.DriverCore.S7PlcRx.Enterprise;
+using IoT.DriverCore.S7PlcRx.Enums;
 
 using var pool = new ConnectionPool(
     new[]
@@ -887,8 +934,8 @@ Console.WriteLine($"Pool active: {pool.ActiveConnections}/{pool.MaxConnections}"
 Optimized read/write configuration:
 
 ```csharp
-using S7PlcRx.Optimization;
-using S7PlcRx.Performance;
+using IoT.DriverCore.S7PlcRx.Optimization;
+using IoT.DriverCore.S7PlcRx.Performance;
 
 var readConfig = new ReadOptimizationConfig
 {
@@ -898,9 +945,11 @@ var readConfig = new ReadOptimizationConfig
     InterGroupDelayMs = 10,
 };
 
-var values = await plc.ReadOptimized<float>(
+var values = await PerformanceExtensions.ReadOptimizedAsync(
+    plc,
     new[] { "Temperature", "Pressure", "Flow" },
-    readConfig);
+    typeMarker: default(float),
+    optimizationConfig: readConfig);
 
 var writeConfig = new WriteOptimizationConfig
 {
@@ -911,7 +960,8 @@ var writeConfig = new WriteOptimizationConfig
     InterGroupDelayMs = 25,
 };
 
-var writeResult = await plc.WriteOptimized(
+var writeResult = await PerformanceExtensions.WriteOptimizedAsync(
+    plc,
     new Dictionary<string, float>
     {
         ["SetPoint1"] = 72.5f,
@@ -925,10 +975,10 @@ Console.WriteLine($"Wrote {writeResult.SuccessfulWrites.Count} tags in {writeRes
 Diagnostics through public APIs:
 
 ```csharp
-using S7PlcRx.Advanced;
-using S7PlcRx.Production;
+using IoT.DriverCore.S7PlcRx.Advanced;
+using IoT.DriverCore.S7PlcRx.Production;
 
-var diagnostics = await plc.GetDiagnostics();
+var diagnostics = await AdvancedExtensions.GetDiagnosticsAsync(plc);
 
 Console.WriteLine($"Connected: {diagnostics.IsConnected}");
 Console.WriteLine($"Latency: {diagnostics.ConnectionLatencyMs:F1} ms");
@@ -943,33 +993,33 @@ Low-level socket transport is internal implementation detail. Use `IRxS7` connec
 
 ## Public API reference
 
-This section is generated from the public C# surface in `src/S7PlcRx` and `src/S7PlcRx.SourceGenerators`, then paired with the usage guidance above. It lists the core package type names; `S7PlcRx.Reactive` shares the same implementation and publishes the equivalent surface under `S7PlcRx.Reactive.*` namespaces.
+This section is generated from the public C# surface in `src/S7PlcRx` and `src/S7PlcRx.Generators`, then paired with the usage guidance above. It lists the core package type names; `S7PlcRx.Reactive` shares the same implementation and publishes the equivalent surface under `IoT.DriverCore.S7PlcRx.Reactive.*` namespaces.
 
 Reactive namespace equivalents:
 
 | Core namespace | Reactive package namespace |
 |---|---|
-| `S7PlcRx` | `S7PlcRx.Reactive` |
-| `S7PlcRx.Advanced` | `S7PlcRx.Reactive.Advanced` |
-| `S7PlcRx.BatchOperations` | `S7PlcRx.Reactive.BatchOperations` |
-| `S7PlcRx.Binding` | `S7PlcRx.Reactive.Binding` |
-| `S7PlcRx.Cache` | `S7PlcRx.Reactive.Cache` |
-| `S7PlcRx.Core` | `S7PlcRx.Reactive.Core` |
-| `S7PlcRx.Enterprise` | `S7PlcRx.Reactive.Enterprise` |
-| `S7PlcRx.Enums` | `S7PlcRx.Reactive.Enums` |
-| `S7PlcRx.Optimization` | `S7PlcRx.Reactive.Optimization` |
-| `S7PlcRx.Performance` | `S7PlcRx.Reactive.Performance` |
-| `S7PlcRx.PlcTypes` | `S7PlcRx.Reactive.PlcTypes` |
-| `S7PlcRx.Production` | `S7PlcRx.Reactive.Production` |
-| `S7PlcRx.SourceGeneration` | `S7PlcRx.Reactive.SourceGeneration` |
+| `IoT.DriverCore.S7PlcRx` | `IoT.DriverCore.S7PlcRx.Reactive` |
+| `IoT.DriverCore.S7PlcRx.Advanced` | `IoT.DriverCore.S7PlcRx.Reactive.Advanced` |
+| `IoT.DriverCore.S7PlcRx.BatchOperations` | `IoT.DriverCore.S7PlcRx.Reactive.BatchOperations` |
+| `IoT.DriverCore.S7PlcRx.Binding` | `IoT.DriverCore.S7PlcRx.Reactive.Binding` |
+| `IoT.DriverCore.S7PlcRx.Cache` | `IoT.DriverCore.S7PlcRx.Reactive.Cache` |
+| `IoT.DriverCore.S7PlcRx.Core` | `IoT.DriverCore.S7PlcRx.Reactive.Core` |
+| `IoT.DriverCore.S7PlcRx.Enterprise` | `IoT.DriverCore.S7PlcRx.Reactive.Enterprise` |
+| `IoT.DriverCore.S7PlcRx.Enums` | `IoT.DriverCore.S7PlcRx.Reactive.Enums` |
+| `IoT.DriverCore.S7PlcRx.Optimization` | `IoT.DriverCore.S7PlcRx.Reactive.Optimization` |
+| `IoT.DriverCore.S7PlcRx.Performance` | `IoT.DriverCore.S7PlcRx.Reactive.Performance` |
+| `IoT.DriverCore.S7PlcRx.PlcTypes` | `IoT.DriverCore.S7PlcRx.Reactive.PlcTypes` |
+| `IoT.DriverCore.S7PlcRx.Production` | `IoT.DriverCore.S7PlcRx.Reactive.Production` |
+| `IoT.DriverCore.S7PlcRx.SourceGeneration` | `IoT.DriverCore.S7PlcRx.Reactive.SourceGeneration` |
 
 ### Source generator generated API
 
 The source generator emits these compile-time-only types into consumer projects:
 
-- `S7PlcRx.SourceGeneration.S7PlcBindingAttribute` / `S7PlcRx.Reactive.SourceGeneration.S7PlcBindingAttribute` - marks a `partial class` for PLC property binding generation.
-- `S7PlcRx.SourceGeneration.S7TagAttribute` / `S7PlcRx.Reactive.SourceGeneration.S7TagAttribute` - marks a `partial` property with an S7 address; properties: `Address`, `PollIntervalMs`, `Direction`, `ArrayLength`.
-- `S7PlcRx.SourceGeneration.S7TagDirection` / `S7PlcRx.Reactive.SourceGeneration.S7TagDirection` - `ReadWrite`, `ReadOnly`, `WriteOnly`.
+- `IoT.DriverCore.S7PlcRx.SourceGeneration.S7PlcBindingAttribute` / `IoT.DriverCore.S7PlcRx.Reactive.SourceGeneration.S7PlcBindingAttribute` - marks a `partial class` for PLC property binding generation.
+- `IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagAttribute` / `IoT.DriverCore.S7PlcRx.Reactive.SourceGeneration.S7TagAttribute` - marks a `partial` property with an S7 address; properties: `Address`, `PollIntervalMs`, `Direction`, `ArrayLength`.
+- `IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagDirection` / `IoT.DriverCore.S7PlcRx.Reactive.SourceGeneration.S7TagDirection` - `ReadWrite`, `ReadOnly`, `WriteOnly`.
 - Generated instance method: `public IDisposable Bind(IRxS7 plc)` on each `[S7PlcBinding]` class.
 
 ### Runtime public surface
@@ -977,9 +1027,9 @@ The source generator emits these compile-time-only types into consumer projects:
 <details open>
 <summary>All public types and members</summary>
 
-#### Namespace `S7PlcRx`
+#### Namespace `IoT.DriverCore.S7PlcRx`
 
-##### `S7PlcRx.IRxS7`
+##### `IoT.DriverCore.S7PlcRx.IRxS7`
 Source: `IRxS7.cs:19`
 
 Defines an interface for reactive communication with a Siemens S7 PLC, providing observable access to connection status, errors, tag values, and PLC information, as well as methods for reading and writing variables asynchronously. <remarks>The IRxS7 interface exposes members for monitoring and interacting with a PLC in a reactive manner using observables. It supports observing connection state, errors, and tag values, as well as reading and writing variables with optional cancellation support. Implementations are expected to handle connection management and provide up-to-date PLC information. Thread safety and subscription management depend on the specific implementation.</remarks>
@@ -1003,13 +1053,13 @@ Defines an interface for reactive communication with a Siemens S7 PLC, providing
 | `public ushort WatchDogValueToWrite get; set; }` | Gets or sets the value to be written to the watchdog register. |
 | `public int WatchDogWritingTime get; }` | Gets the time interval, in milliseconds, used by the watchdog for writing operations. |
 | `public IObservable<long> ReadTime get; }` | Gets an observable sequence that provides the current read time in ticks. <remarks>Subscribers receive updates whenever the read time changes. The value represents the number of ticks elapsed, where one tick equals 100 nanoseconds.</remarks> |
-| `public IObservable<T?> Observe<T>(string? variable);` | Observes changes to the specified variable and returns a sequence of its values as they are updated. <typeparam name="T">The type of the variable to observe.</typeparam> <param name="variable">The name of the variable to observe. Can be null to observe the default variable, if applicable.</param> <returns>An observable sequence that emits the current and subsequent values of the specified variable. The value is null if the variable does not exist or has not been set.</returns> |
-| `public Task<T?> Value<T>(string? variable);` | Asynchronously retrieves the value of the specified variable, if it exists. <typeparam name="T">The type of the value to retrieve.</typeparam> <param name="variable">The name of the variable whose value is to be retrieved. Can be null to indicate the default variable.</param> <returns>A task that represents the asynchronous operation. The task result contains the value of the variable if found; otherwise, null.</returns> |
-| `public Task<T?> ValueAsync<T>(string? variable, CancellationToken cancellationToken);` | Asynchronously retrieves the value of the specified variable, if it exists. <typeparam name="T">The type of the value to retrieve.</typeparam> <param name="variable">The name of the variable to retrieve. Can be null to indicate the default variable, if supported.</param> <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param> <returns>A task that represents the asynchronous operation. The task result contains the value of the variable if found; otherwise, null.</returns> |
+| `IObservable<T?> Observe<T>(LogicalTagKey<T> tag)` | Observes updates for a registered typed key. Construct `new LogicalTagKey<T>(name)` with the same CLR type used in registration. |
+| `Task<T?> ReadAsync<T>(LogicalTagKey<T> tag)` / `ReadAsync<T>(LogicalTagKey<T>, CancellationToken)` | Performs a typed direct read. A null result means no compatible value was obtained; it is not a successful zero value. |
 | `public void Value<T>(string? variable, T? value);` | Sets the value of a variable with the specified name and value. <typeparam name="T">The type of the value to assign to the variable.</typeparam> <param name="variable">The name of the variable to set. Can be null to indicate an unnamed or default variable.</param> <param name="value">The value to assign to the variable. Can be null if the variable type allows null values.</param> |
+| `bool IsDisposed` (inherited `ICancelable` lifecycle) | `IRxS7` is disposable through `ICancelable`; use `using IRxS7 plc = ...` or call `Dispose` when the connection is no longer needed. |
 | `public IObservable<string[]> GetCpuInfo();` | Retrieves an observable sequence containing information about the system's CPU. <remarks>Subscribers receive updates as the CPU information changes. The format and content of each string array may vary depending on the platform or implementation.</remarks> <returns>An observable sequence of string arrays, where each array contains details about the CPU. The sequence emits new arrays when CPU information is updated.</returns> |
 
-##### `S7PlcRx.ITag`
+##### `IoT.DriverCore.S7PlcRx.ITag`
 Source: `Tags/ITag.cs:9`
 
 Represents a tag that can be configured to control polling behavior.
@@ -1018,7 +1068,7 @@ Represents a tag that can be configured to control polling behavior.
 |---|---|
 | `public void SetDoNotPoll(bool value);` | Sets whether the object should be excluded from polling operations. <param name="value">true to prevent the object from being polled; otherwise, false.</param> |
 
-##### `S7PlcRx.PlcException`
+##### `IoT.DriverCore.S7PlcRx.PlcException`
 Source: `PlcException.cs:16`
 
 | Member | Summary |
@@ -1029,7 +1079,7 @@ Source: `PlcException.cs:16`
 | `public PlcException(ErrorCode errorCode, string? message, Exception? inner) : base(message, inner) => ...` | Initializes a new instance of the <see cref="PlcException"/> class. <param name="errorCode">The error code.</param> <param name="message">The message.</param> <param name="inner">The inner.</param> |
 | `public ErrorCode ErrorCode get; }` | Gets the error code. <value> The error code. </value> |
 
-##### `S7PlcRx.RxS7`
+##### `IoT.DriverCore.S7PlcRx.RxS7`
 Source: `RxS7.cs:32`
 
 Provides an observable, reactive interface for reading from and writing to Siemens S7 PLCs, supporting tag-based access, status monitoring, and asynchronous operations. <remarks>The RxS7 class enables integration with Siemens S7 programmable logic controllers (PLCs) using a tag-based model and reactive programming patterns. It exposes observables for PLC data, connection status, errors, and operational metrics, allowing clients to subscribe to real-time updates. The class supports both synchronous and asynchronous read/write operations, as well as advanced features such as watchdog monitoring and batch variable access. Thread safety is maintained for concurrent operations. Dispose the instance when no longer needed to release resources and terminate background operations.</remarks>
@@ -1055,14 +1105,13 @@ Provides an observable, reactive interface for reading from and writing to Sieme
 | `public int WatchDogWritingTime get; } = 10;` | Gets the interval, in seconds, that the watchdog uses when writing status updates. |
 | `public bool IsDisposed get; private set; }` | Gets a value indicating whether gets a value that indicates whether the object is disposed. |
 | `public IObservable<long> ReadTime => ...` | Gets an observable sequence that emits the current read time in ticks whenever a read operation occurs. <remarks>The observable sequence is shared among all subscribers. Each subscriber receives notifications when a read operation is performed, with the value representing the read time in ticks. The sequence completes when the underlying source completes.</remarks> |
-| `public IObservable<T?> Observe<T>(string? variable) => ...` | Returns an observable sequence that emits the current and future values of the specified variable, cast to the specified type. <remarks>The returned observable is hot and shared among all subscribers. Subscribers receive the most recent value and all subsequent updates. If the variable does not exist or its value cannot be cast to the specified type, the observable emits null.</remarks> <typeparam name="T">The type to which the variable's value is cast in the observable sequence.</typeparam> <param name="variable">The name of the variable to observe. If null, all variables are observed.</param> <returns>An observable sequence of values of type T, or null if the variable's value is not present or cannot be cast to T. The sequence emits a new value each time the variable changes.</returns> |
-| `public async Task<T?> Value<T>(string? variable)` | Asynchronously retrieves the value of the specified variable, cast to the specified type, if available. <remarks>If the variable's type is not known, it is set to the requested type <typeparamref name="T"/> before retrieving the value. The method waits for an internal pause condition to be met before proceeding.</remarks> <typeparam name="T">The type to which the variable's value is cast and returned.</typeparam> <param name="variable">The name of the variable whose value is to be retrieved. Can be null.</param> <returns>A value of type <typeparamref name="T"/> if the variable exists and can be cast to the specified type; otherwise, <see langword="default"/>.</returns> |
-| `public async Task<T?> ValueAsync<T>(string? variable, CancellationToken cancellationToken)` | Asynchronously retrieves the value of the specified variable, pausing polling operations during the read. <remarks>Polling is temporarily paused while the value is being read to ensure consistency. If no polling is active, the method may wait briefly before proceeding. The method is cancellation-friendly and will respond promptly to cancellation requests.</remarks> <typeparam name="T">The expected type of the variable's value to retrieve.</typeparam> <param name="variable">The name of the variable whose value is to be retrieved. Cannot be null, empty, or consist only of white-space characters.</param> <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param> <returns>A task that represents the asynchronous operation. The task result contains the value of the specified variable cast to type T, or the default value of T if the variable is not found or cannot be cast.</returns> <exception cref="ArgumentNullException">Thrown if variable is null, empty, or consists only of white-space characters.</exception> <exception cref="OperationCanceledException">Thrown if the operation is canceled via the cancellation token.</exception> |
+| `public IObservable<T?> Observe<T>(LogicalTagKey<T> tag)` | Typed observable surface; tag-name overloads were removed. |
+| `public Task<T?> ReadAsync<T>(LogicalTagKey<T> tag)` / `ReadAsync<T>(LogicalTagKey<T>, CancellationToken)` | Typed direct read surface; use the cancellation overload for caller-controlled timeouts. |
 | `public void Value<T>(string? variable, T? value)` | Sets the value of the specified variable if it exists and the value is compatible with the variable's type. <remarks>If the variable does not exist or the value is null, this method does nothing. The value is only set if its type matches the variable's expected type or if the type parameter is object.</remarks> <typeparam name="T">The type of the value to assign to the variable.</typeparam> <param name="variable">The name of the variable whose value is to be set. Cannot be null.</param> <param name="value">The value to assign to the variable. Must be compatible with the variable's type.</param> |
 | `public void Dispose()` | Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources. |
 | `public IObservable<string[]> GetCpuInfo() => ...` | Retrieves detailed information about the connected CPU as an observable sequence. <remarks>The method waits until a connection is established before retrieving CPU information. If the required data is not immediately available, the method will retry until successful or until the subscription is disposed. The order and content of the returned string array correspond to specific CPU information fields. This method is intended for use in reactive programming scenarios where CPU information is needed asynchronously.</remarks> <returns>An observable sequence that emits a string array containing CPU information fields, such as the AS name, module name, copyright, serial number, module type name, order code, and version numbers. The sequence completes after emitting the data.</returns> |
 
-##### `S7PlcRx.S71200`
+##### `IoT.DriverCore.S7PlcRx.S71200`
 Source: `Create/S71200.cs:9`
 
 Provides factory methods for creating connections to Siemens S7-1200 PLC devices.
@@ -1071,7 +1120,7 @@ Provides factory methods for creating connections to Siemens S7-1200 PLC devices
 |---|---|
 | `public static IRxS7 Create(string ip, short rack = 0, string? watchDogAddress = null, double interval = 100, ushort watchDogValueToWrite = 4500, int watchDogInterval = 100)` | Creates a new instance of an S7 PLC connection with the specified configuration parameters. <param name="ip">The IP address of the S7 PLC to connect to.</param> <param name="rack">The rack number of the PLC. Must be between 0 and 7. The default is 0.</param> <param name="watchDogAddress">The address of the watchdog variable in the PLC memory. If null, the watchdog feature is disabled.</param> <param name="interval">The polling interval, in milliseconds, for reading data from the PLC. The default is 100 milliseconds.</param> <param name="watchDogValueToWrite">The value to write to the watchdog variable, if specified. The default is 4500.</param> <param name="watchDogInterval">The interval, in milliseconds, at which the watchdog value is written. The default is 100 milliseconds.</param> <returns>An object implementing the IRxS7 interface that represents the configured PLC connection.</returns> <exception cref="ArgumentOutOfRangeException">Thrown if the value of rack is less than 0 or greater than 7.</exception> |
 
-##### `S7PlcRx.S71500`
+##### `IoT.DriverCore.S7PlcRx.S71500`
 Source: `Create/S71500.cs:9`
 
 Provides factory methods for creating connections to Siemens S7-1500 PLC devices.
@@ -1080,7 +1129,7 @@ Provides factory methods for creating connections to Siemens S7-1500 PLC devices
 |---|---|
 | `public static IRxS7 Create(string ip, short rack = 0, short slot = 1, string? watchDogAddress = null, double interval = 100, ushort watchDogValueToWrite = 4500, int watchDogInterval = 10)` | Creates a new instance of an S7 PLC client configured for the specified IP address, rack, slot, and optional watchdog monitoring. <remarks>If <paramref name="watchDogAddress"/> is specified, the client will periodically write <paramref name="watchDogValueToWrite"/> to the given address at the specified <paramref name="watchDogInterval"/>. This can be used to implement a heartbeat or keep-alive mechanism with the PLC.</remarks> <param name="ip">The IP address of the S7 PLC to connect to.</param> <param name="rack">The rack number of the PLC. Must be between 0 and 7.</param> <param name="slot">The slot number of the PLC CPU module. Must be between 1 and 31.</param> <param name="watchDogAddress">The address of the watchdog variable in the PLC memory to monitor. If null, watchdog monitoring is disabled.</param> <param name="interval">The polling interval, in milliseconds, for communication with the PLC. Must be positive.</param> <param name="watchDogValueToWrite">The value to write to the watchdog variable when monitoring is enabled.</param> <param name="watchDogInterval">The interval, in seconds, at which the watchdog value is written. Must be positive.</param> <returns>An IRxS7 instance configured to communicate with the specified S7 PLC and optional watchdog monitoring.</returns> <exception cref="ArgumentOutOfRangeException">Thrown when the value of <paramref name="rack"/> is not between 0 and 7, or <paramref name="slot"/> is not between 1 and 31.</exception> |
 
-##### `S7PlcRx.S7200`
+##### `IoT.DriverCore.S7PlcRx.S7200`
 Source: `Create/S7200.cs:9`
 
 Provides factory methods for creating connections to Siemens S7-200 PLC devices.
@@ -1089,7 +1138,7 @@ Provides factory methods for creating connections to Siemens S7-200 PLC devices.
 |---|---|
 | `public static IRxS7 Create(string ip, short rack, short slot, string? watchDogAddress = null, double interval = 100, ushort watchDogValueToWrite = 4500, int watchDogInterval = 100) => ...` | Creates a new instance of an S7-200 PLC client for communication over TCP/IP with optional watchdog monitoring. <remarks>If a watchdog address is specified, the client will periodically write the specified value to the PLC at the given interval to support connection monitoring or fail-safe logic. Ensure that the PLC is configured to handle the watchdog mechanism as expected.</remarks> <param name="ip">The IP address of the S7-200 PLC to connect to. Cannot be null or empty.</param> <param name="rack">The rack number of the PLC CPU module. Typically 0 for S7-200 devices.</param> <param name="slot">The slot number of the PLC CPU module. Typically 0 or 1 for S7-200 devices.</param> <param name="watchDogAddress">The address in the PLC memory to use for the watchdog mechanism, or null to disable watchdog monitoring.</param> <param name="interval">The polling interval, in milliseconds, for regular communication with the PLC. Must be greater than 0.</param> <param name="watchDogValueToWrite">The value to write to the watchdog address during each watchdog cycle.</param> <param name="watchDogInterval">The interval, in milliseconds, at which the watchdog value is written. Must be greater than 0.</param> <returns>An IRxS7 instance configured to communicate with the specified S7-200 PLC, with optional watchdog monitoring enabled.</returns> |
 
-##### `S7PlcRx.S7300`
+##### `IoT.DriverCore.S7PlcRx.S7300`
 Source: `Create/S7300.cs:9`
 
 Provides factory methods for creating connections to Siemens S7-300 PLC devices.
@@ -1098,7 +1147,7 @@ Provides factory methods for creating connections to Siemens S7-300 PLC devices.
 |---|---|
 | `public static IRxS7 Create(string ip, short rack, short slot, string? watchDogAddress = null, double interval = 100, ushort watchDogValueToWrite = 4500, int watchDogInterval = 100)` | Creates a new instance of an S7 PLC connection with the specified configuration parameters. <param name="ip">The IP address of the S7 PLC to connect to.</param> <param name="rack">The rack number of the PLC. Must be between 0 and 7, inclusive.</param> <param name="slot">The slot number of the PLC. Must be between 1 and 31, inclusive.</param> <param name="watchDogAddress">The address in the PLC memory to use for the watchdog mechanism, or null to disable the watchdog.</param> <param name="interval">The polling interval, in milliseconds, for communication with the PLC. Must be greater than 0.</param> <param name="watchDogValueToWrite">The value to write to the watchdog address during each interval.</param> <param name="watchDogInterval">The interval, in milliseconds, at which the watchdog value is written. Must be greater than 0.</param> <returns>An object implementing the IRxS7 interface that represents the configured PLC connection.</returns> <exception cref="ArgumentOutOfRangeException">Thrown when the value of <paramref name="rack"/> is not between 0 and 7, or when the value of <paramref name="slot"/> is not between 1 and 31.</exception> |
 
-##### `S7PlcRx.S7400`
+##### `IoT.DriverCore.S7PlcRx.S7400`
 Source: `Create/S7400.cs:9`
 
 Provides factory methods for creating S7-400 PLC connections.
@@ -1107,7 +1156,7 @@ Provides factory methods for creating S7-400 PLC connections.
 |---|---|
 | `public static IRxS7 Create(string ip, short rack, short slot, string? watchDogAddress = null, double interval = 100, ushort watchDogValueToWrite = 4500, int watchDogInterval = 100)` | Creates a new instance of an S7 PLC client configured for the specified IP address, rack, slot, and optional watchdog monitoring parameters. <remarks>If watchdog monitoring is enabled by specifying a non-null watchDogAddress, the client will periodically write the specified value to the given address at the defined interval. This can be used to implement a heartbeat or keep-alive mechanism with the PLC.</remarks> <param name="ip">The IP address of the S7 PLC to connect to.</param> <param name="rack">The rack number of the PLC. Must be between 0 and 7.</param> <param name="slot">The slot number of the PLC CPU. Must be between 1 and 31.</param> <param name="watchDogAddress">The address in the PLC memory to use for the watchdog mechanism, or null to disable watchdog monitoring.</param> <param name="interval">The polling interval, in milliseconds, for reading data from the PLC. Must be greater than 0.</param> <param name="watchDogValueToWrite">The value to write to the watchdog address during each interval if watchdog monitoring is enabled.</param> <param name="watchDogInterval">The interval, in milliseconds, at which the watchdog value is written if watchdog monitoring is enabled. Must be greater than 0.</param> <returns>An IRxS7 instance configured to communicate with the specified S7 PLC and optional watchdog monitoring.</returns> <exception cref="ArgumentOutOfRangeException">Thrown if rack is not between 0 and 7, or if slot is not between 1 and 31.</exception> |
 
-##### `S7PlcRx.S7Exception`
+##### `IoT.DriverCore.S7PlcRx.S7Exception`
 Source: `S7Exception.cs:13`
 
 | Member | Summary |
@@ -1116,7 +1165,7 @@ Source: `S7Exception.cs:13`
 | `public S7Exception(string message) : base(message)` | Initializes a new instance of the <see cref="S7Exception"/> class. <param name="message">The message that describes the error.</param> |
 | `public S7Exception(string message, Exception innerException) : base(message, innerException)` | Initializes a new instance of the <see cref="S7Exception"/> class. <param name="message">The error message that explains the reason for the exception.</param> <param name="innerException">The exception that is the cause of the current exception, or a null reference (<see langword="Nothing" /> in Visual Basic) if no inner exception is specified.</param> |
 
-##### `S7PlcRx.Tag`
+##### `IoT.DriverCore.S7PlcRx.Tag`
 Source: `Tags/Tag.cs:15`
 
 | Member | Summary |
@@ -1136,29 +1185,26 @@ Source: `Tags/Tag.cs:15`
 | `public bool DoNotPoll get; internal set; }` | Gets a value indicating whether polling operations should be suppressed for this instance. |
 | `public void SetDoNotPoll(bool value) => ...` | Sets a value indicating whether polling operations should be disabled. <param name="value">true to disable polling; otherwise, false.</param> |
 
-##### `S7PlcRx.TagAddressOutOfRangeException`
+##### `IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException`
 Source: `Tags/TagAddressOutOfRangeException.cs:15`
 
 No public instance/static members declared directly on this type.
 
-##### `S7PlcRx.TagExtensions`
-Source: `Tags/TagExtensions.cs:18`
+##### `IoT.DriverCore.S7PlcRx.TagOperations`
+Source: `Tags/TagOperations.cs`
 
-Provides extension methods for managing and interacting with tag items in IRxS7-based PLC systems. These methods enable adding, updating, retrieving, and removing tags, as well as converting tag streams to dictionary representations. <remarks>The TagExtensions class offers a fluent API for working with tags in Siemens S7 PLC communication scenarios. It includes methods for adding tags with type and array support, controlling polling behavior, and transforming tag data streams. All methods are implemented as extension methods to enhance usability and integration with IRxS7 and related types. Thread safety and error handling depend on the underlying IRxS7 and Tag implementations.</remarks>
+Provides static operations for registering, retrieving, removing, and projecting S7 tags. Register through `TagOperations` and retain the returned `TagRegistration` when polling configuration is required.
 
 | Member | Summary |
 |---|---|
-| `public static (ITag? tag, IRxS7? plc) AddUpdateTagItem<T>(this IRxS7 @this, string tagName, string address, int? arrayLength = null)` | Adds or updates a tag item of the specified type in the PLC and returns the created tag and the PLC instance. <remarks>If the specified type parameter is a string or an array type and an array length is provided, the tag will be created as an array with the given length. Otherwise, the tag will be created as a single value. This method is an extension method for IRxS7 implementations that support tag management.</remarks> <typeparam name="T">The data type of the tag to add or update. This determines the type of value the tag will hold.</typeparam> <param name="this">The PLC instance to which the tag item will be added or updated.</param> <param name="tagName">The name to assign to the tag item.</param> <param name="address">The address in the PLC where the tag item is located.</param> <param name="arrayLength">The length of the array for the tag item, if the tag represents an array type. Specify null for non-array types.</param> <returns>A tuple containing the created or updated tag as the first element and the PLC instance as the second element. The tag will be null if the PLC instance does not support tag operations.</returns> |
-| `public static (ITag? tag, IRxS7? plc) AddUpdateTagItem(this IRxS7 @this, Type type, string tagName, string address, int? arrayLength = null)` | Adds or updates a tag item in the specified PLC instance and returns the created tag and the PLC reference. <remarks>If the specified type is an array or a string, the array length must be provided. If the PLC instance does not support adding or updating tags, the returned tag will be null.</remarks> <param name="this">The PLC instance to which the tag item will be added or updated.</param> <param name="type">The data type of the tag to add or update. Must not be null.</param> <param name="tagName">The name of the tag to add or update.</param> <param name="address">The address in the PLC where the tag is located.</param> <param name="arrayLength">The length of the array if the tag type is an array or a string; otherwise, null.</param> <returns>A tuple containing the created tag (or null if the operation was not successful) and the PLC reference.</returns> |
-| `public static (ITag? tag, IRxS7? plc) AddUpdateTagItem<T>(this (ITag? _, IRxS7? plc) @this, string tagName, string address, int? arrayLength = null)` | Adds or updates a tag item of the specified type in the PLC and returns the created tag along with the PLC instance. <remarks>If the PLC instance is not of type <see cref="RxS7"/>, no tag is added or updated and the returned tag will be null. When adding a string or array tag, <paramref name="arrayLength"/> must be specified to define the size of the tag.</remarks> <typeparam name="T">The data type of the tag to add or update. This can be a primitive type, string, or array type.</typeparam> <param name="this">A tuple containing the current tag (which may be null) and the PLC instance in which to add or update the tag.</param> <param name="tagName">The name to assign to the tag item.</param> <param name="address">The address in the PLC where the tag is located.</param> <param name="arrayLength">The length of the array if the tag represents an array type. This parameter is required when <typeparamref name="T"/> is a string or an array type; otherwise, it is ignored.</param> <returns>A tuple containing the created or updated tag as <see cref="ITag"/> and the PLC instance as <see cref="IRxS7"/>. If the PLC instance is null, the tag will also be null.</returns> |
-| `public static (ITag? tag, IRxS7? plc) AddUpdateTagItem(this (ITag? _, IRxS7? plc) @this, Type type, string tagName, string address, int? arrayLength = null)` | Adds or updates a tag item in the specified PLC instance using the provided type, tag name, and address. <remarks>If the tag type is a string or an array, the array length must be specified. The method does not modify the PLC instance if it is null or if the type is null.</remarks> <param name="this">A tuple containing the current tag (ignored) and the PLC instance in which to add or update the tag item.</param> <param name="type">The type of the tag to add or update. Must not be null.</param> <param name="tagName">The name of the tag to add or update in the PLC.</param> <param name="address">The address in the PLC where the tag is located.</param> <param name="arrayLength">The length of the array if the tag type is an array or a string. Optional.</param> <returns>A tuple containing the created or updated tag and the PLC instance. The tag is null if the PLC instance or type is null.</returns> |
-| `public static (ITag? tag, IRxS7? plc) SetTagPollIng(this (ITag? tag, IRxS7? plc) @this, bool polling = true)` | Enables or disables polling for the specified tag by setting its polling state. <remarks>If the tag is null, this method has no effect. This method does not modify the PLC instance.</remarks> <param name="this">A tuple containing the tag and PLC instance to update.</param> <param name="polling">true to enable polling for the tag; false to disable polling. The default is true.</param> <returns>A tuple containing the original tag and PLC instance.</returns> |
-| `public static (ITag? tag, IRxS7? plc) GetTag(this IRxS7 @this, string tagName) => ...` | Retrieves the tag with the specified name from the PLC's tag list, along with the associated PLC instance. <remarks>If the specified tag name does not exist in the PLC's tag list, the method returns a tuple with a null tag and the original PLC instance. This method is an extension method for the IRxS7 interface.</remarks> <param name="this">The PLC instance from which to retrieve the tag.</param> <param name="tagName">The name of the tag to retrieve. Cannot be null.</param> <returns>A tuple containing the tag that matches the specified name and the PLC instance. If the tag is not found, the tag element of the tuple is null.</returns> |
-| `public static void RemoveTagItem(this IRxS7 @this, string tagName)` | Removes the tag item with the specified name from the underlying RxS7 instance, if applicable. <remarks>If the underlying object is not an RxS7 instance, this method has no effect.</remarks> <param name="this">The IRxS7 instance from which to remove the tag item.</param> <param name="tagName">The name of the tag item to remove. Cannot be null.</param> |
-| `public static IObservable<IDictionary<string, TValue>> TagToDictionary<TValue>(this IObservable<Tag?> source)` | Projects a sequence of nullable Tag objects into a stream of dictionaries containing the most recent values for each tag name, filtered by the specified value type. <remarks>Each emitted dictionary contains all tag names encountered so far whose values are of type TValue and are not null. The dictionary is updated with each new matching tag in the source sequence. The same dictionary instance is reused and updated for each emission; callers should not modify the returned dictionary.</remarks> <typeparam name="TValue">The type to which tag values are filtered and cast. Only tags whose values are of this type are included in the resulting dictionaries.</typeparam> <param name="source">The observable sequence of nullable Tag objects to process.</param> <returns>An observable sequence of dictionaries mapping tag names to their most recent non-null values of type TValue. Each dictionary reflects the accumulated state up to that point in the source sequence.</returns> |
-| `public static IObservable<(string Tag, TValue Value)> ToTagValue<TValue>(this IObservable<TValue?> source, string tag) => ...` | Projects each non-null value in the source sequence into a tuple containing the specified tag and the value. <remarks>Null values in the source sequence are filtered out. The resulting sequence will not contain any tuples with a null value.</remarks> <typeparam name="TValue">The type of the values in the source sequence.</typeparam> <param name="source">The observable sequence of nullable values to process. Only non-null values are included in the result.</param> <param name="tag">The tag to associate with each value in the resulting sequence. This value is included in each emitted tuple.</param> <returns>An observable sequence of tuples, where each tuple contains the specified tag and a non-null value from the source sequence.</returns> |
+| `TagOperations.AddUpdateTagItem(IRxS7, Type, string, string[, int])` | Static registration with scalar, fixed-length, and nullable-length overloads; returns `TagRegistration`. |
+| `TagRegistration.SetPolling()` / `SetPolling(bool)` | Enables or disables polling for the registration returned by `TagOperations.AddUpdateTagItem` or `GetTag`; this is the current replacement for the removed tuple helper. |
+| `TagOperations.GetTag(IRxS7, string)` | Returns a `TagRegistration`; its `Tag` is null when no tag is registered. |
+| `TagOperations.RemoveTagItem(IRxS7, string)` | Removes a named registration from a concrete `RxS7` instance. |
+| `TagOperations.TagToDictionary(IObservable<Tag?>)` | Produces dictionary snapshots of all non-null tag values. |
+| `TagOperations.ToTagValue<T>(IObservable<T?>, string)` | Associates each non-null typed value with the supplied tag name. |
 
-##### `S7PlcRx.Tags`
+##### `IoT.DriverCore.S7PlcRx.Tags`
 Source: `Tags/Tags.cs:18`
 
 | Member | Summary |
@@ -1175,48 +1221,58 @@ Source: `Tags/Tags.cs:18`
 | `public Tags GetTags()` | Retrieves a collection of tags that have non-null values. <returns>A <see cref="Tags"/> collection containing all tags with non-null values. The collection will be empty if no such tags exist.</returns> |
 | `public List<Tag> ToList()` | Returns a list containing all tags in the collection. <remarks>The returned list is a snapshot of the collection at the time of the call. Subsequent modifications to the collection are not reflected in the returned list. This method is thread-safe.</remarks> <returns>A list of <see cref="Tag"/> objects representing the tags in the collection. The list is empty if the collection contains no tags or if an error occurs while retrieving the tags.</returns> |
 
-#### Namespace `S7PlcRx.Advanced`
+#### Namespace `IoT.DriverCore.S7PlcRx.Advanced`
 
-##### `S7PlcRx.Advanced.AdvancedExtensions`
+##### `IoT.DriverCore.S7PlcRx.Advanced.AdvancedExtensions`
 Source: `Advanced/AdvancedExtensions.cs:22`
 
 Provides advanced extension methods for efficient batch operations, diagnostics, and performance analysis on PLC (Programmable Logic Controller) instances using the IRxS7 interface. <remarks>These extension methods enable high-performance reading, writing, monitoring, and analysis of PLC variables, supporting scenarios such as batch updates, optimized data access, and system diagnostics. Methods are designed to simplify complex PLC interactions and provide recommendations for optimization. All methods require a valid IRxS7 instance and may throw exceptions if invalid arguments are supplied. Thread safety and performance considerations are addressed where relevant in individual method documentation.</remarks>
 
+> **Current V3 names.** Use the `*Async` static methods below. Earlier migration drafts used extension-style, non-Async names; those names are not part of the current public surface.
+
+| Current member | Required arguments and result |
+|---|---|
+| `AdvancedExtensions.ObserveBatch<T>` | `(IRxS7 plc, T typeValue, params string[] variables)` returns observable snapshots. |
+| `AdvancedExtensions.ValueBatchAsync<T>` | `(IRxS7 plc, T typeValue, params string[] variables)` reads; `(IRxS7 plc, Dictionary<string,T> values)` writes. |
+| `AdvancedExtensions.ReadBatchOptimizedAsync<T>` | `(IRxS7 plc, T typeValue, Dictionary<string,string> tagMapping, int timeoutMs)` returns per-tag `BatchReadResult<T>`. |
+| `AdvancedExtensions.WriteBatchOptimizedAsync<T>` | `(IRxS7 plc, Dictionary<string,T> values, bool verifyWrites, bool enableRollback)` returns `BatchWriteResult`. |
+| `AdvancedExtensions.GetDiagnosticsAsync` / `AnalyzePerformanceAsync` | Accept `IRxS7`; analysis also accepts the observation duration. |
+| `AdvancedExtensions.CreateTagGroup<T>` | `(IRxS7 plc, T typeValue, string groupName, params string[] tagNames)` creates a disposable group. |
+
 | Member | Summary |
 |---|---|
-| `public static IObservable<Dictionary<string, T?>> ObserveBatch<T>(this IRxS7 plc, params string[] variables)` | Observes the values of multiple PLC variables as a batch and emits updates as a dictionary when any of the specified variables change. <remarks>The returned observable is hot and shared among all subscribers. If a specified variable is not already being polled, polling is automatically enabled for that variable. The sequence emits a new dictionary only when the set of variable values changes.</remarks> <typeparam name="T">The type of the variable values to observe. Must be compatible with the PLC variable types.</typeparam> <param name="plc">The PLC instance that provides access to the variables to observe. Cannot be null.</param> <param name="variables">The names of the PLC variables to observe. If empty, an empty dictionary is emitted.</param> <returns>An observable sequence that emits a dictionary mapping each specified variable name to its most recent value. The dictionary is updated and emitted whenever any of the observed variables change.</returns> <exception cref="ArgumentNullException">Thrown if the <paramref name="plc"/> parameter is null.</exception> |
-| `public static async Task<Dictionary<string, T?>> ValueBatch<T>(this IRxS7 plc, params string[] variables)` | Asynchronously reads the values of multiple variables from the PLC and returns a dictionary mapping variable names to their values. <remarks>If a variable name does not exist in the PLC or cannot be read, its value in the returned dictionary will be the default value for type T. The order of the returned dictionary corresponds to the order of the requested variable names. This method may perform the reads in parallel for efficiency.</remarks> <typeparam name="T">The type of the variable values to read from the PLC.</typeparam> <param name="plc">The PLC instance from which to read the variable values. Cannot be null.</param> <param name="variables">An array of variable names to read from the PLC. Each name must correspond to a valid variable in the PLC.</param> <returns>A task that represents the asynchronous operation. The task result contains a dictionary mapping each requested variable name to its value of type T, or to the default value of T if the variable could not be read or does not exist. If no variables are specified, returns an empty dictionary.</returns> <exception cref="ArgumentNullException">Thrown if the plc parameter is null.</exception> |
-| `public static async Task ValueBatch<T>(this IRxS7 plc, Dictionary<string, T> values)` | Writes a batch of values to the PLC asynchronously using the specified tag-value pairs. <remarks>If the underlying PLC implementation supports batch writing, the method attempts to write all values in a single operation for improved performance. Otherwise, values are written individually in parallel. No action is taken if the dictionary is null or empty.</remarks> <typeparam name="T">The type of the values to write to the PLC.</typeparam> <param name="plc">The PLC interface to which the values will be written.</param> <param name="values">A dictionary containing tag names as keys and the corresponding values to write. Cannot be null or empty.</param> <returns>A task that represents the asynchronous write operation.</returns> |
-| `public static async Task<BatchReadResult<T>> ReadBatchOptimized<T>( this IRxS7 plc, Dictionary<string, string> tagMapping, int timeoutMs = 5000)` | Reads a batch of tags from the PLC in an optimized manner, grouping reads by data block to improve performance. <remarks>If the tagMapping dictionary is null or empty, the method returns a successful result with no values. Tags are grouped by data block to minimize communication overhead. If a tag does not exist in the PLC's tag list, it is added before reading. Each tag read is subject to the specified timeout.</remarks> <typeparam name="T">The type of the values to read from the PLC tags.</typeparam> <param name="plc">The PLC instance that provides access to the tags to be read. Cannot be null.</param> <param name="tagMapping">A dictionary mapping logical tag names to their corresponding PLC addresses. Each key is the tag name, and each value is the PLC address to read.</param> <param name="timeoutMs">The maximum time, in milliseconds, to wait for each tag read operation before timing out. The default is 5000 milliseconds.</param> <returns>A task that represents the asynchronous operation. The task result contains a BatchReadResult{T} with the values read, per-tag success status, and any errors encountered.</returns> <exception cref="ArgumentNullException">Thrown if the plc parameter is null.</exception> |
-| `public static async Task<BatchWriteResult> WriteBatchOptimized<T>( this IRxS7 plc, Dictionary<string, T> values, bool verifyWrites = false, bool enableRollback = false)` | Writes a batch of values to the specified PLC in an optimized manner, with optional write verification and rollback support. <remarks>If enableRollback is set to true and any write fails, the method attempts to restore all affected PLC addresses to their original values. Write verification, if enabled, reads back each value after writing to ensure correctness. This method is asynchronous and should be awaited to ensure completion of all write and verification operations.</remarks> <typeparam name="T">The type of the values to write to the PLC.</typeparam> <param name="plc">The PLC instance to which the values will be written. Cannot be null.</param> <param name="values">A dictionary mapping PLC variable addresses to the values to write. Each key represents a PLC address, and each value is the data to write to that address. If the dictionary is null or empty, no write operations are performed.</param> <param name="verifyWrites">true to verify each write by reading back the value after writing; otherwise, false. Verification may increase operation time.</param> <param name="enableRollback">true to enable rollback of all written values to their original state if any write fails; otherwise, false. Rollback is attempted only if an error occurs during the batch write.</param> <returns>A BatchWriteResult object containing the outcome of the batch write operation, including per-address success and error information. If no values are provided, the result indicates overall success.</returns> <exception cref="ArgumentNullException">Thrown if plc is null.</exception> |
-| `public static async Task<ProductionDiagnostics> GetDiagnostics(this IRxS7 plc)` | Asynchronously collects diagnostic information and performance metrics from the specified PLC instance. <remarks>If the PLC is not connected, only basic information is included in the diagnostics. For S7-1500 PLCs, additional CPU information and connection latency are measured. Any errors encountered during diagnostic collection are recorded in the Errors property of the returned ProductionDiagnostics object.</remarks> <param name="plc">The PLC instance from which to retrieve diagnostics. Must implement the IRxS7 interface.</param> <returns>A task that represents the asynchronous operation. The task result contains a ProductionDiagnostics object with collected diagnostic data, tag metrics, and optimization recommendations.</returns> <exception cref="ArgumentNullException">Thrown if the plc parameter is null.</exception> |
-| `public static async Task<PerformanceAnalysis> AnalyzePerformance(this IRxS7 plc, TimeSpan monitoringDuration)` | Analyzes tag change performance on the specified PLC over a given monitoring duration and returns a summary of tag change frequencies and recommendations. <remarks>This method subscribes to all tag changes on the PLC and tracks the frequency of changes for each tag during the specified monitoring period. The analysis includes total tag changes, per-tag change counts, and suggestions for optimizing performance based on observed activity. The method is thread-safe and does not block the calling thread.</remarks> <param name="plc">The PLC instance to monitor for tag changes. Cannot be null.</param> <param name="monitoringDuration">The length of time to observe tag changes. Must be a positive time span.</param> <returns>A task that represents the asynchronous operation. The task result contains a PerformanceAnalysis object with tag change statistics and performance recommendations for the monitored period.</returns> <exception cref="ArgumentNullException">Thrown if the plc parameter is null.</exception> |
-| `public static HighPerformanceTagGroup<T> CreateTagGroup<T>(this IRxS7 plc, string groupName, params string[] tagNames) => ...` | Creates a new high-performance tag group for batch reading or writing of multiple tags from the specified PLC connection. <remarks>Use this method to efficiently manage and operate on multiple tags as a single group, which can improve performance for batch operations.</remarks> <typeparam name="T">The data type of the tag values in the group.</typeparam> <param name="plc">The PLC connection used to access the tags. Cannot be null.</param> <param name="groupName">The name assigned to the tag group. Used to identify the group within the PLC context.</param> <param name="tagNames">An array of tag names to include in the group. Each name must correspond to a valid tag in the PLC.</param> <returns>A new instance of HighPerformanceTagGroup{T} containing the specified tags, associated with the given PLC connection.</returns> |
+| `AdvancedExtensions.ObserveBatch<T>(IRxS7 plc, T typeValue, params string[] variables)` | Produces batch snapshots and enables polling for newly registered tags. Pass a marker such as `default(float)` so the compiler can infer `T`. |
+| `AdvancedExtensions.ValueBatchAsync<T>(IRxS7 plc, T typeValue, params string[] variables)` | Reads a same-type named set; use `ValueBatchAsync(IRxS7, Dictionary<string,T>)` to issue a batch write. |
+| `AdvancedExtensions.ValueBatchAsync<T>(IRxS7 plc, Dictionary<string,T> values)` | Writes a named set; it does not imply a transactional PLC commit. |
+| `AdvancedExtensions.ReadBatchOptimizedAsync<T>(IRxS7, T typeValue, Dictionary<string,string>, int timeoutMs)` | Registers mapped addresses as necessary, groups work by DB, and returns per-tag `BatchReadResult<T>`. |
+| `AdvancedExtensions.WriteBatchOptimizedAsync<T>(IRxS7, Dictionary<string,T>, bool verifyWrites, bool enableRollback)` | Writes mapped tags with optional readback and best-effort rollback; inspect every result field. |
+| `AdvancedExtensions.GetDiagnosticsAsync(IRxS7)` | Asynchronously gathers connection, CPU/tag, and recommendation diagnostics. |
+| `AdvancedExtensions.AnalyzePerformanceAsync(IRxS7, TimeSpan)` | Observes tag changes for the supplied duration and returns frequencies and recommendations. |
+| `AdvancedExtensions.CreateTagGroup<T>(IRxS7, T typeValue, string groupName, params string[] tagNames)` | Creates a disposable group with `ObserveGroup`, `ReadAllAsync`, and `WriteAllAsync`. |
 
-##### `S7PlcRx.Advanced.AsyncExtensions`
+##### `IoT.DriverCore.S7PlcRx.Advanced.AsyncExtensions`
 Source: `Advanced/AsyncExtensions.cs:18`
 
 Provides additional async-first helpers for reading, writing, and observing PLC values without changing the base <see cref="IRxS7"/> API surface. <remarks>These helpers layer <see cref="ValueTask"/> and async-observable patterns over the existing PLC API. Where possible, they complete synchronously from cached tag values or the existing multi-variable read/write paths to reduce avoidable allocations.</remarks>
 
 | Member | Summary |
 |---|---|
-| `public static ValueTask<T?> ReadValueAsync<T>(this IRxS7 plc, string? variable, CancellationToken cancellationToken = default)` | Reads a PLC value using a <see cref="ValueTask{TResult}"/>, returning synchronously when a compatible cached tag value is already available. <typeparam name="T">The expected PLC value type.</typeparam> <param name="plc">The PLC instance.</param> <param name="variable">The tag name to read.</param> <param name="cancellationToken">The cancellation token for the read operation.</param> <returns>A <see cref="ValueTask{TResult}"/> that resolves to the current PLC value.</returns> |
-| `public static ValueTask<Dictionary<string, T?>> ReadValuesAsync<T>(this IRxS7 plc, params string[] variables) => ...` | Reads multiple PLC values using a <see cref="ValueTask{TResult}"/>, preferring cached values and the optimized multi-variable read path where available. <typeparam name="T">The expected PLC value type.</typeparam> <param name="plc">The PLC instance.</param> <param name="variables">The tag names to read.</param> <returns>A <see cref="ValueTask{TResult}"/> that resolves to a dictionary of tag values keyed by tag name.</returns> |
-| `public static ValueTask<Dictionary<string, T?>> ReadValuesAsync<T>(this IRxS7 plc, IReadOnlyList<string> variables, CancellationToken cancellationToken = default)` | Reads multiple PLC values using a <see cref="ValueTask{TResult}"/>, honoring cancellation for deferred reads. <typeparam name="T">The expected PLC value type.</typeparam> <param name="plc">The PLC instance.</param> <param name="variables">The tag names to read.</param> <param name="cancellationToken">The cancellation token for deferred reads.</param> <returns>A <see cref="ValueTask{TResult}"/> that resolves to a dictionary of tag values keyed by tag name.</returns> |
-| `public static ValueTask WriteValuesAsync<T>(this IRxS7 plc, IReadOnlyDictionary<string, T> values, CancellationToken cancellationToken = default)` | Writes multiple PLC values using a <see cref="ValueTask"/>, preferring the optimized multi-variable write path where available. <typeparam name="T">The PLC value type.</typeparam> <param name="plc">The PLC instance.</param> <param name="values">The tag values to write.</param> <param name="cancellationToken">The cancellation token.</param> <returns>A completed <see cref="ValueTask"/> when the writes have been issued.</returns> |
-| `public static IObservableAsync<T?> ObserveValue<T>(this IRxS7 plc, string? variable)` | Exposes a PLC variable as an async observable sequence. <typeparam name="T">The expected PLC value type.</typeparam> <param name="plc">The PLC instance.</param> <param name="variable">The tag name to observe.</param> <returns>An <see cref="IObservableAsync{T}"/> that emits tag value updates asynchronously.</returns> |
-| `public static IObservableAsync<Dictionary<string, T?>> ObserveValues<T>(this IRxS7 plc, params string[] variables)` | Exposes a batch PLC observation as an async observable sequence. <typeparam name="T">The expected PLC value type.</typeparam> <param name="plc">The PLC instance.</param> <param name="variables">The tag names to observe.</param> <returns>An <see cref="IObservableAsync{T}"/> that emits dictionaries of tag values asynchronously.</returns> |
+| `AsyncExtensions.ReadValueAsync<T>(IRxS7, T typeValue, string variable, CancellationToken)` | ValueTask read with a type marker and caller cancellation. It can satisfy a compatible cached value synchronously. |
+| `AsyncExtensions.ReadValuesAsync<T>(IRxS7, T typeValue, IReadOnlyList<string>, CancellationToken)` | ValueTask multi-read with a type marker and cancellation. |
+| `AsyncExtensions.WriteValuesAsync<T>(IRxS7, IReadOnlyDictionary<string,T>, CancellationToken)` | ValueTask batch write. It uses the multi-variable path when available and still requires application-level command acknowledgement. |
+| `AsyncExtensions.ObserveValue<T>(IRxS7, T typeValue, string variable)` | .NET 8+ async observable for one typed key. Subscribe with a Primitives async observer and dispose the async subscription. |
+| `AsyncExtensions.ObserveValues<T>(IRxS7, T typeValue, params string[] variables)` | .NET 8+ async observable batch projection. |
 
-##### `S7PlcRx.Advanced.DictionaryEqualityComparer<TKey, TValue>`
+##### `IoT.DriverCore.S7PlcRx.Advanced.DictionaryEqualityComparer<TKey, TValue>`
 Source: `Advanced/DictionaryEqualityComparer.cs:15`
 
 Provides an equality comparer for dictionaries that determines equality based on their key-value pairs. <remarks>This comparer considers two dictionaries equal if they contain the same number of key-value pairs and each key in one dictionary exists in the other with an equal value, as determined by the default equality comparer for the value type. The order of key-value pairs does not affect equality. This comparer can be used to compare dictionaries in collections such as hash sets or as keys in other dictionaries.</remarks> <typeparam name="TKey">The type of keys in the dictionaries. Must be non-nullable.</typeparam> <typeparam name="TValue">The type of values in the dictionaries.</typeparam>
 
 No public instance/static members declared directly on this type.
 
-#### Namespace `S7PlcRx.BatchOperations`
+#### Namespace `IoT.DriverCore.S7PlcRx.BatchOperations`
 
-##### `S7PlcRx.BatchOperations.BatchOperationResult`
+##### `IoT.DriverCore.S7PlcRx.BatchOperations.BatchOperationResult`
 Source: `BatchOperations/BatchOperationResult.cs:14`
 
 Represents the result of executing a batch operation, including summary statistics and details for each operation. <remarks>Use this class to access aggregate information such as the number of successful and failed operations, processing times, and detailed results for each operation in the batch. The class provides both summary properties and collections for per-operation and error details.</remarks>
@@ -1233,7 +1289,7 @@ Represents the result of executing a batch operation, including summary statisti
 | `public List<OperationDetail> OperationDetails get; } = [];` | Gets operation details. |
 | `public List<string> ErrorDetails get; } = [];` | Gets error details for failed operations. |
 
-##### `S7PlcRx.BatchOperations.BatchReadResult<T>`
+##### `IoT.DriverCore.S7PlcRx.BatchOperations.BatchReadResult<T>`
 Source: `BatchOperations/BatchReadResult.cs:17`
 
 Represents the result of a batch read operation, including the values read, per-tag success status, error messages, and overall success information. <remarks>Use this class to access the outcome of a batch read, including which tags succeeded, which failed, and any associated error messages. The dictionaries provide per-tag details, while the overall success and count properties offer summary information. This class is typically used in scenarios where multiple items are read in a single operation and individual results must be tracked.</remarks> <typeparam name="T">The type of the values returned for each tag in the batch read operation.</typeparam>
@@ -1247,7 +1303,7 @@ Represents the result of a batch read operation, including the values read, per-
 | `public int SuccessCount => ...` | Gets the count of successful reads. |
 | `public int ErrorCount => ...` | Gets the count of failed reads. |
 
-##### `S7PlcRx.BatchOperations.BatchWriteResult`
+##### `IoT.DriverCore.S7PlcRx.BatchOperations.BatchWriteResult`
 Source: `BatchOperations/BatchWriteResult.cs:15`
 
 Represents the result of a batch write operation, including per-item success status, error messages, and overall outcome. <remarks>Use this class to inspect which items in a batch write succeeded or failed, retrieve error details for failed items, and determine whether the entire batch was successful or if a rollback was performed. The dictionaries map item identifiers (such as tag names) to their respective statuses and error messages.</remarks>
@@ -1261,9 +1317,9 @@ Represents the result of a batch write operation, including per-item success sta
 | `public int SuccessCount => ...` | Gets the count of successful writes. |
 | `public int ErrorCount => ...` | Gets the count of failed writes. |
 
-#### Namespace `S7PlcRx.Binding`
+#### Namespace `IoT.DriverCore.S7PlcRx.Binding`
 
-##### `S7PlcRx.Binding.S7TagDefinition`
+##### `IoT.DriverCore.S7PlcRx.Binding.S7TagDefinition`
 Source: `Binding/S7TagDefinition.cs:9`
 
 Describes a generated PLC tag/property binding.
@@ -1280,14 +1336,14 @@ Describes a generated PLC tag/property binding.
 | `public bool CanRead => ...` | Gets a value indicating whether this tag should be read on polling intervals. |
 | `public bool CanWrite => ...` | Gets a value indicating whether this tag can write property changes to the PLC. |
 
-##### `S7PlcRx.Binding.S7TagDirection`
+##### `IoT.DriverCore.S7PlcRx.Binding.S7TagDirection`
 Source: `Binding/S7TagDirection.cs:9`
 
 Defines the PLC access direction for a generated tag binding.
 
 Enum values: `ReadWrite`, `ReadOnly`, `WriteOnly`.
 
-##### `S7PlcRx.Binding.S7TagRuntimeBinding`
+##### `IoT.DriverCore.S7PlcRx.Binding.S7TagRuntimeBinding`
 Source: `Binding/S7TagRuntimeBinding.cs:15`
 
 Runtime engine used by generated tag bindings to poll and write PLC DB values in byte-array batches.
@@ -1298,9 +1354,9 @@ Runtime engine used by generated tag bindings to poll and write PLC DB values in
 | `public void Write(string name, object? value)` | Queues a generated property change for a grouped byte-array write. <param name="name">The generated tag/property name.</param> <param name="value">The new property value.</param> |
 | `public void Dispose()` | Releases timers and pending write state. |
 
-#### Namespace `S7PlcRx.Cache`
+#### Namespace `IoT.DriverCore.S7PlcRx.Cache`
 
-##### `S7PlcRx.Cache.CacheStatistics`
+##### `IoT.DriverCore.S7PlcRx.Cache.CacheStatistics`
 Source: `Cache/CacheStatistics.cs:13`
 
 Provides statistical information about the state and performance of a cache, including entry counts, hit rates, and entry timestamps. <remarks>Use this class to monitor cache usage patterns and effectiveness. The statistics can help identify cache performance issues or guide tuning decisions. All values represent a snapshot at the time the object is created or updated; they do not update automatically.</remarks>
@@ -1316,7 +1372,7 @@ Provides statistical information about the state and performance of a cache, inc
 | `public int PendingRequestCount get; internal set; }` | Gets the pending request count. <value> The pending request count. </value> |
 | `public double CacheHitRatio get; internal set; }` | Gets the cache hit ratio. <value> The cache hit ratio. </value> |
 
-##### `S7PlcRx.Cache.CachedTagValue`
+##### `IoT.DriverCore.S7PlcRx.Cache.CachedTagValue`
 Source: `Cache/CachedTagValue.cs:12`
 
 Represents a cached value along with metadata about its storage and usage. <remarks>This class is typically used to store a value retrieved from a data source, along with the time it was cached and the number of times it has been accessed. It is intended for use in caching scenarios where tracking cache usage and freshness is important.</remarks>
@@ -1327,9 +1383,9 @@ Represents a cached value along with metadata about its storage and usage. <rema
 | `public DateTime Timestamp get; set; }` | Gets or sets when the value was cached. |
 | `public long HitCount get; set; }` | Gets or sets the number of cache hits. |
 
-#### Namespace `S7PlcRx.Core`
+#### Namespace `IoT.DriverCore.S7PlcRx.Core`
 
-##### `S7PlcRx.Core.ConnectionPool`
+##### `IoT.DriverCore.S7PlcRx.Core.ConnectionPool`
 Source: `Core/ConnectionPool.cs:17`
 
 Manages a pool of PLC connections, providing load-balanced access and connection reuse according to the specified configuration. <remarks>The ConnectionPool enables efficient management of multiple PLC connections by reusing and balancing requests across available connections. It supports configurable pool size and connection reuse strategies. This class is thread-safe for concurrent access. Call Dispose to release all connections when the pool is no longer needed.</remarks>
@@ -1341,10 +1397,10 @@ Manages a pool of PLC connections, providing load-balanced access and connection
 | `public int MaxConnections => ...` | Gets the maximum number of connections in the pool. |
 | `public int ActiveConnections => ...` | Gets the number of active connections. |
 | `public IRxS7 GetConnection` | Gets a connection from the pool using load balancing. <returns>An available PLC connection.</returns> |
-| `public IEnumerable<IRxS7> GetAllConnections() => ...` | Gets all connections in the pool. <returns>All connections.</returns> |
+| `public IEnumerable<IRxS7> AllConnections` | Snapshot of managed connections. Dispose the pool rather than attempting to dispose entries individually while it owns them. |
 | `public void Dispose()` | Disposes all connections in the pool. |
 
-##### `S7PlcRx.Core.ConnectionPoolConfig`
+##### `IoT.DriverCore.S7PlcRx.Core.ConnectionPoolConfig`
 Source: `Core/ConnectionPoolConfig.cs:12`
 
 Represents the configuration settings for a connection pool, including limits, timeouts, and behavior options. <remarks>Use this class to specify parameters that control the size, performance, and health monitoring of a connection pool. Adjusting these settings can help optimize resource usage and connection reliability for applications that manage multiple concurrent connections.</remarks>
@@ -1358,7 +1414,7 @@ Represents the configuration settings for a connection pool, including limits, t
 | `public bool EnableConnectionReuse get; set; } = true;` | Gets or sets a value indicating whether to enable connection reuse. |
 | `public TimeSpan HealthCheckInterval get; set; } = TimeSpan.FromMinutes(1);` | Gets or sets the health check interval. |
 
-##### `S7PlcRx.Core.DataBlockInfo`
+##### `IoT.DriverCore.S7PlcRx.Core.DataBlockInfo`
 Source: `Core/DataBlockInfo.cs:14`
 
 Represents metadata and configuration information for a data block, including its identifier, size, tag details, access frequency, and optimization settings. <remarks>Use this class to describe the characteristics of a data block, such as its block number, size in bytes, and associated tag names. The properties provide information useful for managing, analyzing, or optimizing data storage and access patterns. Instances of this class are typically used in scenarios where data blocks are processed, monitored, or configured for batch operations.</remarks>
@@ -1372,7 +1428,7 @@ Represents metadata and configuration information for a data block, including it
 | `public bool IsBatchOptimized get; set; }` | Gets or sets a value indicating whether gets or sets whether the block is optimized for batch operations. |
 | `public List<string> TagNames get; } = [];` | Gets the tags in this data block. |
 
-##### `S7PlcRx.Core.OperationDetail`
+##### `IoT.DriverCore.S7PlcRx.Core.OperationDetail`
 Source: `Core/OperationDetail.cs:9`
 
 Represents the details of an operation, including its type, status, duration, and related metadata.
@@ -1386,16 +1442,16 @@ Represents the details of an operation, including its type, status, duration, an
 | `public string? ErrorMessage get; set; }` | Gets or sets any error message. |
 | `public int DataBlockNumber get; set; }` | Gets or sets the data block number. |
 
-##### `S7PlcRx.Core.RequestPriority`
+##### `IoT.DriverCore.S7PlcRx.Core.RequestPriority`
 Source: `Core/RequestPriority.cs:9`
 
 Request priority levels for batch processing.
 
 Enum values: `Low`, `Normal`, `High`, `Critical`.
 
-#### Namespace `S7PlcRx.Enterprise`
+#### Namespace `IoT.DriverCore.S7PlcRx.Enterprise`
 
-##### `S7PlcRx.Enterprise.EnterpriseExtensions`
+##### `IoT.DriverCore.S7PlcRx.Enterprise.EnterpriseExtensions`
 Source: `Enterprise/EnterpriseExtensions.cs:19`
 
 Provides extension methods for enhanced PLC connectivity, symbolic addressing, high-availability management, and connection pooling in enterprise automation scenarios. <remarks>The EnterpriseExtensions class offers advanced features for working with PLCs, including loading and caching symbol tables for symbolic access, reading and writing values by symbol name, creating high-availability connections with automatic failover, and managing connection pools for high-throughput applications. These methods are designed to simplify integration with industrial automation systems and improve reliability and scalability in production environments.</remarks>
@@ -1408,7 +1464,7 @@ Provides extension methods for enhanced PLC connectivity, symbolic addressing, h
 | `public static HighAvailabilityPlcManager CreateHighAvailabilityConnection( IRxS7 primaryPlc, IList<IRxS7> backupPlcs, TimeSpan? healthCheckInterval = null)` | Creates a high-availability connection manager that coordinates failover between a primary PLC and one or more backup PLCs. <remarks>The returned manager automatically monitors the health of the primary and backup PLCs and handles failover as needed. The order of backupPlcs determines the failover priority.</remarks> <param name="primaryPlc">The primary PLC instance to be used for initial communication and operations. Cannot be null.</param> <param name="backupPlcs">A list of backup PLC instances to be used for failover if the primary PLC becomes unavailable. Cannot be null or empty.</param> <param name="healthCheckInterval">The interval at which the health of the PLCs is checked. If null, a default interval is used.</param> <returns>A HighAvailabilityPlcManager instance that manages high-availability communication across the specified PLCs.</returns> <exception cref="ArgumentNullException">Thrown if primaryPlc or backupPlcs is null.</exception> |
 | `public static ConnectionPool CreateConnectionPool( IEnumerable<PlcConnectionConfig> connectionConfigs, ConnectionPoolConfig poolConfig)` | Creates a new connection pool using the specified PLC connection configurations and pool settings. <param name="connectionConfigs">A collection of PLC connection configurations to include in the pool. Must contain at least one configuration.</param> <param name="poolConfig">The configuration settings to apply to the connection pool. Cannot be null.</param> <returns>A new instance of <see cref="ConnectionPool"/> initialized with the provided connection configurations and pool settings.</returns> <exception cref="ArgumentNullException">Thrown if <paramref name="connectionConfigs"/> or <paramref name="poolConfig"/> is null.</exception> <exception cref="ArgumentException">Thrown if <paramref name="connectionConfigs"/> does not contain at least one configuration.</exception> |
 
-##### `S7PlcRx.Enterprise.HighAvailabilityPlcManager`
+##### `IoT.DriverCore.S7PlcRx.Enterprise.HighAvailabilityPlcManager`
 Source: `Enterprise/HighAvailabilityPlcManager.cs:17`
 
 Provides high-availability management for a set of PLC (Programmable Logic Controller) connections, automatically handling failover to backup PLCs in case of connection loss. <remarks>The HighAvailabilityPlcManager monitors the health of the primary PLC and automatically switches to a backup PLC if the primary becomes unavailable. It exposes an observable stream of failover events for monitoring and allows manual triggering of failover. This class is thread-safe for typical usage scenarios. Dispose the manager when it is no longer needed to release resources.</remarks>
@@ -1421,7 +1477,7 @@ Provides high-availability management for a set of PLC (Programmable Logic Contr
 | `public async Task<bool> TriggerFailover() => ...` | Manually triggers a failover to the next available backup. <returns>A value indicating whether failover was successful.</returns> |
 | `public void Dispose()` | Disposes the high-availability manager. |
 
-##### `S7PlcRx.Enterprise.PlcConnectionConfig`
+##### `IoT.DriverCore.S7PlcRx.Enterprise.PlcConnectionConfig`
 Source: `Enterprise/PlcConnectionConfig.cs:14`
 
 Represents the configuration settings required to establish a connection to a programmable logic controller (PLC). <remarks>Use this class to specify connection parameters such as PLC type, network address, rack, slot, and an optional connection name when initializing or managing PLC connections. This configuration is typically used by PLC communication libraries to open and maintain a session with the target device.</remarks>
@@ -1434,7 +1490,7 @@ Represents the configuration settings required to establish a connection to a pr
 | `public short Slot get; set; }` | Gets or sets the slot number. |
 | `public string ConnectionName get; set; } = string.Empty;` | Gets or sets the connection name. |
 
-##### `S7PlcRx.Enterprise.PlcFailoverEvent`
+##### `IoT.DriverCore.S7PlcRx.Enterprise.PlcFailoverEvent`
 Source: `Enterprise/PlcFailoverEvent.cs:12`
 
 Represents an event that occurs when a failover between programmable logic controllers (PLCs) takes place. <remarks>This class encapsulates information about a PLC failover event, including the time of occurrence, the reason for the failover, and the identifiers of the PLCs involved. Instances of this class are typically used for logging, monitoring, or auditing failover activities within PLC-based systems.</remarks>
@@ -1446,7 +1502,7 @@ Represents an event that occurs when a failover between programmable logic contr
 | `public string OldPlc get; set; } = string.Empty;` | Gets or sets the old PLC identifier. |
 | `public string NewPlc get; set; } = string.Empty;` | Gets or sets the new PLC identifier. |
 
-##### `S7PlcRx.Enterprise.SecurityContext`
+##### `IoT.DriverCore.S7PlcRx.Enterprise.SecurityContext`
 Source: `Enterprise/SecurityContext.cs:14`
 
 Represents the security context for a session, including encryption settings, session timing, and certificate information. <remarks>The SecurityContext class encapsulates all security-related parameters required to manage and validate a secure session. It provides properties for encryption keys, session validity, and certificate details, allowing consumers to configure and query the security state of a session. This class is sealed and cannot be inherited.</remarks>
@@ -1463,7 +1519,7 @@ Represents the security context for a session, including encryption settings, se
 | `public string? CertificatePath get; internal set; }` | Gets the certificate path. <value> The certificate path. </value> |
 | `public string? CertificatePassword get; internal set; }` | Gets the certificate password. <value> The certificate password. </value> |
 
-##### `S7PlcRx.Enterprise.Symbol`
+##### `IoT.DriverCore.S7PlcRx.Enterprise.Symbol`
 Source: `Enterprise/Symbol.cs:13`
 
 Represents a programmable logic controller (PLC) symbol, including its name, address, data type, length, and description. <remarks>Use the Symbol class to define and manage metadata for PLC variables, such as their symbolic name, address, and data type. This class is typically used in applications that interact with PLCs for automation or monitoring purposes.</remarks>
@@ -1476,7 +1532,7 @@ Represents a programmable logic controller (PLC) symbol, including its name, add
 | `public int Length get; set; } = 1;` | Gets or sets the length for array types. |
 | `public string Description get; set; } = string.Empty;` | Gets or sets the description. |
 
-##### `S7PlcRx.Enterprise.SymbolTable`
+##### `IoT.DriverCore.S7PlcRx.Enterprise.SymbolTable`
 Source: `Enterprise/SymbolTable.cs:9`
 
 Represents a read-only table of named symbols and the time at which it was loaded.
@@ -1486,58 +1542,58 @@ Represents a read-only table of named symbols and the time at which it was loade
 | `public Dictionary<string, Symbol> Symbols get; } = [];` | Gets the collection of symbols indexed by name. |
 | `public DateTime LoadedAt get; } = DateTime.UtcNow;` | Gets the timestamp when the symbol table was loaded. |
 
-##### `S7PlcRx.Enterprise.SymbolTableFormat`
+##### `IoT.DriverCore.S7PlcRx.Enterprise.SymbolTableFormat`
 Source: `Enterprise/SymbolTableFormat.cs:9`
 
 Specifies the supported formats for serializing or deserializing a symbol table.
 
 Enum values: `Csv`, `Json`, `Xml`.
 
-#### Namespace `S7PlcRx.Enums`
+#### Namespace `IoT.DriverCore.S7PlcRx.Enums`
 
-##### `S7PlcRx.Enums.CpuType`
+##### `IoT.DriverCore.S7PlcRx.Enums.CpuType`
 Source: `Enums/CpuType.cs:13`
 
 Specifies the supported CPU types for Siemens programmable logic controllers (PLCs). <remarks>Use this enumeration to indicate the model of CPU when configuring or communicating with Siemens PLC devices. The available values correspond to common Siemens PLC families, such as LOGO!, S7-200, S7-300, S7-400, S7-1200, and S7-1500. Selecting the correct CPU type ensures compatibility with device-specific protocols and features.</remarks>
 
 Enum values: `Logo0BA8`, `S7200`, `S7300`, `S7400`, `S71200`, `S71500`.
 
-##### `S7PlcRx.Enums.ErrorCode`
+##### `IoT.DriverCore.S7PlcRx.Enums.ErrorCode`
 Source: `Enums/ErrorCode.cs:12`
 
 Specifies error codes that indicate the result of an operation or the type of error encountered. <remarks>Use this enumeration to identify specific error conditions when handling operation results. The values represent distinct error types, such as connection failures, invalid data formats, or communication issues. The meaning of each code is defined by the context in which it is used.</remarks>
 
 Enum values: `NoError`, `WrongCPUType`, `ConnectionError`, `IPAddressNotAvailable`, `WrongVarFormat`, `WrongNumberReceivedBytes`, `SendData`, `ReadData`, `WriteData`.
 
-##### `S7PlcRx.Enums.S7StringType`
+##### `IoT.DriverCore.S7PlcRx.Enums.S7StringType`
 Source: `Enums/S7StringType.cs:12`
 
 Specifies the string encoding type used for S7 PLC string variables. <remarks>Use this enumeration to indicate whether a string variable should be interpreted as an ASCII (S7String) or Unicode (S7WString) string when communicating with Siemens S7 PLCs. The encoding type determines how string data is read from or written to the PLC.</remarks>
 
 Enum values: `S7String`, `S7WString`.
 
-#### Namespace `S7PlcRx.Optimization`
+#### Namespace `IoT.DriverCore.S7PlcRx.Optimization`
 
-##### `S7PlcRx.Optimization.OptimizationExtensions`
+##### `IoT.DriverCore.S7PlcRx.Optimization.OptimizationExtensions`
 Source: `Optimization/OptimizationExtensions.cs:18`
 
 Provides extension methods for IRxS7 to enable optimized tag monitoring, intelligent value caching, and cache management for PLC data access. <remarks>These extensions enhance performance and usability when interacting with PLC tags by offering adaptive polling, caching strategies, and cache statistics. All methods require a valid IRxS7 instance and are designed to be thread-safe. Use these methods to reduce unnecessary network traffic, improve responsiveness, and monitor tag changes efficiently.</remarks>
 
 | Member | Summary |
 |---|---|
-| `public static IObservable<SmartTagChange<T>> MonitorTagSmart<T>( this IRxS7 plc, string tagName, double changeThreshold = 0.0, int debounceMs = 100)` | Observes changes to a specified PLC tag and emits significant value changes as a stream of smart change events. <remarks>The returned observable emits a new event only when the tag value changes by at least the specified threshold and after the debounce interval has elapsed. This method uses a publish/subscribe mechanism to share the observable sequence among multiple subscribers.</remarks> <typeparam name="T">The type of the tag value to monitor.</typeparam> <param name="plc">The PLC instance that provides access to the tag to be monitored. Cannot be null.</param> <param name="tagName">The name of the tag to observe for changes. Cannot be null or empty.</param> <param name="changeThreshold">The minimum change required between consecutive tag values to consider the change significant. Use 0.0 to report all changes.</param> <param name="debounceMs">The minimum interval, in milliseconds, between emitted change events. Used to debounce rapid changes.</param> <returns>An observable sequence of smart tag change events containing details about each significant change detected in the tag value.</returns> <exception cref="ArgumentNullException">Thrown if <paramref name="plc"/> is null.</exception> <exception cref="ArgumentException">Thrown if <paramref name="tagName"/> is null or empty.</exception> |
-| `public static async Task<T?> ValueCached<T>( this IRxS7 plc, string tagName, TimeSpan? cacheTimeout = null)` | Asynchronously retrieves the value of the specified PLC tag, using a cached value if available and not expired. <remarks>If a cached value for the specified tag exists and has not expired, it is returned immediately. Otherwise, the method reads a fresh value from the PLC and updates the cache. This method is thread-safe.</remarks> <typeparam name="T">The type of the value to retrieve from the PLC tag.</typeparam> <param name="plc">The PLC interface used to access the tag value. Cannot be null.</param> <param name="tagName">The name of the PLC tag to read. Cannot be null or empty.</param> <param name="cacheTimeout">The maximum duration for which a cached value is considered valid. If null, a default of one second is used.</param> <returns>A task that represents the asynchronous operation. The task result contains the value of the specified tag, or the cached value if it is still valid. Returns null if the tag value cannot be retrieved.</returns> <exception cref="ArgumentNullException">Thrown if <paramref name="plc"/> is null.</exception> <exception cref="ArgumentException">Thrown if <paramref name="tagName"/> is null or empty.</exception> |
-| `public static void ClearCache(this IRxS7 plc, string? tagName = null)` | Clears cached values for the specified PLC instance, optionally restricting the operation to a single tag. <remarks>This method is thread-safe. Clearing the cache may affect subsequent read operations, which will retrieve fresh values from the PLC rather than cached results.</remarks> <param name="plc">The PLC instance whose cache entries will be cleared. Cannot be null.</param> <param name="tagName">The name of the tag to clear from the cache. If null or empty, all cache entries for the specified PLC are cleared.</param> <exception cref="ArgumentNullException">Thrown if <paramref name="plc"/> is null.</exception> |
-| `public static CacheStatistics GetCacheStatistics(this IRxS7 plc)` | Retrieves cache usage statistics for the specified PLC instance, including entry count, hit count, hit rate, and entry timestamps. <remarks>This method provides insight into the cache performance and usage for a particular PLC. The statistics can be used to monitor cache effectiveness or diagnose caching issues. The method is thread-safe.</remarks> <param name="plc">The PLC instance for which to obtain cache statistics. Cannot be null.</param> <returns>A CacheStatistics object containing aggregated cache metrics for the specified PLC. If no cache entries exist for the PLC, the statistics will reflect zero entries and hits.</returns> <exception cref="ArgumentNullException">Thrown if <paramref name="plc"/> is null.</exception> |
+| `OptimizationExtensions.MonitorTagSmart<T>(IRxS7, string, IEqualityComparer<T>, double, int)` | Emits debounced significant changes using the supplied comparer. |
+| `OptimizationExtensions.ValueCachedAsync<T>(IRxS7, string, T fallbackValue, TimeSpan)` | Reads through the cache, returning the supplied fallback if the PLC yields no value. |
+| `OptimizationExtensions.ClearCache(IRxS7)` / `ClearCache(IRxS7, string?)` | Clears all cache entries for the endpoint or one tag. |
+| `OptimizationExtensions.GetCacheStatistics(IRxS7)` | Returns endpoint cache hit and age statistics. |
 
-##### `S7PlcRx.Optimization.OptimizationRequestPriority`
+##### `IoT.DriverCore.S7PlcRx.Optimization.OptimizationRequestPriority`
 Source: `Optimization/OptimizationRequestPriority.cs:11`
 
 Specifies the priority level for an optimization request. <remarks>Use this enumeration to indicate the relative importance of an optimization request. Higher priority values may be processed before lower ones, depending on the scheduling or queuing logic of the system.</remarks>
 
 Enum values: `Low`, `Normal`, `High`, `Critical`.
 
-##### `S7PlcRx.Optimization.ReadOptimizationConfig`
+##### `IoT.DriverCore.S7PlcRx.Optimization.ReadOptimizationConfig`
 Source: `Optimization/ReadOptimizationConfig.cs:13`
 
 Provides configuration options for optimizing read operations, including parallelism, delays, concurrency limits, and timeouts within data block groups. <remarks>Use this class to fine-tune the performance characteristics of read operations in scenarios where data is organized into block groups. Adjusting these settings can help balance throughput, latency, and resource usage based on application requirements.</remarks>
@@ -1549,7 +1605,7 @@ Provides configuration options for optimizing read operations, including paralle
 | `public int MaxConcurrentReads get; set; } = 10;` | Gets or sets the maximum number of concurrent reads. |
 | `public int ReadTimeoutMs get; set; } = 5000;` | Gets or sets the read timeout in milliseconds. |
 
-##### `S7PlcRx.Optimization.SmartTagChange<T>`
+##### `IoT.DriverCore.S7PlcRx.Optimization.SmartTagChange<T>`
 Source: `Optimization/SmartTagChange.cs:16`
 
 Represents a change to a smart tag, including its name, previous and current values, the time of change, the amount of change for numeric types, and associated metadata. <remarks>Use this class to track changes to smart tags in applications that require auditing, history, or notification of tag value updates. The <see cref="ChangeAmount"/> property is intended for numeric types; for non-numeric types, its value may be ignored. The <see cref="Metadata"/> dictionary can be used to store additional context or information relevant to the change.</remarks> <typeparam name="T">The type of the value associated with the smart tag. This can be any type representing the tag's value before and after the change.</typeparam>
@@ -1563,7 +1619,7 @@ Represents a change to a smart tag, including its name, previous and current val
 | `public double ChangeAmount get; set; }` | Gets or sets the amount of change for numeric types. |
 | `public Dictionary<string, object> Metadata get; set; } = new();` | Gets or sets additional metadata about the change. |
 
-##### `S7PlcRx.Optimization.WriteOptimizationConfig`
+##### `IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationConfig`
 Source: `Optimization/WriteOptimizationConfig.cs:13`
 
 Provides configuration options for optimizing write operations, including parallelism, verification, timing, and concurrency settings. <remarks>Use this class to customize the behavior of write operations, such as enabling parallel writes, specifying verification requirements, and controlling delays and timeouts. Adjusting these settings can help balance performance and reliability based on application needs.</remarks>
@@ -1576,7 +1632,7 @@ Provides configuration options for optimizing write operations, including parall
 | `public int MaxConcurrentWrites get; set; } = 5;` | Gets or sets the maximum number of concurrent writes. |
 | `public int WriteTimeoutMs get; set; } = 5000;` | Gets or sets the write timeout in milliseconds. |
 
-##### `S7PlcRx.Optimization.WriteOptimizationResult`
+##### `IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationResult`
 Source: `Optimization/WriteOptimizationResult.cs:14`
 
 Represents the result of a write optimization operation, including timing information, per-write outcomes, and overall error details. <remarks>Use this class to access detailed results of a write optimization process, such as the start and end times, lists of successful and failed writes, and aggregate metrics like total duration and success rate. The dictionaries provide per-write information, with keys typically representing write identifiers. This type is immutable except for properties explicitly marked as settable.</remarks>
@@ -1591,9 +1647,9 @@ Represents the result of a write optimization operation, including timing inform
 | `public TimeSpan TotalDuration => ...` | Gets the total operation duration. |
 | `public double SuccessRate => ...` | Gets the success rate. |
 
-#### Namespace `S7PlcRx.Performance`
+#### Namespace `IoT.DriverCore.S7PlcRx.Performance`
 
-##### `S7PlcRx.Performance.BenchmarkConfig`
+##### `IoT.DriverCore.S7PlcRx.Performance.BenchmarkConfig`
 Source: `Performance/BenchmarkConfig.cs:12`
 
 Represents the configuration settings for benchmark tests, including parameters for latency, throughput, and reliability measurements. <remarks>Use this class to specify the number and duration of various benchmark tests when running performance evaluations. All properties are configurable to tailor the benchmarking process to specific requirements.</remarks>
@@ -1604,7 +1660,7 @@ Represents the configuration settings for benchmark tests, including parameters 
 | `public TimeSpan ThroughputTestDuration get; set; } = TimeSpan.FromSeconds(10);` | Gets or sets the duration for throughput testing. |
 | `public int ReliabilityTestCount get; set; } = 20;` | Gets or sets the number of reliability tests to perform. |
 
-##### `S7PlcRx.Performance.BenchmarkResult`
+##### `IoT.DriverCore.S7PlcRx.Performance.BenchmarkResult`
 Source: `Performance/BenchmarkResult.cs:15`
 
 Represents the results of a performance benchmark, including timing, latency, throughput, reliability, and any errors encountered during execution. <remarks>Use this class to access detailed metrics and diagnostic information from a completed benchmark run. The properties provide summary statistics such as average, minimum, and maximum latency, as well as overall reliability and score. Errors encountered during benchmarking are available in the <see cref="Errors"/> collection for troubleshooting. This type is immutable except for its settable properties; thread safety is not guaranteed if modified concurrently.</remarks>
@@ -1623,7 +1679,7 @@ Represents the results of a performance benchmark, including timing, latency, th
 | `public List<string> Errors get; } = [];` | Gets any errors encountered during benchmarking. |
 | `public TimeSpan TotalDuration => ...` | Gets the total benchmark duration. |
 
-##### `S7PlcRx.Performance.HighPerformanceTagGroup<T>`
+##### `IoT.DriverCore.S7PlcRx.Performance.HighPerformanceTagGroup<T>`
 Source: `Performance/HighPerformanceTagGroup.cs:18`
 
 Provides high-performance batch operations for reading, writing, and observing a group of PLC tags as a single unit. <remarks>This class is designed to optimize communication with a PLC by grouping related tags and minimizing individual polling. It supports efficient batch reads and writes, and exposes an observable stream for monitoring group state changes. Instances of this class are not thread-safe; external synchronization may be required if accessed concurrently.</remarks> <typeparam name="T">The type of value associated with each PLC tag in the group.</typeparam>
@@ -1638,7 +1694,7 @@ Provides high-performance batch operations for reading, writing, and observing a
 | `public async Task WriteAll(Dictionary<string, T> values)` | Writes all specified values to the PLC in a single batch operation. <remarks>Entries in the dictionary with tag names not recognized by the PLC are ignored. This method performs the write operation asynchronously and does not block the calling thread.</remarks> <param name="values">A dictionary containing tag names as keys and their corresponding values to be written. Only entries with tag names recognized by the PLC will be processed.</param> <returns>A task that represents the asynchronous write operation.</returns> |
 | `public void Dispose()` | Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources. |
 
-##### `S7PlcRx.Performance.PerformanceAnalysis`
+##### `IoT.DriverCore.S7PlcRx.Performance.PerformanceAnalysis`
 Source: `Performance/PerformanceAnalysis.cs:13`
 
 Represents the results and metrics of a performance analysis, including time intervals, tag change statistics, and optimization recommendations. <remarks>Use this class to encapsulate data collected during a performance monitoring session, such as the frequency of tag changes and suggested improvements. The properties provide access to both raw metrics and calculated values, enabling further reporting or decision-making based on the analysis.</remarks>
@@ -1653,20 +1709,20 @@ Represents the results and metrics of a performance analysis, including time int
 | `public double AverageChangesPerTag get; set; }` | Gets or sets the average changes per tag. |
 | `public List<string> Recommendations get; set; } = [];` | Gets or sets the optimization recommendations. |
 
-##### `S7PlcRx.Performance.PerformanceExtensions`
+##### `IoT.DriverCore.S7PlcRx.Performance.PerformanceExtensions`
 Source: `Performance/PerformanceExtensions.cs:19`
 
 Provides extension methods for IRxS7 PLC instances to enable advanced performance monitoring, optimized read and write operations, and benchmarking capabilities. <remarks>The methods in this class facilitate efficient interaction with PLCs by offering features such as real-time performance metrics, automatic grouping and batching of read/write operations, and comprehensive benchmarking. These extensions are designed to improve throughput, reliability, and observability when working with industrial automation systems. All methods require a valid IRxS7 instance and may throw exceptions if invalid arguments are supplied. Thread safety is ensured for performance data collection and metrics aggregation.</remarks>
 
 | Member | Summary |
 |---|---|
-| `public static IObservable<PerformanceMetrics> MonitorPerformance( this IRxS7 plc, TimeSpan? monitoringInterval = null)` | Monitors the performance of the specified PLC and provides periodic updates as an observable sequence of performance metrics. <remarks>The returned observable begins emitting metrics immediately and continues at the specified interval. Metrics include connection status, tag counts, operation rates, and error rates. The observable is hot and shared among subscribers; unsubscribing from all observers will stop monitoring until a new subscription is made.</remarks> <param name="plc">The PLC instance to monitor. Cannot be null.</param> <param name="monitoringInterval">The interval at which performance metrics are sampled. If null, defaults to 30 seconds.</param> <returns>An observable sequence of <see cref="PerformanceMetrics"/> objects containing performance data for the PLC, emitted at each monitoring interval.</returns> <exception cref="ArgumentNullException">Thrown if <paramref name="plc"/> is null.</exception> |
-| `public static async Task<Dictionary<string, T?>> ReadOptimized<T>( this IRxS7 plc, IEnumerable<string> tagNames, Optimization.ReadOptimizationConfig? optimizationConfig = null)` | Reads the specified tags from the PLC using optimized grouping and optional parallelization, returning a dictionary of tag names and their corresponding values. <remarks>Tags are grouped by data block for efficient reading. When parallel reads are enabled in the optimization configuration, tag groups are read concurrently to improve performance. The method records performance metrics and errors for diagnostic purposes. If an error occurs while reading a tag, the operation is aborted and an exception is thrown.</remarks> <typeparam name="T">The type of the value to read for each tag.</typeparam> <param name="plc">The PLC instance from which to read tag values. Cannot be null.</param> <param name="tagNames">A collection of tag names to read from the PLC. Cannot be null. If empty, an empty dictionary is returned.</param> <param name="optimizationConfig">An optional configuration that controls read optimization behavior, such as enabling parallel reads and setting inter-group delays. If null, default optimization settings are used.</param> <returns>A dictionary mapping each requested tag name to its read value. If a tag cannot be read, an exception is thrown and the dictionary may be incomplete.</returns> <exception cref="ArgumentNullException">Thrown if <paramref name="plc"/> or <paramref name="tagNames"/> is null.</exception> <exception cref="InvalidOperationException">Thrown if reading a tag fails due to a PLC communication error or invalid tag name.</exception> |
-| `public static async Task<Optimization.WriteOptimizationResult> WriteOptimized<T>( this IRxS7 plc, Dictionary<string, T> values, Optimization.WriteOptimizationConfig? optimizationConfig = null)` | Writes multiple values to the PLC in an optimized manner, grouping operations and optionally verifying writes for accuracy. <remarks>Writes are grouped by data block for performance optimization. If parallel writes are enabled in the configuration, write operations within each group are performed concurrently. When write verification is enabled, each value is read back after writing to ensure accuracy. Delays between groups can be configured to control write pacing. The method is thread-safe and intended for batch write scenarios to improve throughput and reliability.</remarks> <typeparam name="T">The type of the values to be written to the PLC.</typeparam> <param name="plc">The PLC interface to which the values will be written. Cannot be null.</param> <param name="values">A dictionary containing tag names and their corresponding values to write. Cannot be null.</param> <param name="optimizationConfig">An optional configuration object that controls optimization behavior, such as enabling parallel writes, write verification, and inter-group delays. If null, default optimization settings are used.</param> <returns>A task that represents the asynchronous operation. The result contains details about successful and failed writes, timing information, and any overall errors encountered during the operation.</returns> <exception cref="ArgumentNullException">Thrown if <paramref name="plc"/> or <paramref name="values"/> is null.</exception> <exception cref="InvalidOperationException">Thrown if write verification is enabled and a written value does not match the value read back from the PLC.</exception> |
-| `public static async Task<BenchmarkResult> RunBenchmark( this IRxS7 plc, BenchmarkConfig? benchmarkConfig = null)` | Runs a set of benchmark tests on the specified PLC, measuring latency, throughput, and reliability. <remarks>The returned <see cref="BenchmarkResult"/> includes timing information, test scores, and any errors encountered during benchmarking. The method performs multiple tests and aggregates results to provide an overall score. This method does not throw on benchmark failures; errors are recorded in the result.</remarks> <param name="plc">The PLC instance to benchmark. Cannot be null.</param> <param name="benchmarkConfig">An optional configuration object specifying benchmark parameters. If null, default settings are used.</param> <returns>A task that represents the asynchronous operation. The result contains detailed benchmark metrics and scores for the PLC.</returns> <exception cref="ArgumentNullException">Thrown if <paramref name="plc"/> is null.</exception> |
-| `public static PerformanceStatistics GetPerformanceStatistics(this IRxS7 plc)` | Retrieves aggregated performance statistics for the specified PLC connection, including operation counts, error rates, response times, and connection metrics. <remarks>The returned statistics reflect metrics collected since the application started or since the PLC connection was first established. This method is thread-safe and can be called concurrently from multiple threads.</remarks> <param name="plc">The PLC connection for which to obtain performance statistics. Cannot be null.</param> <returns>A PerformanceStatistics object containing metrics such as total operations, error rate, average response time, connection uptime, and reconnection count for the specified PLC.</returns> <exception cref="ArgumentNullException">Thrown if <paramref name="plc"/> is null.</exception> |
+| `PerformanceExtensions.MonitorPerformance(IRxS7, TimeSpan?)` | Returns periodic connection, tag, rate, and error metrics. |
+| `PerformanceExtensions.ReadOptimizedAsync<T>(IRxS7, IEnumerable<string>, T typeMarker, ReadOptimizationConfig?)` | Reads optimized groups and returns the typed values. |
+| `PerformanceExtensions.WriteOptimizedAsync<T>(IRxS7, Dictionary<string,T>, WriteOptimizationConfig?)` | Writes optimized groups and returns detailed timing/outcome information. |
+| `PerformanceExtensions.RunBenchmarkAsync(IRxS7, BenchmarkConfig?)` | Runs latency, throughput, and reliability checks and records errors in the result. |
+| `PerformanceExtensions.GetPerformanceStatistics(IRxS7)` | Returns aggregate connection performance statistics. |
 
-##### `S7PlcRx.Performance.PerformanceMetrics`
+##### `IoT.DriverCore.S7PlcRx.Performance.PerformanceMetrics`
 Source: `Performance/PerformanceMetrics.cs:13`
 
 Represents a set of performance metrics for a programmable logic controller (PLC) at a specific point in time. <remarks>This class provides properties for tracking key operational statistics of a PLC, including connection status, tag activity, performance rates, and error metrics. It is typically used to monitor and analyze PLC performance in industrial automation scenarios. All properties are read-write, allowing metrics to be set or updated as needed.</remarks>
@@ -1684,7 +1740,7 @@ Represents a set of performance metrics for a programmable logic controller (PLC
 | `public TimeSpan ConnectionUptime get; set; }` | Gets or sets the connection uptime. |
 | `public int ReconnectionCount get; set; }` | Gets or sets the number of reconnections. |
 
-##### `S7PlcRx.Performance.PerformanceStatistics`
+##### `IoT.DriverCore.S7PlcRx.Performance.PerformanceStatistics`
 Source: `Performance/PerformanceStatistics.cs:14`
 
 Represents a set of performance statistics for a programmable logic controller (PLC) connection, including operation counts, error metrics, response times, and connection status information. <remarks>Use this class to track and analyze the operational performance and reliability of a PLC connection over time. The statistics provided can assist in monitoring system health, diagnosing issues, and optimizing performance. All properties are read-write, allowing for aggregation and updating of statistics as needed. This class is not thread-safe; synchronize access if used concurrently.</remarks>
@@ -1701,7 +1757,7 @@ Represents a set of performance statistics for a programmable logic controller (
 | `public int ReconnectionCount get; set; }` | Gets or sets the number of reconnections. |
 | `public DateTime LastUpdated get; set; }` | Gets or sets when these statistics were last updated. |
 
-##### `S7PlcRx.Performance.TagPerformanceMetrics`
+##### `IoT.DriverCore.S7PlcRx.Performance.TagPerformanceMetrics`
 Source: `Performance/TagPerformanceMetrics.cs:12`
 
 Represents performance metrics for a specific tag, including operation counts, timing statistics, and success rates. <remarks>Use this class to track and analyze the performance of tag-related operations, such as reads and writes, over time. The metrics provided can help identify bottlenecks, monitor reliability, and optimize system performance. All properties are intended to be updated as new operation data becomes available.</remarks>
@@ -1717,9 +1773,9 @@ Represents performance metrics for a specific tag, including operation counts, t
 | `public double SuccessRate get; set; }` | Gets or sets the success rate (0.0 to 1.0). |
 | `public DateTime LastOperationTime get; set; }` | Gets or sets the last operation timestamp. |
 
-#### Namespace `S7PlcRx.PlcTypes`
+#### Namespace `IoT.DriverCore.S7PlcRx.PlcTypes`
 
-##### `S7PlcRx.PlcTypes.Bit`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.Bit`
 Source: `PlcTypes/Bit.cs:11`
 
 Contains the conversion methods to convert Bit from S7 plc to C#.
@@ -1736,7 +1792,7 @@ Contains the conversion methods to convert Bit from S7 plc to C#.
 | `public static bool[] GetBits(ReadOnlySpan<byte> bytes, ReadOnlySpan<(int byteIndex, int bitIndex)> bitPositions)` | Extracts the values of specified bits from a sequence of bytes. <remarks>If a specified bit position refers to an index outside the bounds of the input span, an exception may be thrown.</remarks> <param name="bytes">The span of bytes from which bits will be read.</param> <param name="bitPositions">A span of tuples specifying the positions of bits to extract. Each tuple contains the zero-based index of the byte and the zero-based index of the bit within that byte.</param> <returns>An array of Boolean values indicating the state of each requested bit. Each element is <see langword="true"/> if the corresponding bit is set; otherwise, <see langword="false"/>.</returns> |
 | `public static void SetBits(Span<byte> bytes, ReadOnlySpan<(int byteIndex, int bitIndex, bool value)> bitUpdates)` | Sets the specified bits in the provided byte span according to the given updates. <remarks>Each tuple in <paramref name="bitUpdates"/> must reference a valid byte and bit index within <paramref name="bytes"/>. Modifying bits outside the bounds of <paramref name="bytes"/> may result in undefined behavior.</remarks> <param name="bytes">The span of bytes in which bits will be set or cleared. Each update modifies a bit within this span.</param> <param name="bitUpdates">A read-only span of tuples specifying the byte index, bit index, and value to set for each bit. Each tuple indicates which bit to update and whether to set it to <see langword="true"/> or <see langword="false"/>.</param> |
 
-##### `S7PlcRx.PlcTypes.Boolean`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.Boolean`
 Source: `PlcTypes/Boolean.cs:13`
 
 Provides static methods for manipulating individual bits within a byte value. <remarks>This class includes utility methods for reading, setting, and clearing specific bits in a byte. All bit indices are zero-based, ranging from 0 (least significant bit) to 7 (most significant bit). These methods are useful for low-level operations such as flag management, bitmasking, or protocol handling where direct bit manipulation is required.</remarks>
@@ -1749,7 +1805,7 @@ Provides static methods for manipulating individual bits within a byte value. <r
 | `public static byte ClearBit(byte value, int bit)` | Resets the value of a bit to 0 (false), given the address of the bit. Returns a copy of the value with the bit cleared. <param name="value">The input value to modify.</param> <param name="bit">The index (zero based) of the bit to clear.</param> <returns>The modified value with the bit at index cleared.</returns> |
 | `public static void ClearBit(ref byte value, int bit) => ...` | Resets the value of a bit to 0 (false), given the address of the bit. <param name="value">The input value to modify.</param> <param name="bit">The index (zero based) of the bit to clear.</param> |
 
-##### `S7PlcRx.PlcTypes.Byte`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.Byte`
 Source: `PlcTypes/Byte.cs:13`
 
 Provides utility methods for converting and manipulating byte values and byte arrays. <remarks>This static class includes methods for converting between single byte values and arrays or spans, as well as writing byte data to spans. All members are static and designed for efficient, low-level byte operations. Methods in this class do not perform validation beyond basic length checks and do not handle multi-byte conversions or encoding.</remarks>
@@ -1762,7 +1818,7 @@ Provides utility methods for converting and manipulating byte values and byte ar
 | `public static byte FromSpan(ReadOnlySpan<byte> bytes)` | Returns the first byte from the specified read-only span. <param name="bytes">A read-only span of bytes from which to retrieve the first byte. Must contain at least one byte.</param> <returns>The first byte in the <paramref name="bytes"/> span.</returns> <exception cref="ArgumentException">Thrown when <paramref name="bytes"/> does not contain at least one byte.</exception> |
 | `public static void ToSpan(ReadOnlySpan<byte> values, Span<byte> destination)` | Copies the contents of the specified read-only byte span to the destination span. <param name="values">The read-only span containing the bytes to copy.</param> <param name="destination">The span that receives the copied bytes. Must be at least as large as <paramref name="values"/>.</param> <exception cref="ArgumentException">Thrown when <paramref name="destination"/> is smaller than <paramref name="values"/>.</exception> |
 
-##### `S7PlcRx.PlcTypes.ByteArray`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray`
 Source: `PlcTypes/ByteArray.cs:14`
 
 Provides a dynamically sized buffer for accumulating bytes, with efficient memory management using array pooling. <remarks>The buffer automatically grows as data is added. The internal array is rented from the shared array pool and returned when disposed. This class is not thread-safe.</remarks> <param name="size">The initial capacity of the internal buffer, in bytes. Must be greater than zero.</param>
@@ -1782,7 +1838,7 @@ Provides a dynamically sized buffer for accumulating bytes, with efficient memor
 | `public bool TryCopyTo(Span<byte> destination)` | Attempts to copy the written bytes to the specified destination buffer. <remarks>No data is copied if the destination buffer is too small. The method does not modify the destination buffer if it returns false.</remarks> <param name="destination">The buffer to which the written bytes will be copied. Must have a length greater than or equal to the number of bytes written.</param> <returns>true if the copy operation succeeds; otherwise, false.</returns> |
 | `public void Dispose()` | Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources. |
 
-##### `S7PlcRx.PlcTypes.Class`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.Class`
 Source: `PlcTypes/Class.cs:19`
 
 Provides static methods for serializing and deserializing class and struct instances to and from byte arrays, as well as calculating the size of a class in bytes for serialization purposes. <remarks>This class is intended for scenarios where objects need to be converted to a byte representation, such as communication with PLCs or other systems requiring structured binary formats. All methods operate statically and require the caller to supply instances and byte arrays as needed. Properties within serialized classes must be accessible and, for string fields, decorated with the appropriate S7StringAttribute. Methods may throw exceptions if required attributes are missing or if input values are invalid. Thread safety is not guaranteed; callers should ensure appropriate synchronization if accessing shared objects.</remarks>
@@ -1793,7 +1849,7 @@ Provides static methods for serializing and deserializing class and struct insta
 | `public static double FromBytes(object sourceClass, byte[] bytes, double numBytes = 0, bool isInnerClass = false)` | Populates the properties of the specified object instance from the provided byte array, deserializing each property value according to its type. <remarks>Properties that are arrays are deserialized element by element. The method updates numBytes to reflect the number of bytes read. If bytes is shorter than required for all properties, only the available bytes are used.</remarks> <param name="sourceClass">The object instance whose properties will be set from the byte array. Must not be null.</param> <param name="bytes">The byte array containing serialized property values to be assigned to the object. If null, no properties are set and the method returns the value of numBytes.</param> <param name="numBytes">The starting offset, in bytes, within the byte array from which to begin deserialization. This value is incremented as properties are read.</param> <param name="isInnerClass">Indicates whether the object instance represents an inner class. This may affect how properties are deserialized.</param> <returns>The total number of bytes consumed from the byte array during deserialization.</returns> <exception cref="ArgumentNullException">Thrown if sourceClass is null.</exception> <exception cref="ArgumentException">Thrown if a property on sourceClass that is expected to be an array is not initialized.</exception> |
 | `public static double ToBytes(object sourceClass, byte[] bytes, double numBytes = 0.0)` | Serializes the accessible properties of the specified source object into the provided byte array, starting at the given offset. <remarks>If a property of the source object is an array, its elements are serialized sequentially into the byte array. Serialization stops if the end of the byte array is reached before all properties are written.</remarks> <param name="sourceClass">The object whose properties will be serialized into the byte array. Cannot be null. All accessible properties must have non-null values.</param> <param name="bytes">The byte array that receives the serialized property values. Cannot be null.</param> <param name="numBytes">The starting offset, in bytes, within the array at which serialization begins. If not specified, serialization starts at the beginning of the array.</param> <returns>The total number of bytes written to the array after serialization is complete.</returns> <exception cref="ArgumentNullException">Thrown if <paramref name="sourceClass"/> or <paramref name="bytes"/> is null.</exception> <exception cref="ArgumentException">Thrown if any accessible property of <paramref name="sourceClass"/> is null.</exception> |
 
-##### `S7PlcRx.PlcTypes.Counter`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.Counter`
 Source: `PlcTypes/Counter.cs:15`
 
 Provides static methods for converting between S7 Counter byte representations and <see cref="ushort"/> values. <remarks>The <see cref="Counter"/> class supports parsing and serializing S7 Counter values, which are commonly used in Siemens S7 PLC communication protocols. All methods use big-endian byte order, with the high byte first, to match the S7 Counter format. This class is thread-safe as it contains only static methods and does not maintain any internal state.</remarks>
@@ -1811,7 +1867,7 @@ Provides static methods for converting between S7 Counter byte representations a
 | `public static void ToSpan(ReadOnlySpan<ushort> values, Span<byte> destination)` | Copies the contents of a span of 16-bit unsigned integers into a span of bytes, encoding each value as two bytes in little-endian order. <remarks>Each <see cref="ushort"/> value in <paramref name="values"/> is encoded as two bytes in little-endian format and written sequentially to <paramref name="destination"/>. The method does not allocate additional memory.</remarks> <param name="values">The read-only span of 16-bit unsigned integers to copy from.</param> <param name="destination">The span of bytes to copy the encoded values into. Must be at least twice the length of <paramref name="values"/>.</param> <exception cref="ArgumentException">Thrown when <paramref name="destination"/> is not large enough to hold the encoded bytes.</exception> |
 | `public static byte[] ToByteArray(ushort[] value)` | Converts an array of 16-bit unsigned integers to a byte array. <param name="value">An array of <see cref="ushort"/> values to convert. Cannot be <see langword="null"/>.</param> <returns>A byte array representing the binary data of the input <see cref="ushort"/> array.</returns> <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is <see langword="null"/>.</exception> |
 
-##### `S7PlcRx.PlcTypes.DInt`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.DInt`
 Source: `PlcTypes/DInt.cs:17`
 
 Provides static methods for converting between Siemens S7 DInt (32-bit signed integer) representations and .NET int values. <remarks>This class supports conversion between S7 DInt values, which use big-endian byte order, and .NET int values. Methods are provided for reading and writing single or multiple DInt values from and to byte arrays and spans. All methods assume S7 DInt format and handle endianness as required. This class is intended for internal use when working with S7 PLC data structures.</remarks>
@@ -1830,7 +1886,7 @@ Provides static methods for converting between Siemens S7 DInt (32-bit signed in
 | `public static void ToSpan(ReadOnlySpan<int> values, Span<byte> destination)` | Writes the binary representation of each 32-bit integer in the specified read-only span to the provided destination span of bytes. <param name="values">A read-only span of 32-bit integers to convert to their binary representation.</param> <param name="destination">A span of bytes that receives the binary data. Must be at least four times the length of <paramref name="values"/>.</param> <exception cref="ArgumentException">Thrown if <paramref name="destination"/> is not large enough to contain the binary representations of all values.</exception> |
 | `public static byte[] ToByteArray(int[] value)` | Converts an array of 32-bit integers to its equivalent byte array representation. <param name="value">An array of 32-bit integers to convert. Cannot be null.</param> <returns>A byte array containing the binary representation of the input integer array. The length of the returned array is four times the length of the input array.</returns> |
 
-##### `S7PlcRx.PlcTypes.DWord`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.DWord`
 Source: `PlcTypes/DWord.cs:16`
 
 Provides utility methods for converting between S7 DWord (4-byte) representations and unsigned 32-bit integers (uint). <remarks>All conversions assume S7 DWord format, which uses big-endian byte order. These methods are intended for working with Siemens S7 PLC data or other protocols that represent 32-bit unsigned integers in big-endian format. Methods throw exceptions if provided buffers are too small to contain a DWord value.</remarks>
@@ -1848,7 +1904,7 @@ Provides utility methods for converting between S7 DWord (4-byte) representation
 | `public static void ToSpan(ReadOnlySpan<uint> values, Span<byte> destination)` | Converts each 32-bit unsigned integer in the specified read-only span to its byte representation and writes the result to the provided destination span. <param name="values">A read-only span of 32-bit unsigned integers to convert to bytes.</param> <param name="destination">A span of bytes that receives the byte representations of the input values. Must be at least four times the length of <paramref name="values"/>.</param> <exception cref="ArgumentException">Thrown when <paramref name="destination"/> is not large enough to contain the byte representations of all elements in <paramref name="values"/>.</exception> |
 | `public static byte[] ToByteArray(uint[] value)` | Converts the specified array of 32-bit unsigned integers to a byte array. <param name="value">An array of 32-bit unsigned integers to convert. Cannot be null.</param> <returns>A byte array containing the binary representation of the input values. The length of the returned array is four times the length of the input array.</returns> |
 
-##### `S7PlcRx.PlcTypes.DateTime`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.DateTime`
 Source: `PlcTypes/DateTime.cs:11`
 
 Contains the methods to convert between <see cref="T:System.DateTime"/> and S7 representation of datetime values.
@@ -1866,7 +1922,7 @@ Contains the methods to convert between <see cref="T:System.DateTime"/> and S7 r
 | `public static byte[] ToByteArray(System.DateTime[] dateTimes)` | Converts an array of <see cref="T:System.DateTime"/> values to a byte array. <param name="dateTimes">The DateTime values to convert.</param> <returns>A byte array containing the S7 date time representations of <paramref name="dateTimes"/>.</returns> |
 | `public static void ToSpan(ReadOnlySpan<System.DateTime> dateTimes, Span<byte> destination)` | Converts multiple DateTime values to the specified span. <param name="dateTimes">The DateTime values.</param> <param name="destination">The destination span.</param> |
 
-##### `S7PlcRx.PlcTypes.DateTimeLong`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.DateTimeLong`
 Source: `PlcTypes/DateTimeLong.cs:11`
 
 Contains the methods to convert between <see cref="T:System.DateTime" /> and S7 representation of DateTimeLong (DTL) values.
@@ -1885,7 +1941,7 @@ Contains the methods to convert between <see cref="T:System.DateTime" /> and S7 
 | `public static byte[] ToByteArray(System.DateTime[] dateTimes)` | Converts an array of <see cref="T:System.DateTime" /> values to a byte array. <param name="dateTimes">The DateTime values to convert.</param> <returns>A byte array containing the S7 DateTimeLong representations of <paramref name="dateTimes" />.</returns> |
 | `public static void ToSpan(ReadOnlySpan<System.DateTime> dateTimes, Span<byte> destination)` | Converts multiple DateTime values to the specified span. <param name="dateTimes">The DateTime values.</param> <param name="destination">The destination span.</param> |
 
-##### `S7PlcRx.PlcTypes.Int`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.Int`
 Source: `PlcTypes/Int.cs:16`
 
 Provides static methods for converting between S7 Int (16-bit signed integer) representations and .NET types, including byte arrays and spans. <remarks>This class is intended for working with Siemens S7 PLC data formats, which use big-endian byte order for 16-bit signed integers. All methods assume S7 Int format unless otherwise specified. The class is internal and not intended for direct use outside of the containing assembly.</remarks>
@@ -1904,7 +1960,7 @@ Provides static methods for converting between S7 Int (16-bit signed integer) re
 | `public static void ToSpan(ReadOnlySpan<short> values, Span<byte> destination)` | Writes the contents of a span of 16-bit signed integers to a span of bytes in little-endian order. <param name="values">The source span containing the 16-bit signed integer values to write.</param> <param name="destination">The destination span where the bytes will be written. Must be at least twice the length of <paramref name="values"/>.</param> <exception cref="ArgumentException">Thrown if <paramref name="destination"/> is not large enough to contain the converted bytes.</exception> |
 | `public static byte[] ToByteArray(short[] value)` | Converts an array of 16-bit signed integers to a byte array. <param name="value">An array of 16-bit signed integers to convert. Cannot be null.</param> <returns>A byte array containing the binary representation of the input values.</returns> |
 
-##### `S7PlcRx.PlcTypes.LReal`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.LReal`
 Source: `PlcTypes/LReal.cs:17`
 
 Provides static methods for converting between S7 LReal (64-bit floating point) representations and .NET double values. <remarks>The methods in this class handle conversion between S7 LReal format (used in Siemens S7 PLCs) and .NET double values, including proper handling of endianness. All methods are static and intended for internal use when working with S7 protocol data. This class is not thread-safe, but all members are stateless and safe for concurrent use.</remarks>
@@ -1920,10 +1976,10 @@ Provides static methods for converting between S7 LReal (64-bit floating point) 
 | `public static double[] ToArray(ReadOnlySpan<byte> bytes)` | Converts a read-only span of bytes to an array of double-precision floating-point values. <remarks>The method interprets each consecutive group of 8 bytes in the span as a double-precision floating-point value. The conversion uses the system's endianness. Any remaining bytes that do not form a complete double are ignored.</remarks> <param name="bytes">A read-only span of bytes representing the binary data to convert. The length must be a multiple of 8, as each double value is represented by 8 bytes.</param> <returns>An array of double values parsed from the specified byte span. The length of the array is equal to the number of complete double values in the input.</returns> |
 | `public static byte[] ToByteArray(double value)` | Converts the specified double-precision floating-point value to its equivalent 8-byte array representation. <param name="value">The double-precision floating-point number to convert.</param> <returns>A byte array containing the 8-byte binary representation of the specified value.</returns> |
 | `public static void ToSpan(double value, Span<byte> destination)` | Writes the specified double-precision floating-point value to the provided span in big-endian byte order. <remarks>This method writes the value in big-endian format, which is commonly used in certain binary protocols such as Siemens S7. If the current platform is little-endian, the bytes are reversed to ensure correct ordering.</remarks> <param name="value">The double-precision floating-point value to write to the span.</param> <param name="destination">The span of bytes that will receive the 8-byte big-endian representation of the value. Must be at least 8 bytes in length.</param> <exception cref="ArgumentException">Thrown if the length of destination is less than 8 bytes.</exception> |
-| `public static void ToSpan(ReadOnlySpan<double> values, Span<byte> destination)` | Writes each double-precision floating-point value from the specified read-only span to the specified destination span as a sequence of bytes. <param name="values">The read-only span of double values to convert to their byte representations.</param> <param name="destination">The span of bytes that receives the byte representations of the values. Must be at least values.Length × 8 bytes in length.</param> <exception cref="ArgumentException">Thrown when the length of destination is less than values.Length × 8 bytes.</exception> |
+| `public static void ToSpan(ReadOnlySpan<double> values, Span<byte> destination)` | Writes each double-precision value to the destination as S7 bytes. The destination must be at least `values.Length * 8` bytes; otherwise it throws `ArgumentException`. |
 | `public static byte[] ToByteArray(double[] value)` | Converts an array of double-precision floating-point numbers to a byte array representation. <param name="value">The array of double values to convert. Cannot be null.</param> <returns>A byte array containing the binary representation of the input double array. The array will be empty if the input array is empty.</returns> |
 
-##### `S7PlcRx.PlcTypes.Real`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.Real`
 Source: `PlcTypes/Real.cs:16`
 
 Provides static methods for converting between Siemens S7 Real (4-byte IEEE 754 floating-point) representations and .NET float values. <remarks>The methods in this class handle endianness according to the S7 protocol, which uses big-endian byte order. Use these methods to serialize and deserialize float values when communicating with Siemens S7 PLCs or working with S7 Real data formats. All methods are static and intended for internal use.</remarks>
@@ -1939,7 +1995,7 @@ Provides static methods for converting between Siemens S7 Real (4-byte IEEE 754 
 | `public static float[] ToArray(byte[] bytes) => ...` | Converts a byte array to an array of single-precision floating-point values. <remarks>The method interprets each group of four bytes in the input array as a single-precision floating-point value, using the default endianness of the system. If the length of <paramref name="bytes"/> is not a multiple of 4, an exception may be thrown.</remarks> <param name="bytes">The byte array containing the binary representation of the floating-point values. The length must be a multiple of 4.</param> <returns>An array of <see cref="float"/> values converted from the specified byte array.</returns> |
 | `public static float[] ToArray(ReadOnlySpan<byte> bytes)` | Converts a read-only span of bytes to an array of 32-bit floating-point values. <remarks>The method interprets each consecutive group of 4 bytes in the input span as a single-precision floating-point value. The byte order and format must match the expected representation for floats on the current platform.</remarks> <param name="bytes">The read-only span of bytes to convert. The length must be a multiple of 4, as each float consists of 4 bytes.</param> <returns>An array of 32-bit floating-point values parsed from the input byte span.</returns> |
 
-##### `S7PlcRx.PlcTypes.S7String`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.S7String`
 Source: `PlcTypes/S7String.cs:15`
 
 Provides methods for encoding and decoding S7 string values to and from byte arrays using the S7 protocol format. <remarks>This static class supports conversion between .NET strings and the S7 string format used in Siemens PLCs, which includes a 2-byte header indicating the reserved and actual string lengths. The encoding used for string conversion can be configured via the StringEncoding property. All methods are thread-safe.</remarks>
@@ -1947,14 +2003,14 @@ Provides methods for encoding and decoding S7 string values to and from byte arr
 | Member | Summary |
 |---|---|
 | `public static Encoding StringEncoding` | Gets or sets the Encoding used when serializing and deserializing S7String (Encoding.ASCII by default). <value> The string encoding. </value> <exception cref="System.ArgumentNullException">StringEncoding.</exception> <exception cref="ArgumentNullException">StringEncoding must not be null.</exception> |
-| `public static string FromByteArray(byte[] bytes) => ...` | Converts S7 bytes to a string. <param name="bytes">The bytes.</param> <returns>A string.</returns> <exception cref="S7PlcRx.PlcException"> Malformed S7 String / too short or Malformed S7 String / length larger than capacity or Failed to parse {VarType.S7String} from data. Following fields were read: size: '{size}', actual length: '{length}', total number of bytes (including header): '{bytes.Length}'. </exception> |
-| `public static string FromSpan(ReadOnlySpan<byte> bytes)` | Converts S7 bytes from span to a string. <param name="bytes">The bytes span.</param> <returns>A string.</returns> <exception cref="S7PlcRx.PlcException"> Malformed S7 String / too short or Malformed S7 String / length larger than capacity or Failed to parse {VarType.S7String} from data. Following fields were read: size: '{size}', actual length: '{length}', total number of bytes (including header): '{bytes.Length}'. </exception> |
+| `public static string FromByteArray(byte[] bytes) => ...` | Converts S7 bytes to a string. <param name="bytes">The bytes.</param> <returns>A string.</returns> <exception cref="IoT.DriverCore.S7PlcRx.PlcException"> Malformed S7 String / too short or Malformed S7 String / length larger than capacity or Failed to parse {VarType.S7String} from data. Following fields were read: size: '{size}', actual length: '{length}', total number of bytes (including header): '{bytes.Length}'. </exception> |
+| `public static string FromSpan(ReadOnlySpan<byte> bytes)` | Converts S7 bytes from span to a string. <param name="bytes">The bytes span.</param> <returns>A string.</returns> <exception cref="IoT.DriverCore.S7PlcRx.PlcException"> Malformed S7 String / too short or Malformed S7 String / length larger than capacity or Failed to parse {VarType.S7String} from data. Following fields were read: size: '{size}', actual length: '{length}', total number of bytes (including header): '{bytes.Length}'. </exception> |
 | `public static byte[] ToByteArray(string? value, int reservedLength)` | Converts a <see cref="T:string"/> to S7 string with 2-byte header. <param name="value">The string to convert to byte array.</param> <param name="reservedLength">The length (in characters) allocated in PLC for the string.</param> <returns>A <see cref="T:byte[]" /> containing the string header and string value with a maximum length of <paramref name="reservedLength"/> + 2.</returns> |
 | `public static int ToSpan(string? value, int reservedLength, Span<byte> destination)` | Converts a string to S7 string format in the specified span. <param name="value">The string to convert.</param> <param name="reservedLength">The length allocated in PLC for the string.</param> <param name="destination">The destination span.</param> <returns>The number of bytes written.</returns> <exception cref="ArgumentNullException">value.</exception> <exception cref="ArgumentException"> The maximum string length supported is 254. or Destination span is too small. </exception> |
 | `public static bool TryToSpan(string? value, int reservedLength, Span<byte> destination, out int bytesWritten)` | Tries to convert a string to S7 string format in the specified span. <param name="value">The string to convert.</param> <param name="reservedLength">The length allocated in PLC for the string.</param> <param name="destination">The destination span.</param> <param name="bytesWritten">The number of bytes written.</param> <returns>True if successful, false if the destination is too small.</returns> |
 | `public static int GetByteLength(int reservedLength) => ...` | Gets the total byte length for an S7 string with the specified reserved length. <param name="reservedLength">The reserved length for the string.</param> <returns>The total byte length including header.</returns> |
 
-##### `S7PlcRx.PlcTypes.S7StringAttribute`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.S7StringAttribute`
 Source: `PlcTypes/S7StringAttribute.cs:16`
 
 | Member | Summary |
@@ -1964,7 +2020,7 @@ Source: `PlcTypes/S7StringAttribute.cs:16`
 | `public int ReservedLength get; }` | Gets the number of characters reserved for the value. |
 | `public int ReservedLengthInBytes => ...` | Gets the total number of bytes reserved for the string, including any protocol-specific header or length fields. <remarks>The reserved length in bytes depends on the string type. For S7String, the value includes 2 bytes for header information; for S7WString, it includes 4 bytes for header information and accounts for UTF-16 encoding. This value is typically used to allocate buffers or validate data boundaries when working with S7 string types.</remarks> |
 
-##### `S7PlcRx.PlcTypes.S7WString`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.S7WString`
 Source: `PlcTypes/S7WString.cs:15`
 
 Provides static methods for converting between S7 WString byte arrays and .NET strings. <remarks>The S7WString class supports encoding and decoding of S7 WString values, which are commonly used in Siemens S7 PLCs. All methods are static and thread-safe. The S7 WString format includes a 4-byte header specifying the reserved and actual string lengths, followed by the UTF-16 encoded string data.</remarks>
@@ -1974,7 +2030,7 @@ Provides static methods for converting between S7 WString byte arrays and .NET s
 | `public static string FromByteArray(byte[] bytes)` | Converts a byte array containing an S7 WString value to its corresponding .NET string representation. <remarks>The input array must follow the S7 WString format, where the first two bytes specify the maximum capacity, the next two bytes specify the actual string length, and the remaining bytes contain the UTF-16 encoded string data in big-endian order.</remarks> <param name="bytes">The byte array containing the S7 WString data, including the 4-byte header. Must not be null and must have a length of at least 4 bytes.</param> <returns>A string representing the decoded S7 WString value from the specified byte array.</returns> <exception cref="PlcException">Thrown if the input array is null, too short, contains malformed S7 WString data, or if decoding fails.</exception> |
 | `public static byte[] ToByteArray(string? value, int reservedLength)` | Converts the specified string to a big-endian Unicode byte array with a reserved length prefix. <remarks>The returned byte array begins with a 4-byte header: the first two bytes represent the reserved length, and the next two bytes represent the actual string length, both in big-endian order. The string is encoded using big-endian Unicode (UTF-16BE).</remarks> <param name="value">The string to convert to a byte array. Cannot be null.</param> <param name="reservedLength">The number of characters to reserve in the output buffer. Must be less than or equal to 16,382 and greater than or equal to the length of <paramref name="value"/>.</param> <returns>A byte array containing a 4-byte header followed by the big-endian Unicode bytes of the string, padded to the reserved length if necessary.</returns> <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is null.</exception> <exception cref="ArgumentException">Thrown if <paramref name="reservedLength"/> is greater than 16,382, or if the length of <paramref name="value"/> exceeds <paramref name="reservedLength"/>.</exception> |
 
-##### `S7PlcRx.PlcTypes.String`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.String`
 Source: `PlcTypes/String.cs:14`
 
 Provides utility methods for converting between strings and byte arrays using ASCII encoding. <remarks>All methods in this class use ASCII encoding for conversions. These methods are intended for scenarios where data is known to be ASCII-compatible. Non-ASCII characters will be replaced with '?' during encoding and decoding. The class is internal and intended for use within the assembly.</remarks>
@@ -1988,7 +2044,7 @@ Provides utility methods for converting between strings and byte arrays using AS
 | `public static int ToSpan(string? value, Span<byte> destination)` | Encodes the specified string as ASCII bytes and writes the result to the provided destination span. <remarks>Characters in the input string that cannot be represented in ASCII are replaced with a question mark ('?').</remarks> <param name="value">The string to encode as ASCII. If null or empty, no bytes are written.</param> <param name="destination">The span to which the encoded ASCII bytes are written. Must be large enough to hold the encoded bytes.</param> <returns>The number of bytes written to the destination span. Returns 0 if the input string is null or empty.</returns> <exception cref="ArgumentException">Thrown if the destination span is not large enough to contain the encoded bytes.</exception> |
 | `public static bool TryToSpan(string? value, Span<byte> destination, out int bytesWritten)` | Attempts to encode the specified string as ASCII bytes and write the result to the provided destination buffer. <remarks>If the input string is null or empty, no bytes are written and the method returns true. The method returns false if the destination buffer is not large enough to hold the encoded bytes.</remarks> <param name="value">The string to encode as ASCII. Can be null or empty.</param> <param name="destination">The buffer that receives the ASCII-encoded bytes of the string.</param> <param name="bytesWritten">When this method returns, contains the number of bytes written to the destination buffer. Set to 0 if the input string is null or empty.</param> <returns>true if the string was successfully encoded and written to the destination buffer; otherwise, false.</returns> |
 
-##### `S7PlcRx.PlcTypes.Struct`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.Struct`
 Source: `PlcTypes/Struct.cs:17`
 
 Provides utility methods for working with struct types, including calculating their size in bytes and converting between structs and byte arrays. <remarks>The methods in this class are primarily intended for scenarios where struct data needs to be serialized to or deserialized from byte arrays, such as communication with PLCs or binary protocols. The struct types used with these methods should have public fields and, for string fields, must be decorated with the S7StringAttribute to specify their encoding and length. All methods are static and thread-safe.</remarks>
@@ -1999,7 +2055,7 @@ Provides utility methods for working with struct types, including calculating th
 | `public static object? FromBytes(Type structType, byte[] bytes)` | Deserializes a byte array into an instance of the specified structure type. <remarks>The method supports deserialization of structures containing fields of supported primitive types, strings with S7StringAttribute, and nested structures. All fields must be public. The structure's layout and field order must match the serialized byte format.</remarks> <param name="structType">The type of the structure to deserialize the byte array into. Must be a type with a parameterless constructor and supported field types.</param> <param name="bytes">The byte array containing the serialized data for the structure. The length must match the expected size of the structure.</param> <returns>An object representing the deserialized structure, or null if the byte array is null or does not match the expected size.</returns> <exception cref="ArgumentException">Thrown if an instance of the specified type cannot be created, or if a string field is missing the required S7StringAttribute, or if an invalid string type is specified for the S7StringAttribute.</exception> |
 | `public static byte[] ToBytes(object structValue)` | Converts the specified structure object to its byte array representation. <remarks>Supported field types include Boolean, Byte, Int16, UInt16, Int32, UInt32, Single, Double, String (with S7StringAttribute), and TimeSpan. All fields of the structure must be of these types for successful conversion.</remarks> <param name="structValue">The structure object to convert to a byte array. Must not be null. The object's fields must be of supported types.</param> <returns>A byte array containing the serialized representation of the structure. Returns an empty array if <paramref name="structValue"/> is null.</returns> <exception cref="ArgumentException">Thrown if a field value cannot be converted to its corresponding type, or if a string field is missing the required S7StringAttribute, or if an invalid string type is specified in the S7StringAttribute.</exception> |
 
-##### `S7PlcRx.PlcTypes.TimeSpan`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.TimeSpan`
 Source: `PlcTypes/TimeSpan.cs:16`
 
 Provides methods and constants for converting between S7 PLC time representations and .NET <see cref="T:System.TimeSpan"/> values. <remarks>This class supports parsing and serializing <see cref="T:System.TimeSpan"/> values to and from the S7 PLC binary format, where time spans are represented as 4-byte signed integers in milliseconds. All methods assume the S7 time format and enforce the valid range defined by <see cref="F:SpecMinimumTimeSpan"/> and <see cref="F:SpecMaximumTimeSpan"/>. The class is static and cannot be instantiated.</remarks>
@@ -2018,7 +2074,7 @@ Provides methods and constants for converting between S7 PLC time representation
 | `public static byte[] ToByteArray(System.TimeSpan[] timeSpans)` | Converts an array of <see cref="System.TimeSpan"/> values to a byte array representation. <param name="timeSpans">An array of <see cref="System.TimeSpan"/> values to convert. Cannot be null.</param> <returns>A byte array containing the serialized representation of the input <see cref="System.TimeSpan"/> values. The length of the array is proportional to the number of elements in <paramref name="timeSpans"/>.</returns> <exception cref="ArgumentNullException">Thrown if <paramref name="timeSpans"/> is null.</exception> |
 | `public static void ToSpan(ReadOnlySpan<System.TimeSpan> timeSpans, Span<byte> destination)` | Converts a sequence of <see cref="System.TimeSpan"/> values to their binary representation and writes the result to the specified destination span. <param name="timeSpans">The read-only span containing the <see cref="System.TimeSpan"/> values to convert.</param> <param name="destination">The span of bytes that receives the binary representation of the <paramref name="timeSpans"/> values. Must be large enough to hold all converted values.</param> <exception cref="ArgumentException">Thrown when <paramref name="destination"/> is not large enough to contain the binary representation of all <paramref name="timeSpans"/> values.</exception> |
 
-##### `S7PlcRx.PlcTypes.Timer`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.Timer`
 Source: `PlcTypes/Timer.cs:14`
 
 Provides static methods for converting between S7 Timer byte representations and .NET numeric types. <remarks>This class is intended for working with Siemens S7 PLC timer values, enabling conversion to and from the S7-specific byte format and standard .NET types such as double and ushort. All members are static and the class cannot be instantiated.</remarks>
@@ -2036,7 +2092,7 @@ Provides static methods for converting between S7 Timer byte representations and
 | `public static void ToSpan(ReadOnlySpan<ushort> values, Span<byte> destination)` | Converts a sequence of 16-bit unsigned integers to their byte representations and writes the result to the specified destination span. <param name="values">The read-only span of 16-bit unsigned integers to convert.</param> <param name="destination">The span of bytes that receives the converted values. Must be at least twice the length of <paramref name="values"/>.</param> <exception cref="ArgumentException">Thrown when <paramref name="destination"/> is not large enough to contain the converted bytes.</exception> |
 | `public static byte[] ToByteArray(ushort[] value)` | Converts an array of 16-bit unsigned integers to a byte array. <param name="value">The array of 16-bit unsigned integers to convert. Cannot be null.</param> <returns>A byte array containing the binary representation of the input values.</returns> |
 
-##### `S7PlcRx.PlcTypes.Word`
+##### `IoT.DriverCore.S7PlcRx.PlcTypes.Word`
 Source: `PlcTypes/Word.cs:16`
 
 Provides utility methods for converting between 16-bit unsigned integers (words) and their byte array or span representations, using big-endian (high byte first) byte order. <remarks>All methods in this class assume that words are represented in big-endian format, where the first byte is the high-order byte and the second byte is the low-order byte. These methods are intended for scenarios where explicit control over byte order is required, such as binary serialization, communication protocols, or file I/O. The class is static and cannot be instantiated.</remarks>
@@ -2055,9 +2111,9 @@ Provides utility methods for converting between 16-bit unsigned integers (words)
 | `public static byte[] ToByteArray(ushort[] value)` | Converts an array of 16-bit unsigned integers to a byte array. <param name="value">The array of 16-bit unsigned integers to convert. Cannot be null.</param> <returns>A byte array containing the binary representation of the input values.</returns> |
 | `public static void ToSpan(ReadOnlySpan<ushort> values, Span<byte> destination)` | Converts a sequence of 16-bit unsigned integers to their byte representation and writes the result to the specified destination span. <param name="values">The sequence of 16-bit unsigned integers to convert.</param> <param name="destination">The span of bytes that receives the converted values. Must be at least twice the length of <paramref name="values"/>.</param> <exception cref="ArgumentException">Thrown when <paramref name="destination"/> is not large enough to contain the converted bytes.</exception> |
 
-#### Namespace `S7PlcRx.Production`
+#### Namespace `IoT.DriverCore.S7PlcRx.Production`
 
-##### `S7PlcRx.Production.CircuitBreaker`
+##### `IoT.DriverCore.S7PlcRx.Production.CircuitBreaker`
 Source: `Production/CircuitBreaker.cs:17`
 
 Provides a thread-safe implementation of the circuit breaker pattern to prevent repeated execution of failing operations and to allow recovery after a specified timeout. <remarks>The circuit breaker monitors consecutive operation failures and transitions between Closed, Open, and HalfOpen states based on the provided configuration. When the failure threshold is reached, the circuit breaker enters the Open state and blocks further operations until the timeout elapses. After the timeout, it transitions to HalfOpen to test if operations can succeed before fully closing again. This class is thread-safe and intended for use in scenarios where repeated failures should be prevented from overwhelming a system or external dependency.</remarks> <param name="config">The configuration settings that control circuit breaker thresholds, retry behavior, and timeouts.</param>
@@ -2071,14 +2127,14 @@ Provides a thread-safe implementation of the circuit breaker pattern to prevent 
 | `public double SuccessRate => ...` | Gets the percentage of operations that completed successfully. |
 | `public async Task<T> ExecuteAsync<T>(Func<Task<T>> operation)` | Executes the specified asynchronous operation within the circuit breaker, applying retry and failure handling policies as configured. <remarks>If the circuit breaker is open due to previous failures, the operation will be blocked until the configured timeout has elapsed. Upon successful execution, the circuit breaker state is reset. This method is thread-safe.</remarks> <typeparam name="T">The type of the result returned by the asynchronous operation.</typeparam> <param name="operation">A function that represents the asynchronous operation to execute. Cannot be null.</param> <returns>A task that represents the asynchronous execution of the operation. The task result contains the value returned by the operation if it completes successfully.</returns> <exception cref="ArgumentNullException">Thrown if the operation parameter is null.</exception> <exception cref="InvalidOperationException">Thrown if the circuit breaker is open and the timeout period has not elapsed, preventing the operation from being executed.</exception> |
 
-##### `S7PlcRx.Production.CircuitBreakerState`
+##### `IoT.DriverCore.S7PlcRx.Production.CircuitBreakerState`
 Source: `Production/CircuitBreakerState.cs:12`
 
 Specifies the operational state of a circuit breaker used to control the flow of operations in response to failures. <remarks>Use this enumeration to determine or set the current state of a circuit breaker implementation. The state controls whether operations are allowed, blocked, or tested for recovery. Typical usage involves transitioning between these states based on error rates or recovery attempts.</remarks>
 
 Enum values: `Closed`, `Open`, `HalfOpen`.
 
-##### `S7PlcRx.Production.ProductionDiagnostics`
+##### `IoT.DriverCore.S7PlcRx.Production.ProductionDiagnostics`
 Source: `Production/ProductionDiagnostics.cs:16`
 
 Represents diagnostic information collected from a production programmable logic controller (PLC) connection, including connection details, performance metrics, and recommendations. <remarks>This class is typically used to capture and analyze the state of a PLC connection and its associated metrics at a specific point in time. It aggregates connection parameters, diagnostic results, and any errors or optimization suggestions identified during the diagnostic process. All properties are intended to be set and read by consumers managing or monitoring PLC diagnostics.</remarks>
@@ -2097,7 +2153,7 @@ Represents diagnostic information collected from a production programmable logic
 | `public List<string> Recommendations get; set; } = [];` | Gets or sets the optimization recommendations. |
 | `public List<string> Errors get; set; } = [];` | Gets or sets any errors encountered during diagnostics. |
 
-##### `S7PlcRx.Production.ProductionErrorConfig`
+##### `IoT.DriverCore.S7PlcRx.Production.ProductionErrorConfig`
 Source: `Production/ProductionErrorConfig.cs:12`
 
 Represents the configuration settings for error handling and retry logic in a production environment. <remarks>This class provides options to control retry attempts, delay strategies, and circuit breaker behavior for handling transient errors. It is typically used to configure error resilience policies in applications that interact with external systems or services.</remarks>
@@ -2110,7 +2166,7 @@ Represents the configuration settings for error handling and retry logic in a pr
 | `public int CircuitBreakerThreshold get; set; } = 5;` | Gets or sets the circuit breaker failure threshold. |
 | `public TimeSpan CircuitBreakerTimeout get; set; } = TimeSpan.FromMinutes(1);` | Gets or sets the circuit breaker timeout. |
 
-##### `S7PlcRx.Production.ProductionErrorHandler`
+##### `IoT.DriverCore.S7PlcRx.Production.ProductionErrorHandler`
 Source: `Production/ProductionErrorHandler.cs:16`
 
 Provides error handling for production environments by executing operations with circuit breaker protection and configurable error handling policies. <remarks>This class is intended for use in production scenarios where robust error handling and resilience are required. It wraps operations in a circuit breaker to prevent repeated failures and applies the error handling strategies specified in the provided configuration. Instances of this class are thread-safe and can be reused across multiple operations.</remarks> <param name="config">The configuration settings that define error handling behavior, including circuit breaker thresholds and retry policies. Cannot be null.</param>
@@ -2119,7 +2175,7 @@ Provides error handling for production environments by executing operations with
 |---|---|
 | `public async Task<T> ExecuteAsync<T>(Func<Task<T>> operation) => ...` | Executes an operation with comprehensive error handling. <typeparam name="T">The return type.</typeparam> <param name="operation">The operation to execute.</param> <returns>The result of the operation.</returns> |
 
-##### `S7PlcRx.Production.ProductionExtensions`
+##### `IoT.DriverCore.S7PlcRx.Production.ProductionExtensions`
 Source: `Production/ProductionExtensions.cs:18`
 
 Provides extension methods for enabling production-grade error handling, retry logic, and system validation on PLC instances using the circuit breaker pattern. <remarks>These extension methods are intended to enhance the reliability and readiness of PLC-based systems in production environments. They offer mechanisms for robust error handling, configurable retry strategies, and comprehensive validation routines to assess system health and readiness for production deployment. All methods require a valid IRxS7 PLC instance and may utilize user-supplied or default configuration objects. Thread safety is ensured for shared resources such as circuit breakers.</remarks>
@@ -2130,7 +2186,7 @@ Provides extension methods for enabling production-grade error handling, retry l
 | `public static async Task<T> ExecuteWithErrorHandling<T>( this IRxS7 plc, Func<Task<T>> operation, ProductionErrorConfig? config = null)` | Executes the specified asynchronous PLC operation with error handling and circuit breaker protection. <remarks>This method ensures that the provided operation is executed with error handling policies defined by the specified or default configuration. It uses a circuit breaker to prevent repeated execution of failing operations, which can help protect the PLC and improve system resilience.</remarks> <typeparam name="T">The type of the result returned by the operation.</typeparam> <param name="plc">The PLC instance on which to perform the operation. Cannot be null.</param> <param name="operation">A function that represents the asynchronous operation to execute. Cannot be null.</param> <param name="config">An optional configuration object that specifies error handling and circuit breaker behavior. If null, a default configuration is used.</param> <returns>A task that represents the asynchronous operation. The task result contains the value returned by the operation.</returns> <exception cref="ArgumentNullException">Thrown if <paramref name="plc"/> or <paramref name="operation"/> is null.</exception> |
 | `public static async Task<SystemValidationResult> ValidateProductionReadiness( this IRxS7 plc, ProductionValidationConfig? validationConfig = null)` | Performs a comprehensive validation of the specified PLC to determine its readiness for production deployment. <remarks>The validation process includes checks for connectivity, performance, and reliability. The method aggregates results and determines production readiness based on the provided or default configuration. The returned result includes timestamps, scores, and any critical errors encountered during validation.</remarks> <param name="plc">The PLC instance to validate for production readiness. Cannot be null.</param> <param name="validationConfig">An optional configuration object that specifies validation parameters and thresholds. If null, default validation settings are used.</param> <returns>A task that represents the asynchronous operation. The task result contains a SystemValidationResult object with detailed validation outcomes, including overall readiness, scores, and any detected issues.</returns> <exception cref="ArgumentNullException">Thrown if the plc parameter is null.</exception> |
 
-##### `S7PlcRx.Production.ProductionMetrics`
+##### `IoT.DriverCore.S7PlcRx.Production.ProductionMetrics`
 Source: `Production/ProductionMetrics.cs:13`
 
 Represents a set of metrics related to the monitoring and connectivity status of a PLC (Programmable Logic Controller) over a specified period. <remarks>This class is typically used to capture and report operational statistics for a PLC, such as connection times, uptime percentage, and tag counts. All properties are mutable, allowing for incremental updates as new data is collected.</remarks>
@@ -2147,7 +2203,7 @@ Represents a set of metrics related to the monitoring and connectivity status of
 | `public int ActiveTagCount get; set; }` | Gets or sets the number of active tags. |
 | `public int TotalTagCount get; set; }` | Gets or sets the total number of tags. |
 
-##### `S7PlcRx.Production.ProductionTagMetrics`
+##### `IoT.DriverCore.S7PlcRx.Production.ProductionTagMetrics`
 Source: `Production/ProductionTagMetrics.cs:12`
 
 Represents aggregated metrics related to production tags, including counts and distribution information. <remarks>Use this class to track and analyze the status and distribution of tags within a production environment. The metrics provided can assist in monitoring tag activity and identifying trends or anomalies in tag usage.</remarks>
@@ -2159,7 +2215,7 @@ Represents aggregated metrics related to production tags, including counts and d
 | `public int InactiveTags get; set; }` | Gets or sets the number of inactive tags. |
 | `public Dictionary<string, int> DataBlockDistribution get; set; } = [];` | Gets or sets the distribution of tags by data block. |
 
-##### `S7PlcRx.Production.ProductionValidationConfig`
+##### `IoT.DriverCore.S7PlcRx.Production.ProductionValidationConfig`
 Source: `Production/ProductionValidationConfig.cs:12`
 
 Represents configuration settings for validating production system performance and reliability. <remarks>Use this class to specify thresholds and criteria for production validation checks, such as acceptable response times, reliability rates, and minimum production scores. These settings can be adjusted to match the requirements of different production environments.</remarks>
@@ -2171,7 +2227,7 @@ Represents configuration settings for validating production system performance a
 | `public int ReliabilityTestCount get; set; } = 10;` | Gets or sets the number of operations to test for reliability. |
 | `public double MinimumProductionScore get; set; } = 80.0;` | Gets or sets the minimum production score (0 to 100). |
 
-##### `S7PlcRx.Production.SystemValidationResult`
+##### `IoT.DriverCore.S7PlcRx.Production.SystemValidationResult`
 Source: `Production/SystemValidationResult.cs:13`
 
 Represents the result of a system validation process, including timing, test results, and production readiness status. <remarks>Use this class to capture and inspect the outcome of a system validation run, such as for a PLC or similar automated system. It provides details about the validation period, individual test results, critical errors, and an overall score indicating system readiness for production.</remarks>
@@ -2187,7 +2243,7 @@ Represents the result of a system validation process, including timing, test res
 | `public List<string> CriticalErrors get; } = [];` | Gets critical errors that prevent production use. |
 | `public TimeSpan TotalValidationTime => ...` | Gets the total validation time. |
 
-##### `S7PlcRx.Production.ValidationTest`
+##### `IoT.DriverCore.S7PlcRx.Production.ValidationTest`
 Source: `Production/ValidationTest.cs:9`
 
 Represents the result and metadata of a validation test, including timing, outcome, and related details.
@@ -2202,14 +2258,14 @@ Represents the result and metadata of a validation test, including timing, outco
 | `public List<string> Details get; } = [];` | Gets additional test details. |
 | `public TimeSpan Duration => ...` | Gets the test duration. |
 
-#### Namespace `S7PlcRx.SourceGeneration`
+#### Namespace `IoT.DriverCore.S7PlcRx.SourceGeneration`
 
-##### `S7PlcRx.SourceGeneration.S7PlcBindingAttribute`
+##### `IoT.DriverCore.S7PlcRx.SourceGeneration.S7PlcBindingAttribute`
 Source: `S7TagBindingSourceGenerator.cs:273`
 
 No public instance/static members declared directly on this type.
 
-##### `S7PlcRx.SourceGeneration.S7TagAttribute`
+##### `IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagAttribute`
 Source: `S7TagBindingSourceGenerator.cs:278`
 
 | Member | Summary |
@@ -2220,14 +2276,14 @@ Source: `S7TagBindingSourceGenerator.cs:278`
 | `public S7TagDirection Direction get; set; }` |  |
 | `public int ArrayLength get; set; } = 1;` |  |
 
-##### `S7PlcRx.SourceGeneration.S7TagDirection`
+##### `IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagDirection`
 Source: `S7TagBindingSourceGenerator.cs:294`
 
 Enum values: `ReadWrite`, `ReadOnly`, `WriteOnly`.
 
-#### Namespace `S7PlcRx.SourceGenerators`
+#### Namespace `IoT.DriverCore.S7PlcRx.SourceGenerators`
 
-##### `S7PlcRx.SourceGenerators.S7TagBindingSourceGenerator`
+##### `IoT.DriverCore.S7PlcRx.SourceGenerators.S7TagBindingSourceGenerator`
 Source: `S7TagBindingSourceGenerator.cs:17`
 
 | Member | Summary |
@@ -2237,10 +2293,173 @@ Source: `S7TagBindingSourceGenerator.cs:17`
 </details>
 
 
+## Migrated API additions and full member-family guide
+
+The preceding API reference retains the complete original feature documentation. This section records the migrated public surface that was added or expanded in IoT-DriverCore, including its overload families and the two composition patterns most commonly used in an application.
+
+### Tag registration, polling, and observable adaptation
+
+| Type/member family | Purpose, result, errors, and lifecycle |
+|---|---|
+| `TagOperations.AddUpdateTagItem(plc, type, name, address[, length])` | Creates or replaces a tag and returns `TagRegistration`. The scalar, fixed-length, and nullable-length overloads select the PLC value shape. Invalid addresses/types surface through the PLC error streams; call `SetPolling(bool)` on the result before relying on observation. |
+| `TagOperations.GetTag` / `RemoveTagItem` | Retrieves a registration wrapper or removes a named tag. Removing a tag produces an `ObserveAll` null notification and invalidates later reads by that name. |
+| `TagOperations.ToTagValue<T>` / `TagToDictionary` | Converts a tag notification stream to typed name/value pairs or a dictionary for UI/state projections. Dispose the resulting subscription with the projection owner. |
+| `TagRegistration.SetPolling()` / `SetPolling(bool)` / `Deconstruct` | Enables/disables polling or exposes its `ITag` and `IRxS7`. It changes tag scheduling only; it does not validate a write nor close the PLC connection. |
+| `S7TagValueObservable<T>` | Small multicast observable with `Subscribe` and `Publish`; use for your own binding projection, then dispose each returned subscription. |
+| `S7TagObservableAdapter.ToAsyncEnumerable<T>` | Turns any `IObservable<T>` into an `IAsyncEnumerable<T>`. Cancellation stops the enumerator/subscription; errors are rethrown by `MoveNextAsync`. |
+
+```csharp
+using IoT.DriverCore.Core;
+using IoT.DriverCore.S7PlcRx;
+
+TagOperations.AddUpdateTagItem(plc, typeof(bool), "Pump.Enabled", "DB10.DBX0.0").SetPolling();
+TagOperations.AddUpdateTagItem(plc, typeof(short), "Pump.Speed", "DB10.DBW2").SetPolling(false);
+
+using var updates = TagOperations.ToTagValue<bool>(plc.ObserveAll)
+    .Subscribe(change => Console.WriteLine($"{change.Tag}={change.Value}"));
+
+await foreach (var tag in S7TagObservableAdapter.ToAsyncEnumerable(plc.ObserveAll)
+                   .WithCancellation(CancellationToken.None))
+{
+    if (tag?.Name == "Pump.Enabled")
+        Console.WriteLine($"State is {tag.Value}");
+}
+```
+
+### Runtime binding and generated binding
+
+`S7TagRuntimeBinding.Bind(IRxS7, IReadOnlyList<S7TagDefinition>, Action<string, object?>)` registers a supplied definition set and returns a disposable binding. `Write(name, value)` performs the corresponding managed write and throws argument/address/type exceptions before a PLC command if the definition cannot be resolved. `S7TagBindingSession` composes the runtime binding with a logical-tag client and disposes both exactly once. `S7TagDefinition` carries the definition name, address, type, poll interval, direction, and array-length metadata; `S7TagDirection` distinguishes read/write intent.
+
+The analyzer is `S7PlcRx.Generators`. It consumes public `[S7PlcBinding]` and `[S7Tag(address)]` attributes from `IoT.DriverCore.S7PlcRx.SourceGeneration`; `Address` is required, while `PollIntervalMs`, `Direction`, and `ArrayLength` configure the generated registration. The target class and attributed properties must be `partial`. Build diagnostics are deliberately actionable: fix invalid address/property/type/direction metadata instead of suppressing them.
+
+```csharp
+using IoT.DriverCore.S7PlcRx;
+using IoT.DriverCore.S7PlcRx.SourceGeneration;
+
+[S7PlcBinding]
+public partial class MixerBinding
+{
+    [S7Tag("DB20.DBX0.0", PollIntervalMs = 250, Direction = S7TagDirection.ReadWrite)]
+    public partial bool Run { get; set; }
+
+    [S7Tag("DB20.DBD4", Direction = S7TagDirection.ReadOnly)]
+    public partial float Temperature { get; set; }
+}
+
+// The generated API connects this binding to the IRxS7 instance and emits typed
+// observable/property hooks. Handle its build diagnostics before deploying.
+```
+
+```csharp
+using IoT.DriverCore.S7PlcRx.Binding;
+
+var definitions = new[]
+{
+    new S7TagDefinition("Mix.Run", "DB20.DBX0.0", typeof(bool), 250, S7TagDirection.ReadWrite, 1),
+    new S7TagDefinition("Mix.Target", "DB20.DBW2", typeof(short), 0, S7TagDirection.ReadWrite, 1),
+};
+using var runtime = S7TagRuntimeBinding.Bind(plc, definitions, (_, _) => { });
+runtime.Write("Mix.Target", (short)850);
+
+// In an application that owns both resources, create a catalog/client and make
+// its teardown explicit. Do not also dispose runtime separately after session.
+var catalog = S7LogicalTagExtensions.CreateLogicalTagCatalog(definitions);
+using var logicalClient = S7LogicalTagExtensions.CreateLogicalTagClient(plc, catalog);
+```
+
+### Logical tags, persistence, CSV, and typed operations
+
+`S7LogicalTagExtensions.CreateLogicalTagCatalog` creates a shared catalog. `CreateLogicalTagClient` has overloads for catalog/store construction; the returned `S7LogicalTagClient` implements `IDisposable` and must be disposed. Its constructor overloads accept the PLC, catalog, optional store, and composition dependencies. `RegisterTag`, `CreateTag`, and `RemoveTag` modify the in-memory catalog; `InitializeStoreAsync`, `LoadTagsAsync`, `GetTagAsync`, `ListTagsAsync`, `UpsertTagAsync`, `EditTagAsync`, `UpdateTagAsync`, and `DeleteTagAsync` are store-backed operations with cancellation-token overloads. The matching group methods are `GetGroupAsync`, `ListGroupsAsync`, `UpsertGroupAsync`, and `DeleteGroupAsync`.
+
+`ImportCsvAsync` and `ExportCsvAsync` have default-delimiter, explicit-delimiter, and cancellation-aware overloads. Use a caller-owned `TextReader`/`TextWriter`; the client does not own or close it. `ReadAsync`, `ReadManyAsync`, `WriteAsync`, and `WriteManyAsync` return `TagOperationResult<LogicalTagValue>` or a list, preserving per-tag failures. `Observe`/`ObserveMany` return observables, while `ObserveAsync`/`ObserveManyAsync` return cancelable async streams.
+
+```csharp
+using IoT.DriverCore.Core;
+using IoT.DriverCore.S7PlcRx.LogicalTags;
+
+var catalog = S7LogicalTagExtensions.CreateLogicalTagCatalog(definitions);
+using var client = S7LogicalTagExtensions.CreateLogicalTagClient(plc, catalog);
+var store = new LogicalTagSqliteStore("Data Source=tags.db;Pooling=False");
+await client.InitializeStoreAsync(store, cancellationToken);
+await client.ImportCsvAsync(reader, delimiter: ';', cancellationToken);
+
+var result = await client.WriteAsync(
+    new LogicalTagValue("Recipe.Target", 1200, DateTimeOffset.UtcNow), cancellationToken);
+if (!result.Succeeded)
+    throw new InvalidOperationException(result.Error);
+
+using var observed = client.ObserveMany(["Recipe.Target", "Recipe.Actual"])
+    .Subscribe(value => Console.WriteLine($"{value.Name}: {value.Value}"));
+```
+
+### Combined workflow 1: safe command with verification and timeout
+
+Register command and feedback tags, observe errors before writing, send the command, then verify feedback by a bounded read. This combines tag registration, queued writes, cancellation, and error observability without treating a setter as an acknowledgement.
+
+```csharp
+using IoT.DriverCore.Core;
+using IoT.DriverCore.S7PlcRx;
+
+TagOperations.AddUpdateTagItem(plc, typeof(bool), "StartCommand", "DB1.DBX0.0").SetPolling(false);
+TagOperations.AddUpdateTagItem(plc, typeof(bool), "RunningFeedback", "DB1.DBX0.1").SetPolling();
+using var faults = plc.LastError.Subscribe(Console.Error.WriteLine);
+using var stop = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+
+plc.Value("StartCommand", true);
+bool? running = await plc.ReadAsync(new LogicalTagKey<bool>("RunningFeedback"), stop.Token);
+if (running != true)
+    throw new TimeoutException("Start was not acknowledged; inspect PLC diagnostics.");
+```
+
+### Combined workflow 2: imported logical schema, generated display, batch update
+
+Use CSV/store import for the operational schema, generated bindings for fixed application properties, and logical batch operations for an audited recipe update. Dispose each subscription/session/client you own; the PLC factory result itself has the lifecycle limitation described above.
+
+```csharp
+using IoT.DriverCore.S7PlcRx;
+using IoT.DriverCore.S7PlcRx.Binding;
+
+var catalog = S7LogicalTagExtensions.CreateLogicalTagCatalog(screenDefinitions);
+using var client = S7LogicalTagExtensions.CreateLogicalTagClient(plc, catalog);
+await client.LoadTagsAsync(cancellationToken);
+
+var changes = await client.WriteManyAsync(
+[
+    new LogicalTagValue("Recipe.Speed", (short)1200, DateTimeOffset.UtcNow),
+    new LogicalTagValue("Recipe.Enabled", true, DateTimeOffset.UtcNow),
+], cancellationToken);
+
+foreach (var change in changes.Where(result => !result.Succeeded))
+    Console.Error.WriteLine(change.Error);
+
+using var binding = S7TagRuntimeBinding.Bind(plc, screenDefinitions, (_, _) => { });
+```
+
+### Complete migrated public API reference
+
+| Namespace/type | Public member families and how to use them |
+|---|---|
+| `IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient` | Constructors; catalog tag methods; CSV import/export; store init/load/get/list/upsert/edit/update/delete for tags and groups; typed single/many read/write; observable and async-enumerable single/many observe; `Dispose`. Cancellation overloads are for I/O and streaming boundaries. |
+| `S7LogicalTagExtensions` | Catalog/client creation plus typed logical `ReadAsync<T>` and `WriteAsync<T>`. The package's batch implementation is intentionally internal; call the public logical-client and extension methods and check each operation result rather than assuming an all-or-nothing PLC commit. |
+| `IoT.DriverCore.S7PlcRx.Binding.S7TagDefinition`, `S7TagDirection`, `S7TagRuntimeBinding`, `S7TagBindingSession` | Definition metadata, direction, static `Bind`, named `Write`, and deterministic binding/session disposal. `S7TagObservableAdapter` offers `ToAsyncEnumerable`; `S7TagValueObservable<T>` offers `Subscribe`/`Publish`. |
+| `IoT.DriverCore.S7PlcRx.Tags.TagOperations`, `TagRegistration`, `Tag`, `ITag`, `Tags` | All registration overloads, lookup/removal, typed stream/dictionary projection, per-tag polling, and tag model metadata. Combine with `IRxS7.Observe`/read/write member families documented in the original API reference above. |
+| `IoT.DriverCore.S7PlcRx.SourceGeneration.S7PlcBindingAttribute`, `S7TagAttribute`, `S7TagDirection` | Compile-time binding configuration: class marker; address plus `PollIntervalMs`, `Direction`, `ArrayLength`; direction enum. `IoT.DriverCore.S7PlcRx.SourceGenerators.S7TagBindingSourceGenerator` is the analyzer implementation packaged by `S7PlcRx.Generators`. |
+
+## Operations and troubleshooting
+
+| Symptom | Cause and corrective action |
+|---|---|
+| Connection state never reaches true | Check CPU-specific factory, IP, rack/slot, firewall/VLAN, PUT/GET, and `LastErrorCode`; do not retry writes blindly. |
+| Read is null or wrong-shaped | Register the tag, make key/property CLR type match PLC data, verify DB/bit/array address, and check non-optimised DB layout. |
+| Generated binding does not appear | Ensure the analyzer package is referenced, class/property declarations are partial, attributes use the migrated namespace, and generator diagnostics are fixed. |
+| Stale/high-load updates | Reduce polling set/interval, group contiguous DB data, use batch/optimisation helpers, and measure with performance APIs before increasing parallelism. |
+| Store/CSV operation fails | Keep the reader/writer/store alive for the await, pass a cancellation token, inspect per-tag `TagOperationResult`, and dispose the logical client only after streams stop. |
+| Shutdown needs deterministic PLC disposal | `IRxS7` inherits disposable `ICancelable`; use a `using IRxS7` scope (or call `Dispose`) after disposing owned subscriptions, bindings, clients, pools, and groups. |
+
 ## Build and test
 
 ```bash
-dotnet build src/S7PlcRx.sln
+dotnet build src/IoT-DriverCore.slnx
 dotnet build src/S7PlcRx/S7PlcRx.csproj
 dotnet build src/S7PlcRx.Reactive/S7PlcRx.Reactive.csproj
 dotnet test src/S7PlcRx.Tests/S7PlcRx.Tests.csproj --framework net8.0
@@ -2249,17 +2468,7932 @@ dotnet test src/S7PlcRx.Tests/S7PlcRx.Tests.csproj --framework net8.0
 From WSL when only Windows .NET is installed:
 
 ```bash
-"/mnt/c/Program Files/dotnet/dotnet.exe" build src/S7PlcRx.sln
+"/mnt/c/Program Files/dotnet/dotnet.exe" build src/IoT-DriverCore.slnx
 "/mnt/c/Program Files/dotnet/dotnet.exe" build src/S7PlcRx.Reactive/S7PlcRx.Reactive.csproj
 "/mnt/c/Program Files/dotnet/dotnet.exe" test src/S7PlcRx.Tests/S7PlcRx.Tests.csproj --framework net8.0
 ```
 
 ## License
 
-MIT. See [LICENSE](LICENSE).
+MIT. See the repository [LICENSE](https://github.com/ChrisPulman/IoT-DriverCore/blob/main/LICENSE).
 
 ## Support
 
-- Issues: <https://github.com/ChrisPulman/S7PlcRx/issues>
+- Issues: <https://github.com/ChrisPulman/IoT-DriverCore/issues>
 - NuGet: <https://www.nuget.org/packages/S7PlcRx>
 - NuGet reactive package: <https://www.nuget.org/packages/S7PlcRx.Reactive>
+
+## AI skill
+
+For a concise agent workflow, load [`skills/s7-plc-rx/SKILL.md`](../../skills/s7-plc-rx/SKILL.md). This README remains the exhaustive package API and operational reference.
+
+<!-- BEGIN GENERATED PUBLIC API -->
+
+## Exhaustive public API reference
+
+This catalogue is generated from the packaged runtime assemblies and their XML documentation. It includes exported public types and their declared public members; inherited members and non-public implementation details are intentionally omitted.
+
+### `S7PlcRx`
+
+Exported public types: 100; declared public members: 736.
+
+#### `T:IoT.DriverCore.S7PlcRx.Advanced.AdvancedExtensions`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Advanced.AdvancedExtensions
+```
+Provides advanced extension methods for efficient batch operations, diagnostics, and performance analysis on PLC (Programmable Logic Controller) instances using the IRxS7 interface.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Advanced.AdvancedExtensions.AnalyzePerformanceAsync(IoT.DriverCore.S7PlcRx.IRxS7,System.TimeSpan)`
+
+```csharp
+public static System.Threading.Tasks.Task<IoT.DriverCore.S7PlcRx.Performance.PerformanceAnalysis> AnalyzePerformanceAsync(IoT.DriverCore.S7PlcRx.IRxS7 plc, System.TimeSpan monitoringDuration)
+```
+Analyzes tag change performance on the specified PLC over a given monitoring duration and returns a summary of tag change frequencies and recommendations.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `monitoringDuration`: The positive duration over which to observe tag changes.
+- Returns: A task that produces a PerformanceAnalysis object with tag change statistics and performance recommendations for the monitored period.
+
+###### `M:IoT.DriverCore.S7PlcRx.Advanced.AdvancedExtensions.AnalyzePerformanceAsync(IoT.DriverCore.S7PlcRx.IRxS7,System.TimeSpan,System.TimeProvider)`
+
+```csharp
+public static System.Threading.Tasks.Task<IoT.DriverCore.S7PlcRx.Performance.PerformanceAnalysis> AnalyzePerformanceAsync(IoT.DriverCore.S7PlcRx.IRxS7 plc, System.TimeSpan monitoringDuration, System.TimeProvider timeProvider)
+```
+Analyzes tag change performance on the specified PLC over a given monitoring duration and returns a summary of tag change frequencies and recommendations.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `monitoringDuration`: The positive duration over which to observe tag changes.
+- Parameter `timeProvider`: The time provider.
+- Returns: A task that produces a PerformanceAnalysis object with tag change statistics and performance recommendations for the monitored period.
+
+###### `M:IoT.DriverCore.S7PlcRx.Advanced.AdvancedExtensions.CreateTagGroup``1(IoT.DriverCore.S7PlcRx.IRxS7,``0,System.String,System.String[])`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.Performance.HighPerformanceTagGroup<T> CreateTagGroup<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, T typeValue, string groupName, string[] tagNames)
+```
+Creates a new high-performance tag group for batch reading or writing of multiple tags from the specified PLC connection.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `typeValue`: A value used to infer the tag-group value type.
+- Parameter `groupName`: The name used to identify the tag group.
+- Parameter `tagNames`: The tag names to include in the group.
+- Returns: A new HighPerformanceTagGroup{T} that contains the specified tags and PLC connection.
+
+###### `M:IoT.DriverCore.S7PlcRx.Advanced.AdvancedExtensions.GetDiagnosticsAsync(IoT.DriverCore.S7PlcRx.IRxS7)`
+
+```csharp
+public static System.Threading.Tasks.Task<IoT.DriverCore.S7PlcRx.Production.ProductionDiagnostics> GetDiagnosticsAsync(IoT.DriverCore.S7PlcRx.IRxS7 plc)
+```
+Asynchronously collects diagnostics and performance metrics from a PLC instance.
+
+- Parameter `plc`: The PLC instance.
+- Returns: A task that produces a ProductionDiagnostics object with collected diagnostic data, tag metrics, and optimization recommendations.
+
+###### `M:IoT.DriverCore.S7PlcRx.Advanced.AdvancedExtensions.GetDiagnosticsAsync(IoT.DriverCore.S7PlcRx.IRxS7,System.TimeProvider)`
+
+```csharp
+public static System.Threading.Tasks.Task<IoT.DriverCore.S7PlcRx.Production.ProductionDiagnostics> GetDiagnosticsAsync(IoT.DriverCore.S7PlcRx.IRxS7 plc, System.TimeProvider timeProvider)
+```
+Asynchronously collects diagnostics and performance metrics from a PLC instance.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `timeProvider`: The time provider.
+- Returns: A task that produces a ProductionDiagnostics object with collected diagnostic data, tag metrics, and optimization recommendations.
+
+###### `M:IoT.DriverCore.S7PlcRx.Advanced.AdvancedExtensions.ObserveBatch``1(IoT.DriverCore.S7PlcRx.IRxS7,``0,System.String[])`
+
+```csharp
+public static System.IObservable<System.Collections.Generic.Dictionary<string, T>> ObserveBatch<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, T typeValue, string[] variables)
+```
+Observes the values of multiple PLC variables as a batch and emits updates as a dictionary when any of the specified variables change.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `typeValue`: A value used to infer the PLC value type.
+- Parameter `variables`: The PLC variables to observe.
+- Returns: An observable that emits the latest value for each variable. The dictionary is updated and emitted whenever any of the observed variables change.
+
+###### `M:IoT.DriverCore.S7PlcRx.Advanced.AdvancedExtensions.ReadBatchOptimizedAsync``1(IoT.DriverCore.S7PlcRx.IRxS7,``0,System.Collections.Generic.Dictionary`2{System.String,System.String},System.Int32)`
+
+```csharp
+public static System.Threading.Tasks.Task<IoT.DriverCore.S7PlcRx.BatchOperations.BatchReadResult<T>> ReadBatchOptimizedAsync<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, T typeValue, System.Collections.Generic.Dictionary<string, string> tagMapping, int timeoutMs)
+```
+Executes the `ReadBatchOptimizedAsync` operation.
+
+- Parameter `plc`: The `plc` value.
+- Parameter `typeValue`: The `typeValue` value.
+- Parameter `tagMapping`: The `tagMapping` value.
+- Parameter `timeoutMs`: The `timeoutMs` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.S7PlcRx.BatchOperations.BatchReadResult<T>>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.Advanced.AdvancedExtensions.ValueBatchAsync``1(IoT.DriverCore.S7PlcRx.IRxS7,System.Collections.Generic.Dictionary`2{System.String,``0})`
+
+```csharp
+public static System.Threading.Tasks.Task ValueBatchAsync<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, System.Collections.Generic.Dictionary<string, T> values)
+```
+Executes the `ValueBatchAsync` operation.
+
+- Parameter `plc`: The `plc` value.
+- Parameter `values`: The `values` value.
+- Returns: A `System.Threading.Tasks.Task` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.Advanced.AdvancedExtensions.ValueBatchAsync``1(IoT.DriverCore.S7PlcRx.IRxS7,``0,System.String[])`
+
+```csharp
+public static System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<string, T>> ValueBatchAsync<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, T typeValue, string[] variables)
+```
+Asynchronously reads the values of multiple variables from the PLC and returns a dictionary mapping variable names to their values.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `typeValue`: A value used to infer the PLC value type.
+- Parameter `variables`: The PLC variables to read.
+- Returns: A task that produces a dictionary mapping each requested variable name to its value of type T, or to the default value of T if the variable could not be read or does not exist. If no variables are specified, returns an empty dictionary.
+
+###### `M:IoT.DriverCore.S7PlcRx.Advanced.AdvancedExtensions.WriteBatchOptimizedAsync``1(IoT.DriverCore.S7PlcRx.IRxS7,System.Collections.Generic.Dictionary`2{System.String,``0},System.Boolean,System.Boolean)`
+
+```csharp
+public static System.Threading.Tasks.Task<IoT.DriverCore.S7PlcRx.BatchOperations.BatchWriteResult> WriteBatchOptimizedAsync<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, System.Collections.Generic.Dictionary<string, T> values, bool verifyWrites, bool enableRollback)
+```
+Executes the `WriteBatchOptimizedAsync` operation.
+
+- Parameter `plc`: The `plc` value.
+- Parameter `values`: The `values` value.
+- Parameter `verifyWrites`: The `verifyWrites` value.
+- Parameter `enableRollback`: The `enableRollback` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.S7PlcRx.BatchOperations.BatchWriteResult>` result.
+
+#### `T:IoT.DriverCore.S7PlcRx.Advanced.AsyncExtensions`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Advanced.AsyncExtensions
+```
+Provides additional async-first helpers for reading, writing, and observing PLC values without changing the base `T:IoT.DriverCore.S7PlcRx.IRxS7` API surface.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Advanced.AsyncExtensions.ObserveValue``1(IoT.DriverCore.S7PlcRx.IRxS7,``0,System.String)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<T> ObserveValue<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, T typeValue, string variable)
+```
+Exposes a PLC variable as an async observable sequence.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `typeValue`: A value used to infer the PLC value type.
+- Parameter `variable`: The tag name to observe.
+- Returns: An async observable that emits tag value updates asynchronously.
+
+###### `M:IoT.DriverCore.S7PlcRx.Advanced.AsyncExtensions.ObserveValues``1(IoT.DriverCore.S7PlcRx.IRxS7,``0,System.String[])`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.Collections.Generic.Dictionary<string, T>> ObserveValues<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, T typeValue, string[] variables)
+```
+Exposes a batch PLC observation as an async observable sequence.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `typeValue`: A value used to infer the PLC value type.
+- Parameter `variables`: The tag names to observe.
+- Returns: An async observable that emits dictionaries of tag values asynchronously.
+
+###### `M:IoT.DriverCore.S7PlcRx.Advanced.AsyncExtensions.ReadValueAsync``1(IoT.DriverCore.S7PlcRx.IRxS7,``0,System.String,System.Threading.CancellationToken)`
+
+```csharp
+public static System.Threading.Tasks.ValueTask<T> ReadValueAsync<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, T typeValue, string variable, System.Threading.CancellationToken cancellationToken)
+```
+Reads a PLC value using a `T:System.Threading.Tasks.ValueTask`1` .
+
+- Parameter `plc`: The PLC instance.
+- Parameter `typeValue`: A value used to infer the PLC value type.
+- Parameter `variable`: The tag name to read.
+- Parameter `cancellationToken`: The cancellation token for the read operation.
+- Returns: A `T:System.Threading.Tasks.ValueTask`1` that resolves to the current PLC value.
+
+###### `M:IoT.DriverCore.S7PlcRx.Advanced.AsyncExtensions.ReadValuesAsync``1(IoT.DriverCore.S7PlcRx.IRxS7,``0,System.Collections.Generic.IReadOnlyList`1{System.String},System.Threading.CancellationToken)`
+
+```csharp
+public static System.Threading.Tasks.ValueTask<System.Collections.Generic.Dictionary<string, T>> ReadValuesAsync<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, T typeValue, System.Collections.Generic.IReadOnlyList<string> variables, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ReadValuesAsync` operation.
+
+- Parameter `plc`: The `plc` value.
+- Parameter `typeValue`: The `typeValue` value.
+- Parameter `variables`: The `variables` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.ValueTask<System.Collections.Generic.Dictionary<string, T>>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.Advanced.AsyncExtensions.WriteValuesAsync``1(IoT.DriverCore.S7PlcRx.IRxS7,System.Collections.Generic.IReadOnlyDictionary`2{System.String,``0},System.Threading.CancellationToken)`
+
+```csharp
+public static System.Threading.Tasks.ValueTask WriteValuesAsync<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, System.Collections.Generic.IReadOnlyDictionary<string, T> values, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `WriteValuesAsync` operation.
+
+- Parameter `plc`: The `plc` value.
+- Parameter `values`: The `values` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.ValueTask` result.
+
+#### `T:IoT.DriverCore.S7PlcRx.Advanced.DictionaryEqualityComparer`2`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Advanced.DictionaryEqualityComparer`2
+```
+Compares dictionaries by their key-value pairs.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Advanced.DictionaryEqualityComparer`2.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Advanced.DictionaryEqualityComparer<TKey, TValue>()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Advanced.DictionaryEqualityComparer`2`.
+
+###### `M:IoT.DriverCore.S7PlcRx.Advanced.DictionaryEqualityComparer`2.Equals(System.Collections.Generic.Dictionary`2{`0,`1},System.Collections.Generic.Dictionary`2{`0,`1})`
+
+```csharp
+public bool Equals(System.Collections.Generic.Dictionary<TKey, TValue> x, System.Collections.Generic.Dictionary<TKey, TValue> y)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `x`: The `x` value.
+- Parameter `y`: The `y` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.Advanced.DictionaryEqualityComparer`2.GetHashCode(System.Collections.Generic.Dictionary`2{`0,`1})`
+
+```csharp
+public int GetHashCode(System.Collections.Generic.Dictionary<TKey, TValue> obj)
+```
+Returns the hash code for the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `int` result.
+
+#### `T:IoT.DriverCore.S7PlcRx.BatchOperations.BatchOperationResult`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.BatchOperations.BatchOperationResult
+```
+Represents the result and summary statistics of a batch operation.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.BatchOperations.BatchOperationResult.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.BatchOperations.BatchOperationResult()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.BatchOperations.BatchOperationResult`.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchOperationResult.AverageTimePerOperation`
+
+```csharp
+public double AverageTimePerOperation { get; }
+```
+Gets the average time per operation.
+
+- Value: The `AverageTimePerOperation` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchOperationResult.EndTime`
+
+```csharp
+public System.DateTimeOffset EndTime { get; set; }
+```
+Gets or sets the operation end time.
+
+- Value: The `EndTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchOperationResult.ErrorDetails`
+
+```csharp
+public System.Collections.Generic.List<string> ErrorDetails { get; }
+```
+Gets error details for failed operations.
+
+- Value: The `ErrorDetails` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchOperationResult.FailedOperations`
+
+```csharp
+public int FailedOperations { get; set; }
+```
+Gets or sets the number of failed operations.
+
+- Value: The `FailedOperations` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchOperationResult.OperationCount`
+
+```csharp
+public int OperationCount { get; set; }
+```
+Gets or sets the number of operations in the batch.
+
+- Value: The `OperationCount` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchOperationResult.OperationDetails`
+
+```csharp
+public System.Collections.Generic.List<IoT.DriverCore.S7PlcRx.Core.OperationDetail> OperationDetails { get; }
+```
+Gets operation details.
+
+- Value: The `OperationDetails` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchOperationResult.ProcessingTime`
+
+```csharp
+public System.TimeSpan ProcessingTime { get; }
+```
+Gets the total processing time.
+
+- Value: The `ProcessingTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchOperationResult.StartTime`
+
+```csharp
+public System.DateTimeOffset StartTime { get; set; }
+```
+Gets or sets the operation start time.
+
+- Value: The `StartTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchOperationResult.SuccessfulOperations`
+
+```csharp
+public int SuccessfulOperations { get; set; }
+```
+Gets or sets the number of successful operations.
+
+- Value: The `SuccessfulOperations` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.BatchOperations.BatchReadResult`1`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.BatchOperations.BatchReadResult`1
+```
+Represents the result of a batch read operation, including the values read, per-tag success status, error messages, and overall success information.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.BatchOperations.BatchReadResult`1.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.BatchOperations.BatchReadResult<T>()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.BatchOperations.BatchReadResult`1`.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchReadResult`1.ErrorCount`
+
+```csharp
+public int ErrorCount { get; }
+```
+Gets the count of failed reads.
+
+- Value: The `ErrorCount` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchReadResult`1.Errors`
+
+```csharp
+public System.Collections.Generic.Dictionary<string, string> Errors { get; }
+```
+Gets error messages for failed reads.
+
+- Value: The `Errors` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchReadResult`1.OverallSuccess`
+
+```csharp
+public bool OverallSuccess { get; set; }
+```
+Gets or sets a value indicating whether gets whether all reads were successful.
+
+- Value: The `OverallSuccess` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchReadResult`1.Success`
+
+```csharp
+public System.Collections.Generic.Dictionary<string, bool> Success { get; }
+```
+Gets the success status for each tag.
+
+- Value: The `Success` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchReadResult`1.SuccessCount`
+
+```csharp
+public int SuccessCount { get; }
+```
+Gets the count of successful reads.
+
+- Value: The `SuccessCount` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchReadResult`1.Values`
+
+```csharp
+public System.Collections.Generic.Dictionary<string, T> Values { get; }
+```
+Gets the successfully read values.
+
+- Value: The `Values` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.BatchOperations.BatchWriteResult`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.BatchOperations.BatchWriteResult
+```
+Represents the result of a batch write operation, including per-item success status, error messages, and overall outcome.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.BatchOperations.BatchWriteResult.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.BatchOperations.BatchWriteResult()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.BatchOperations.BatchWriteResult`.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchWriteResult.ErrorCount`
+
+```csharp
+public int ErrorCount { get; }
+```
+Gets the count of failed writes.
+
+- Value: The `ErrorCount` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchWriteResult.Errors`
+
+```csharp
+public System.Collections.Generic.Dictionary<string, string> Errors { get; }
+```
+Gets error messages for failed writes.
+
+- Value: The `Errors` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchWriteResult.OverallSuccess`
+
+```csharp
+public bool OverallSuccess { get; set; }
+```
+Gets or sets a value indicating whether gets whether all writes were successful.
+
+- Value: The `OverallSuccess` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchWriteResult.RollbackPerformed`
+
+```csharp
+public bool RollbackPerformed { get; set; }
+```
+Gets or sets a value indicating whether gets whether rollback was performed.
+
+- Value: The `RollbackPerformed` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchWriteResult.Success`
+
+```csharp
+public System.Collections.Generic.Dictionary<string, bool> Success { get; }
+```
+Gets the success status for each tag.
+
+- Value: The `Success` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.BatchOperations.BatchWriteResult.SuccessCount`
+
+```csharp
+public int SuccessCount { get; }
+```
+Gets the count of successful writes.
+
+- Value: The `SuccessCount` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Binding.S7TagBindingSession`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Binding.S7TagBindingSession
+```
+Owns the runtime and common logical clients created for one generated binding session.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Binding.S7TagBindingSession.#ctor(System.IDisposable,System.IDisposable)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Binding.S7TagBindingSession(System.IDisposable runtimeBinding, System.IDisposable logicalClient)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.Binding.S7TagBindingSession` class.
+
+- Parameter `runtimeBinding`: The runtime binding.
+- Parameter `logicalClient`: The common logical client.
+
+###### `M:IoT.DriverCore.S7PlcRx.Binding.S7TagBindingSession.Dispose`
+
+```csharp
+public void Dispose()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+#### `T:IoT.DriverCore.S7PlcRx.Binding.S7TagDefinition`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Binding.S7TagDefinition
+```
+Describes a generated PLC tag/property binding.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Binding.S7TagDefinition.#ctor(System.String,System.String,System.Type,System.Int32,IoT.DriverCore.S7PlcRx.Binding.S7TagDirection,System.Int32)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Binding.S7TagDefinition(string name, string address, System.Type valueType, int pollIntervalMs, IoT.DriverCore.S7PlcRx.Binding.S7TagDirection direction, int arrayLength)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.Binding.S7TagDefinition` class.
+
+- Parameter `name`: The property and PLC tag name.
+- Parameter `address`: The S7 DB address.
+- Parameter `valueType`: The .NET value type.
+- Parameter `pollIntervalMs`: The read polling interval in milliseconds.
+- Parameter `direction`: The tag access direction.
+- Parameter `arrayLength`: The array/string element length.
+
+###### `P:IoT.DriverCore.S7PlcRx.Binding.S7TagDefinition.Address`
+
+```csharp
+public string Address { get; }
+```
+Gets the S7 DB address.
+
+- Value: The `Address` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Binding.S7TagDefinition.ArrayLength`
+
+```csharp
+public int ArrayLength { get; }
+```
+Gets the array/string element length.
+
+- Value: The `ArrayLength` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Binding.S7TagDefinition.CanRead`
+
+```csharp
+public bool CanRead { get; }
+```
+Gets a value indicating whether this tag should be read on polling intervals.
+
+- Value: The `CanRead` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Binding.S7TagDefinition.CanWrite`
+
+```csharp
+public bool CanWrite { get; }
+```
+Gets a value indicating whether this tag can write property changes to the PLC.
+
+- Value: The `CanWrite` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Binding.S7TagDefinition.Direction`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Binding.S7TagDirection Direction { get; }
+```
+Gets the tag access direction.
+
+- Value: The `Direction` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Binding.S7TagDefinition.Name`
+
+```csharp
+public string Name { get; }
+```
+Gets the property and PLC tag name.
+
+- Value: The `Name` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Binding.S7TagDefinition.PollIntervalMs`
+
+```csharp
+public int PollIntervalMs { get; }
+```
+Gets the read polling interval in milliseconds.
+
+- Value: The `PollIntervalMs` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Binding.S7TagDefinition.ValueType`
+
+```csharp
+public System.Type ValueType { get; }
+```
+Gets the .NET value type.
+
+- Value: The `ValueType` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Binding.S7TagDirection`
+
+```csharp
+public enum IoT.DriverCore.S7PlcRx.Binding.S7TagDirection
+```
+Defines the PLC access direction for a generated tag binding.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.S7PlcRx.Binding.S7TagDirection.ReadOnly`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Binding.S7TagDirection ReadOnly
+```
+The tag is read from the PLC only.
+
+###### `F:IoT.DriverCore.S7PlcRx.Binding.S7TagDirection.ReadWrite`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Binding.S7TagDirection ReadWrite
+```
+The tag is read from and written to the PLC.
+
+###### `F:IoT.DriverCore.S7PlcRx.Binding.S7TagDirection.WriteOnly`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Binding.S7TagDirection WriteOnly
+```
+The tag is written to the PLC only.
+
+#### `T:IoT.DriverCore.S7PlcRx.Binding.S7TagObservableAdapter`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Binding.S7TagObservableAdapter
+```
+Bridges generated classic observables to async enumeration.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Binding.S7TagObservableAdapter.ToAsyncEnumerable``1(System.IObservable`1{``0})`
+
+```csharp
+public static System.Collections.Generic.IAsyncEnumerable<T> ToAsyncEnumerable<T>(System.IObservable<T> source)
+```
+Executes the `ToAsyncEnumerable` operation.
+
+- Parameter `source`: The `source` value.
+- Returns: A `System.Collections.Generic.IAsyncEnumerable<T>` result.
+
+#### `T:IoT.DriverCore.S7PlcRx.Binding.S7TagRuntimeBinding`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Binding.S7TagRuntimeBinding
+```
+Runtime engine for tag bindings that polls and writes PLC DB values in byte-array batches.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Binding.S7TagRuntimeBinding.Bind(IoT.DriverCore.S7PlcRx.IRxS7,System.Collections.Generic.IReadOnlyList`1{IoT.DriverCore.S7PlcRx.Binding.S7TagDefinition},System.Action`2{System.String,System.Object})`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.Binding.S7TagRuntimeBinding Bind(IoT.DriverCore.S7PlcRx.IRxS7 plc, System.Collections.Generic.IReadOnlyList<IoT.DriverCore.S7PlcRx.Binding.S7TagDefinition> definitions, System.Action<string, object> applyRead)
+```
+Executes the `Bind` operation.
+
+- Parameter `plc`: The `plc` value.
+- Parameter `definitions`: The `definitions` value.
+- Parameter `applyRead`: The `applyRead` value.
+- Returns: A `IoT.DriverCore.S7PlcRx.Binding.S7TagRuntimeBinding` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.Binding.S7TagRuntimeBinding.Dispose`
+
+```csharp
+public void Dispose()
+```
+Releases timers and pending write state.
+
+###### `M:IoT.DriverCore.S7PlcRx.Binding.S7TagRuntimeBinding.Write(System.String,System.Object)`
+
+```csharp
+public void Write(string name, object value)
+```
+Queues a generated property change for a grouped byte-array write.
+
+- Parameter `name`: The generated tag/property name.
+- Parameter `value`: The new property value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Binding.S7TagValueObservable`1`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Binding.S7TagValueObservable`1
+```
+Provides generated bindings with a small replaying observable that has no subject dependency.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Binding.S7TagValueObservable`1.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Binding.S7TagValueObservable<T>()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Binding.S7TagValueObservable`1`.
+
+###### `M:IoT.DriverCore.S7PlcRx.Binding.S7TagValueObservable`1.Publish(`0)`
+
+```csharp
+public void Publish(T value)
+```
+Publishes a property value and retains it for later subscribers.
+
+- Parameter `value`: The new property value.
+
+###### `M:IoT.DriverCore.S7PlcRx.Binding.S7TagValueObservable`1.Subscribe(System.IObserver`1{`0})`
+
+```csharp
+public System.IDisposable Subscribe(System.IObserver<T> observer)
+```
+Executes the `Subscribe` operation.
+
+- Parameter `observer`: The `observer` value.
+- Returns: A `System.IDisposable` result.
+
+#### `T:IoT.DriverCore.S7PlcRx.Cache.CacheStatistics`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Cache.CacheStatistics
+```
+Provides statistical information about the state and performance of a cache, including entry counts, hit rates, and entry timestamps.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Cache.CacheStatistics.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Cache.CacheStatistics()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Cache.CacheStatistics`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Cache.CacheStatistics.CacheHitRatio`
+
+```csharp
+public double CacheHitRatio { get; }
+```
+Gets the cache hit ratio.
+
+- Value: The cache hit ratio.
+
+###### `P:IoT.DriverCore.S7PlcRx.Cache.CacheStatistics.CachedValueCount`
+
+```csharp
+public int CachedValueCount { get; }
+```
+Gets the cached value count.
+
+- Value: The cached value count.
+
+###### `P:IoT.DriverCore.S7PlcRx.Cache.CacheStatistics.HitRate`
+
+```csharp
+public double HitRate { get; set; }
+```
+Gets or sets the cache hit rate (0.0 to 1.0).
+
+- Value: The `HitRate` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Cache.CacheStatistics.NewestEntry`
+
+```csharp
+public System.DateTimeOffset NewestEntry { get; set; }
+```
+Gets or sets the timestamp of the newest cache entry.
+
+- Value: The `NewestEntry` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Cache.CacheStatistics.OldestEntry`
+
+```csharp
+public System.DateTimeOffset OldestEntry { get; set; }
+```
+Gets or sets the timestamp of the oldest cache entry.
+
+- Value: The `OldestEntry` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Cache.CacheStatistics.PendingRequestCount`
+
+```csharp
+public int PendingRequestCount { get; }
+```
+Gets the pending request count.
+
+- Value: The pending request count.
+
+###### `P:IoT.DriverCore.S7PlcRx.Cache.CacheStatistics.TotalEntries`
+
+```csharp
+public int TotalEntries { get; set; }
+```
+Gets or sets the total number of cached entries.
+
+- Value: The `TotalEntries` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Cache.CacheStatistics.TotalHits`
+
+```csharp
+public long TotalHits { get; set; }
+```
+Gets or sets the total number of cache hits.
+
+- Value: The `TotalHits` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Cache.CachedTagValue`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Cache.CachedTagValue
+```
+Represents a cached value along with metadata about its storage and usage.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Cache.CachedTagValue.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Cache.CachedTagValue()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Cache.CachedTagValue`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Cache.CachedTagValue.HitCount`
+
+```csharp
+public long HitCount { get; set; }
+```
+Gets or sets the number of cache hits.
+
+- Value: The `HitCount` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Cache.CachedTagValue.Timestamp`
+
+```csharp
+public System.DateTimeOffset Timestamp { get; set; }
+```
+Gets or sets when the value was cached.
+
+- Value: The `Timestamp` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Cache.CachedTagValue.Value`
+
+```csharp
+public object Value { get; set; }
+```
+Gets or sets the cached value.
+
+- Value: The `Value` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Core.ConnectionPool`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Core.ConnectionPool
+```
+Manages a pool of PLC connections, providing load-balanced access and connection reuse according to the specified configuration.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Core.ConnectionPool.#ctor(IoT.DriverCore.S7PlcRx.Core.ConnectionPoolConfig)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Core.ConnectionPool(IoT.DriverCore.S7PlcRx.Core.ConnectionPoolConfig config)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.Core.ConnectionPool` class.
+
+- Parameter `config`: The pool configuration.
+
+###### `M:IoT.DriverCore.S7PlcRx.Core.ConnectionPool.#ctor(System.Collections.Generic.IEnumerable`1{IoT.DriverCore.S7PlcRx.Enterprise.PlcConnectionConfig},IoT.DriverCore.S7PlcRx.Core.ConnectionPoolConfig)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Core.ConnectionPool(System.Collections.Generic.IEnumerable<IoT.DriverCore.S7PlcRx.Enterprise.PlcConnectionConfig> connectionConfigs, IoT.DriverCore.S7PlcRx.Core.ConnectionPoolConfig poolConfig)
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Core.ConnectionPool`.
+
+- Parameter `connectionConfigs`: The `connectionConfigs` value.
+- Parameter `poolConfig`: The `poolConfig` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.Core.ConnectionPool.Dispose`
+
+```csharp
+public void Dispose()
+```
+Disposes all connections in the pool.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.ConnectionPool.ActiveConnections`
+
+```csharp
+public int ActiveConnections { get; }
+```
+Gets the number of active connections.
+
+- Value: The `ActiveConnections` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.ConnectionPool.AllConnections`
+
+```csharp
+public System.Collections.Generic.IEnumerable<IoT.DriverCore.S7PlcRx.IRxS7> AllConnections { get; }
+```
+Gets all connections in the pool.
+
+- Value: The `AllConnections` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.ConnectionPool.Connection`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.IRxS7 Connection { get; }
+```
+Gets a connection from the pool using load balancing.
+
+- Returns: An available PLC connection.
+- Value: The `Connection` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.ConnectionPool.MaxConnections`
+
+```csharp
+public int MaxConnections { get; }
+```
+Gets the maximum number of connections in the pool.
+
+- Value: The `MaxConnections` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Core.ConnectionPoolConfig`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Core.ConnectionPoolConfig
+```
+Configures connection-pool limits, timeouts, and behavior.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Core.ConnectionPoolConfig.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Core.ConnectionPoolConfig()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Core.ConnectionPoolConfig`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.ConnectionPoolConfig.ConnectionTimeout`
+
+```csharp
+public System.TimeSpan ConnectionTimeout { get; set; }
+```
+Gets or sets the connection timeout.
+
+- Value: The `ConnectionTimeout` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.ConnectionPoolConfig.EnableConnectionReuse`
+
+```csharp
+public bool EnableConnectionReuse { get; set; }
+```
+Gets or sets a value indicating whether to enable connection reuse.
+
+- Value: The `EnableConnectionReuse` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.ConnectionPoolConfig.EnableLoadBalancing`
+
+```csharp
+public bool EnableLoadBalancing { get; set; }
+```
+Gets or sets a value indicating whether to enable load balancing.
+
+- Value: The `EnableLoadBalancing` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.ConnectionPoolConfig.HealthCheckInterval`
+
+```csharp
+public System.TimeSpan HealthCheckInterval { get; set; }
+```
+Gets or sets the health check interval.
+
+- Value: The `HealthCheckInterval` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.ConnectionPoolConfig.MaxConnections`
+
+```csharp
+public int MaxConnections { get; set; }
+```
+Gets or sets the maximum number of connections in the pool.
+
+- Value: The `MaxConnections` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.ConnectionPoolConfig.MaxPoolSize`
+
+```csharp
+public int MaxPoolSize { get; set; }
+```
+Gets or sets the maximum pool size.
+
+- Value: The `MaxPoolSize` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Core.DataBlockInfo`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Core.DataBlockInfo
+```
+Represents metadata and configuration information for a data block, including its identifier, size, tag details, access frequency, and optimization settings.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Core.DataBlockInfo.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Core.DataBlockInfo()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Core.DataBlockInfo`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.DataBlockInfo.AccessFrequency`
+
+```csharp
+public double AccessFrequency { get; set; }
+```
+Gets or sets the access frequency.
+
+- Value: The `AccessFrequency` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.DataBlockInfo.BlockNumber`
+
+```csharp
+public int BlockNumber { get; set; }
+```
+Gets or sets the data block number.
+
+- Value: The `BlockNumber` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.DataBlockInfo.IsBatchOptimized`
+
+```csharp
+public bool IsBatchOptimized { get; set; }
+```
+Gets or sets whether the block is optimized for batch operations.
+
+- Value: The `IsBatchOptimized` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.DataBlockInfo.SizeBytes`
+
+```csharp
+public int SizeBytes { get; set; }
+```
+Gets or sets the total size in bytes.
+
+- Value: The `SizeBytes` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.DataBlockInfo.TagCount`
+
+```csharp
+public int TagCount { get; set; }
+```
+Gets or sets the number of tags in this block.
+
+- Value: The `TagCount` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.DataBlockInfo.TagNames`
+
+```csharp
+public System.Collections.Generic.List<string> TagNames { get; }
+```
+Gets the tags in this data block.
+
+- Value: The `TagNames` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Core.OperationDetail`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Core.OperationDetail
+```
+Describes an operation and its status, duration, and metadata.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Core.OperationDetail.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Core.OperationDetail()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Core.OperationDetail`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.OperationDetail.DataBlockNumber`
+
+```csharp
+public int DataBlockNumber { get; set; }
+```
+Gets or sets the data block number.
+
+- Value: The `DataBlockNumber` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.OperationDetail.Duration`
+
+```csharp
+public System.TimeSpan Duration { get; set; }
+```
+Gets or sets the operation duration.
+
+- Value: The `Duration` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.OperationDetail.ErrorMessage`
+
+```csharp
+public string ErrorMessage { get; set; }
+```
+Gets or sets any error message.
+
+- Value: The `ErrorMessage` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.OperationDetail.OperationType`
+
+```csharp
+public string OperationType { get; set; }
+```
+Gets or sets the operation type.
+
+- Value: The `OperationType` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.OperationDetail.Success`
+
+```csharp
+public bool Success { get; set; }
+```
+Gets or sets a value indicating whether gets or sets whether the operation succeeded.
+
+- Value: The `Success` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Core.OperationDetail.TagName`
+
+```csharp
+public string TagName { get; set; }
+```
+Gets or sets the tag name.
+
+- Value: The `TagName` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Core.RequestPriority`
+
+```csharp
+public enum IoT.DriverCore.S7PlcRx.Core.RequestPriority
+```
+Request priority levels for batch processing.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.S7PlcRx.Core.RequestPriority.Critical`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Core.RequestPriority Critical
+```
+Critical priority request.
+
+###### `F:IoT.DriverCore.S7PlcRx.Core.RequestPriority.High`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Core.RequestPriority High
+```
+High priority request.
+
+###### `F:IoT.DriverCore.S7PlcRx.Core.RequestPriority.Low`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Core.RequestPriority Low
+```
+Low priority request.
+
+###### `F:IoT.DriverCore.S7PlcRx.Core.RequestPriority.Normal`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Core.RequestPriority Normal
+```
+Normal priority request.
+
+#### `T:IoT.DriverCore.S7PlcRx.Enterprise.EnterpriseExtensions`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Enterprise.EnterpriseExtensions
+```
+Provides enterprise PLC connectivity and symbolic-addressing extensions.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Enterprise.EnterpriseExtensions.CreateConnectionPool(System.Collections.Generic.IEnumerable`1{IoT.DriverCore.S7PlcRx.Enterprise.PlcConnectionConfig},IoT.DriverCore.S7PlcRx.Core.ConnectionPoolConfig)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.Core.ConnectionPool CreateConnectionPool(System.Collections.Generic.IEnumerable<IoT.DriverCore.S7PlcRx.Enterprise.PlcConnectionConfig> connectionConfigs, IoT.DriverCore.S7PlcRx.Core.ConnectionPoolConfig poolConfig)
+```
+Executes the `CreateConnectionPool` operation.
+
+- Parameter `connectionConfigs`: The `connectionConfigs` value.
+- Parameter `poolConfig`: The `poolConfig` value.
+- Returns: A `IoT.DriverCore.S7PlcRx.Core.ConnectionPool` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.Enterprise.EnterpriseExtensions.CreateConnectionPool(System.Collections.Generic.IEnumerable`1{IoT.DriverCore.S7PlcRx.Enterprise.PlcConnectionConfig},IoT.DriverCore.S7PlcRx.Core.ConnectionPoolConfig,System.TimeProvider)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.Core.ConnectionPool CreateConnectionPool(System.Collections.Generic.IEnumerable<IoT.DriverCore.S7PlcRx.Enterprise.PlcConnectionConfig> connectionConfigs, IoT.DriverCore.S7PlcRx.Core.ConnectionPoolConfig poolConfig, System.TimeProvider timeProvider)
+```
+Executes the `CreateConnectionPool` operation.
+
+- Parameter `connectionConfigs`: The `connectionConfigs` value.
+- Parameter `poolConfig`: The `poolConfig` value.
+- Parameter `timeProvider`: The `timeProvider` value.
+- Returns: A `IoT.DriverCore.S7PlcRx.Core.ConnectionPool` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.Enterprise.EnterpriseExtensions.CreateHighAvailabilityConnection(IoT.DriverCore.S7PlcRx.IRxS7,System.Collections.Generic.IList`1{IoT.DriverCore.S7PlcRx.IRxS7})`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.Enterprise.HighAvailabilityPlcManager CreateHighAvailabilityConnection(IoT.DriverCore.S7PlcRx.IRxS7 primaryPlc, System.Collections.Generic.IList<IoT.DriverCore.S7PlcRx.IRxS7> backupPlcs)
+```
+Executes the `CreateHighAvailabilityConnection` operation.
+
+- Parameter `primaryPlc`: The `primaryPlc` value.
+- Parameter `backupPlcs`: The `backupPlcs` value.
+- Returns: A `IoT.DriverCore.S7PlcRx.Enterprise.HighAvailabilityPlcManager` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.Enterprise.EnterpriseExtensions.CreateHighAvailabilityConnection(IoT.DriverCore.S7PlcRx.IRxS7,System.Collections.Generic.IList`1{IoT.DriverCore.S7PlcRx.IRxS7},System.TimeSpan)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.Enterprise.HighAvailabilityPlcManager CreateHighAvailabilityConnection(IoT.DriverCore.S7PlcRx.IRxS7 primaryPlc, System.Collections.Generic.IList<IoT.DriverCore.S7PlcRx.IRxS7> backupPlcs, System.TimeSpan healthCheckInterval)
+```
+Executes the `CreateHighAvailabilityConnection` operation.
+
+- Parameter `primaryPlc`: The `primaryPlc` value.
+- Parameter `backupPlcs`: The `backupPlcs` value.
+- Parameter `healthCheckInterval`: The `healthCheckInterval` value.
+- Returns: A `IoT.DriverCore.S7PlcRx.Enterprise.HighAvailabilityPlcManager` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.Enterprise.EnterpriseExtensions.LoadSymbolTableAsync(IoT.DriverCore.S7PlcRx.IRxS7,System.String)`
+
+```csharp
+public static System.Threading.Tasks.Task<IoT.DriverCore.S7PlcRx.Enterprise.SymbolTable> LoadSymbolTableAsync(IoT.DriverCore.S7PlcRx.IRxS7 plc, string symbolTableData)
+```
+Loads and caches a CSV symbol table for symbolic addressing support.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `symbolTableData`: CSV symbol table data.
+- Returns: The loaded symbol table.
+
+###### `M:IoT.DriverCore.S7PlcRx.Enterprise.EnterpriseExtensions.LoadSymbolTableAsync(IoT.DriverCore.S7PlcRx.IRxS7,System.String,IoT.DriverCore.S7PlcRx.Enterprise.SymbolTableFormat)`
+
+```csharp
+public static System.Threading.Tasks.Task<IoT.DriverCore.S7PlcRx.Enterprise.SymbolTable> LoadSymbolTableAsync(IoT.DriverCore.S7PlcRx.IRxS7 plc, string symbolTableData, IoT.DriverCore.S7PlcRx.Enterprise.SymbolTableFormat format)
+```
+Loads and caches a symbol table for symbolic addressing support.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `symbolTableData`: Symbol table data.
+- Parameter `format`: The format of the symbol table data.
+- Returns: The loaded symbol table.
+
+###### `M:IoT.DriverCore.S7PlcRx.Enterprise.EnterpriseExtensions.ReadSymbolAsync(IoT.DriverCore.S7PlcRx.IRxS7,System.String)`
+
+```csharp
+public static System.Threading.Tasks.Task<object> ReadSymbolAsync(IoT.DriverCore.S7PlcRx.IRxS7 plc, string symbolName)
+```
+Reads the value of the specified symbol from the PLC.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `symbolName`: The symbol name.
+- Returns: A task containing the symbol value.
+
+###### `M:IoT.DriverCore.S7PlcRx.Enterprise.EnterpriseExtensions.WriteSymbol``1(IoT.DriverCore.S7PlcRx.IRxS7,System.String,``0)`
+
+```csharp
+public static void WriteSymbol<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, string symbolName, T value)
+```
+Writes a value to the specified PLC symbol by name.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `symbolName`: The symbol name.
+- Parameter `value`: The value to write.
+
+#### `T:IoT.DriverCore.S7PlcRx.Enterprise.HighAvailabilityPlcManager`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Enterprise.HighAvailabilityPlcManager
+```
+Provides high-availability management for PLC connections.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Enterprise.HighAvailabilityPlcManager.#ctor(IoT.DriverCore.S7PlcRx.IRxS7,System.Collections.Generic.IList`1{IoT.DriverCore.S7PlcRx.IRxS7})`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Enterprise.HighAvailabilityPlcManager(IoT.DriverCore.S7PlcRx.IRxS7 primaryPlc, System.Collections.Generic.IList<IoT.DriverCore.S7PlcRx.IRxS7> backupPlcs)
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Enterprise.HighAvailabilityPlcManager`.
+
+- Parameter `primaryPlc`: The `primaryPlc` value.
+- Parameter `backupPlcs`: The `backupPlcs` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.Enterprise.HighAvailabilityPlcManager.#ctor(IoT.DriverCore.S7PlcRx.IRxS7,System.Collections.Generic.IList`1{IoT.DriverCore.S7PlcRx.IRxS7},System.TimeSpan)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Enterprise.HighAvailabilityPlcManager(IoT.DriverCore.S7PlcRx.IRxS7 primaryPlc, System.Collections.Generic.IList<IoT.DriverCore.S7PlcRx.IRxS7> backupPlcs, System.TimeSpan healthCheckInterval)
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Enterprise.HighAvailabilityPlcManager`.
+
+- Parameter `primaryPlc`: The `primaryPlc` value.
+- Parameter `backupPlcs`: The `backupPlcs` value.
+- Parameter `healthCheckInterval`: The `healthCheckInterval` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.Enterprise.HighAvailabilityPlcManager.#ctor(IoT.DriverCore.S7PlcRx.IRxS7,System.Collections.Generic.IList`1{IoT.DriverCore.S7PlcRx.IRxS7},System.TimeSpan,System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Enterprise.HighAvailabilityPlcManager(IoT.DriverCore.S7PlcRx.IRxS7 primaryPlc, System.Collections.Generic.IList<IoT.DriverCore.S7PlcRx.IRxS7> backupPlcs, System.TimeSpan healthCheckInterval, System.TimeProvider timeProvider)
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Enterprise.HighAvailabilityPlcManager`.
+
+- Parameter `primaryPlc`: The `primaryPlc` value.
+- Parameter `backupPlcs`: The `backupPlcs` value.
+- Parameter `healthCheckInterval`: The `healthCheckInterval` value.
+- Parameter `timeProvider`: The `timeProvider` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.Enterprise.HighAvailabilityPlcManager.Dispose`
+
+```csharp
+public void Dispose()
+```
+Disposes the high-availability manager.
+
+###### `M:IoT.DriverCore.S7PlcRx.Enterprise.HighAvailabilityPlcManager.TriggerFailoverAsync`
+
+```csharp
+public System.Threading.Tasks.Task<bool> TriggerFailoverAsync()
+```
+Manually triggers a failover to the next available backup.
+
+- Returns: A value indicating whether failover was successful.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.HighAvailabilityPlcManager.ActivePLC`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.IRxS7 ActivePLC { get; }
+```
+Gets the currently active PLC connection.
+
+- Value: The `ActivePLC` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.HighAvailabilityPlcManager.FailoverEvents`
+
+```csharp
+public System.IObservable<IoT.DriverCore.S7PlcRx.Enterprise.PlcFailoverEvent> FailoverEvents { get; }
+```
+Gets the observable stream of failover events.
+
+- Value: The `FailoverEvents` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Enterprise.PlcConnectionConfig`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Enterprise.PlcConnectionConfig
+```
+Represents the settings required to establish a programmable logic controller connection.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Enterprise.PlcConnectionConfig.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Enterprise.PlcConnectionConfig()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Enterprise.PlcConnectionConfig`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.PlcConnectionConfig.ConnectionName`
+
+```csharp
+public string ConnectionName { get; set; }
+```
+Gets or sets the connection name.
+
+- Value: The `ConnectionName` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.PlcConnectionConfig.IPAddress`
+
+```csharp
+public string IPAddress { get; set; }
+```
+Gets or sets the IP address.
+
+- Value: The `IPAddress` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.PlcConnectionConfig.PLCType`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Enums.CpuType PLCType { get; set; }
+```
+Gets or sets the PLC type.
+
+- Value: The `PLCType` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.PlcConnectionConfig.Rack`
+
+```csharp
+public short Rack { get; set; }
+```
+Gets or sets the rack number.
+
+- Value: The `Rack` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.PlcConnectionConfig.Slot`
+
+```csharp
+public short Slot { get; set; }
+```
+Gets or sets the slot number.
+
+- Value: The `Slot` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Enterprise.PlcFailoverEvent`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Enterprise.PlcFailoverEvent
+```
+Represents an event that occurs when a programmable logic controller failover takes place.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Enterprise.PlcFailoverEvent.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Enterprise.PlcFailoverEvent()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Enterprise.PlcFailoverEvent`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.PlcFailoverEvent.NewPlc`
+
+```csharp
+public string NewPlc { get; set; }
+```
+Gets or sets the new PLC identifier.
+
+- Value: The `NewPlc` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.PlcFailoverEvent.OldPlc`
+
+```csharp
+public string OldPlc { get; set; }
+```
+Gets or sets the old PLC identifier.
+
+- Value: The `OldPlc` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.PlcFailoverEvent.Reason`
+
+```csharp
+public string Reason { get; set; }
+```
+Gets or sets the reason for failover.
+
+- Value: The `Reason` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.PlcFailoverEvent.Timestamp`
+
+```csharp
+public System.DateTimeOffset Timestamp { get; set; }
+```
+Gets or sets the timestamp of the failover.
+
+- Value: The `Timestamp` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Enterprise.SecurityContext`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Enterprise.SecurityContext
+```
+Represents the security context for a session, including encryption settings, session timing, and certificate information.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Enterprise.SecurityContext.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Enterprise.SecurityContext()
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.Enterprise.SecurityContext` class.
+
+###### `M:IoT.DriverCore.S7PlcRx.Enterprise.SecurityContext.#ctor(System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Enterprise.SecurityContext(System.TimeProvider timeProvider)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.Enterprise.SecurityContext` class.
+
+- Parameter `timeProvider`: The time provider.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.SecurityContext.CertificatePassword`
+
+```csharp
+public string CertificatePassword { get; }
+```
+Gets the certificate password.
+
+- Value: The certificate password.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.SecurityContext.CertificatePath`
+
+```csharp
+public string CertificatePath { get; }
+```
+Gets the certificate path.
+
+- Value: The certificate path.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.SecurityContext.EnableEncryption`
+
+```csharp
+public bool EnableEncryption { get; }
+```
+Gets a value indicating whether [enable encryption].
+
+- Value: true if [enable encryption]; otherwise, false .
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.SecurityContext.EncryptionKey`
+
+```csharp
+public string EncryptionKey { get; set; }
+```
+Gets or sets the encryption key.
+
+- Value: The `EncryptionKey` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.SecurityContext.IsEnabled`
+
+```csharp
+public bool IsEnabled { get; set; }
+```
+Gets or sets a value indicating whether security is enabled.
+
+- Value: The `IsEnabled` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.SecurityContext.IsSessionValid`
+
+```csharp
+public bool IsSessionValid { get; }
+```
+Gets a value indicating whether the session is still valid.
+
+- Value: The `IsSessionValid` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.SecurityContext.PLCKey`
+
+```csharp
+public string PLCKey { get; set; }
+```
+Gets or sets the PLC key identifier.
+
+- Value: The `PLCKey` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.SecurityContext.SessionStartTime`
+
+```csharp
+public System.DateTimeOffset SessionStartTime { get; set; }
+```
+Gets or sets the session start time.
+
+- Value: The `SessionStartTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.SecurityContext.SessionTimeout`
+
+```csharp
+public System.TimeSpan SessionTimeout { get; set; }
+```
+Gets or sets the session timeout.
+
+- Value: The `SessionTimeout` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Enterprise.Symbol`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Enterprise.Symbol
+```
+Represents a programmable logic controller (PLC) symbol, including its name, address, data type, length, and description.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Enterprise.Symbol.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Enterprise.Symbol()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Enterprise.Symbol`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.Symbol.Address`
+
+```csharp
+public string Address { get; set; }
+```
+Gets or sets the PLC address.
+
+- Value: The `Address` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.Symbol.DataType`
+
+```csharp
+public string DataType { get; set; }
+```
+Gets or sets the data type.
+
+- Value: The `DataType` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.Symbol.Description`
+
+```csharp
+public string Description { get; set; }
+```
+Gets or sets the description.
+
+- Value: The `Description` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.Symbol.Length`
+
+```csharp
+public int Length { get; set; }
+```
+Gets or sets the length for array types.
+
+- Value: The `Length` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.Symbol.Name`
+
+```csharp
+public string Name { get; set; }
+```
+Gets or sets the symbol name.
+
+- Value: The `Name` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Enterprise.SymbolTable`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Enterprise.SymbolTable
+```
+Represents a read-only table of named symbols and the time at which it was loaded.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Enterprise.SymbolTable.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Enterprise.SymbolTable()
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.Enterprise.SymbolTable` class.
+
+###### `M:IoT.DriverCore.S7PlcRx.Enterprise.SymbolTable.#ctor(System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Enterprise.SymbolTable(System.TimeProvider timeProvider)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.Enterprise.SymbolTable` class.
+
+- Parameter `timeProvider`: The time provider.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.SymbolTable.LoadedAt`
+
+```csharp
+public System.DateTimeOffset LoadedAt { get; }
+```
+Gets the timestamp when the symbol table was loaded.
+
+- Value: The `LoadedAt` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Enterprise.SymbolTable.Symbols`
+
+```csharp
+public System.Collections.Generic.Dictionary<string, IoT.DriverCore.S7PlcRx.Enterprise.Symbol> Symbols { get; }
+```
+Gets the collection of symbols indexed by name.
+
+- Value: The `Symbols` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Enterprise.SymbolTableFormat`
+
+```csharp
+public enum IoT.DriverCore.S7PlcRx.Enterprise.SymbolTableFormat
+```
+Specifies the supported formats for serializing or deserializing a symbol table.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.S7PlcRx.Enterprise.SymbolTableFormat.Csv`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enterprise.SymbolTableFormat Csv
+```
+CSV format.
+
+###### `F:IoT.DriverCore.S7PlcRx.Enterprise.SymbolTableFormat.Json`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enterprise.SymbolTableFormat Json
+```
+JSON format.
+
+###### `F:IoT.DriverCore.S7PlcRx.Enterprise.SymbolTableFormat.Xml`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enterprise.SymbolTableFormat Xml
+```
+XML format.
+
+#### `T:IoT.DriverCore.S7PlcRx.Enums.CpuType`
+
+```csharp
+public enum IoT.DriverCore.S7PlcRx.Enums.CpuType
+```
+Specifies the supported CPU types for Siemens programmable logic controllers (PLCs).
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.S7PlcRx.Enums.CpuType.Logo0BA8`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enums.CpuType Logo0BA8
+```
+The logo0ba8.
+
+###### `F:IoT.DriverCore.S7PlcRx.Enums.CpuType.S71200`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enums.CpuType S71200
+```
+The Siemens S7 1200 CPU family.
+
+###### `F:IoT.DriverCore.S7PlcRx.Enums.CpuType.S71500`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enums.CpuType S71500
+```
+The Siemens S7 1500 CPU family.
+
+###### `F:IoT.DriverCore.S7PlcRx.Enums.CpuType.S7200`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enums.CpuType S7200
+```
+The S7200.
+
+###### `F:IoT.DriverCore.S7PlcRx.Enums.CpuType.S7300`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enums.CpuType S7300
+```
+The S7300.
+
+###### `F:IoT.DriverCore.S7PlcRx.Enums.CpuType.S7400`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enums.CpuType S7400
+```
+The S7400.
+
+#### `T:IoT.DriverCore.S7PlcRx.Enums.ErrorCode`
+
+```csharp
+public enum IoT.DriverCore.S7PlcRx.Enums.ErrorCode
+```
+Specifies error codes that indicate the result of an operation or the type of error encountered.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.S7PlcRx.Enums.ErrorCode.ConnectionError`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enums.ErrorCode ConnectionError
+```
+The connection error.
+
+###### `F:IoT.DriverCore.S7PlcRx.Enums.ErrorCode.IPAddressNotAvailable`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enums.ErrorCode IPAddressNotAvailable
+```
+The IP address not available.
+
+###### `F:IoT.DriverCore.S7PlcRx.Enums.ErrorCode.NoError`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enums.ErrorCode NoError
+```
+The no error.
+
+###### `F:IoT.DriverCore.S7PlcRx.Enums.ErrorCode.ReadData`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enums.ErrorCode ReadData
+```
+The read data.
+
+###### `F:IoT.DriverCore.S7PlcRx.Enums.ErrorCode.SendData`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enums.ErrorCode SendData
+```
+The send data.
+
+###### `F:IoT.DriverCore.S7PlcRx.Enums.ErrorCode.WriteData`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enums.ErrorCode WriteData
+```
+The write data.
+
+###### `F:IoT.DriverCore.S7PlcRx.Enums.ErrorCode.WrongCPUType`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enums.ErrorCode WrongCPUType
+```
+The wrong CPU type.
+
+###### `F:IoT.DriverCore.S7PlcRx.Enums.ErrorCode.WrongNumberReceivedBytes`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enums.ErrorCode WrongNumberReceivedBytes
+```
+The wrong number received bytes.
+
+###### `F:IoT.DriverCore.S7PlcRx.Enums.ErrorCode.WrongVarFormat`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enums.ErrorCode WrongVarFormat
+```
+The wrong variable format.
+
+#### `T:IoT.DriverCore.S7PlcRx.Enums.S7StringType`
+
+```csharp
+public enum IoT.DriverCore.S7PlcRx.Enums.S7StringType
+```
+Specifies the string encoding type used for S7 PLC string variables.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.S7PlcRx.Enums.S7StringType.None`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enums.S7StringType None
+```
+No S7 string encoding type has been selected.
+
+###### `F:IoT.DriverCore.S7PlcRx.Enums.S7StringType.S7String`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enums.S7StringType S7String
+```
+ASCII string.
+
+###### `F:IoT.DriverCore.S7PlcRx.Enums.S7StringType.S7WString`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Enums.S7StringType S7WString
+```
+Unicode string.
+
+#### `T:IoT.DriverCore.S7PlcRx.IRxS7`
+
+```csharp
+public interface IoT.DriverCore.S7PlcRx.IRxS7
+```
+Defines an interface for reactive communication with a Siemens S7 PLC, providing observable access to connection status, errors, tag values, and PLC information, as well as methods for reading and writing variables asynchronously.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.IRxS7.GetCpuInfo`
+
+```csharp
+public System.IObservable<string[]> GetCpuInfo()
+```
+Retrieves an observable sequence containing information about the system's CPU.
+
+- Returns: An observable sequence of string arrays, where each array contains details about the CPU. It emits new arrays when CPU information is updated.
+
+###### `M:IoT.DriverCore.S7PlcRx.IRxS7.Observe``1(IoT.DriverCore.Core.LogicalTagKey`1{``0})`
+
+```csharp
+public System.IObservable<T> Observe<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag)
+```
+Executes the `Observe` operation.
+
+- Parameter `tag`: The `tag` value.
+- Returns: A `System.IObservable<T>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.IRxS7.ReadAsync``1(IoT.DriverCore.Core.LogicalTagKey`1{``0})`
+
+```csharp
+public System.Threading.Tasks.Task<T> ReadAsync<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag)
+```
+Executes the `ReadAsync` operation.
+
+- Parameter `tag`: The `tag` value.
+- Returns: A `System.Threading.Tasks.Task<T>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.IRxS7.ReadAsync``1(IoT.DriverCore.Core.LogicalTagKey`1{``0},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<T> ReadAsync<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ReadAsync` operation.
+
+- Parameter `tag`: The `tag` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<T>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.IRxS7.Value``1(System.String,``0)`
+
+```csharp
+public void Value<T>(string variable, T value)
+```
+Sets the value of a variable with the specified name and value.
+
+- Parameter `variable`: The name of the variable to set. Can be null to indicate an unnamed or default variable.
+- Parameter `value`: The value to assign to the variable. Can be null if the variable type allows null values.
+
+###### `P:IoT.DriverCore.S7PlcRx.IRxS7.IP`
+
+```csharp
+public string IP { get; }
+```
+Gets the IP address associated with the current instance.
+
+- Value: The `IP` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.IRxS7.IsConnected`
+
+```csharp
+public System.IObservable<bool> IsConnected { get; }
+```
+Gets an observable sequence that indicates whether the connection is currently established.
+
+- Value: The `IsConnected` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.IRxS7.IsConnectedValue`
+
+```csharp
+public bool IsConnectedValue { get; }
+```
+Gets a value indicating whether the connection is currently established.
+
+- Value: The `IsConnectedValue` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.IRxS7.IsPaused`
+
+```csharp
+public System.IObservable<bool> IsPaused { get; }
+```
+Gets an observable sequence that indicates whether the operation is currently paused.
+
+- Value: The `IsPaused` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.IRxS7.LastError`
+
+```csharp
+public System.IObservable<string> LastError { get; }
+```
+Gets an observable sequence that provides error messages encountered during operation.
+
+- Value: The `LastError` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.IRxS7.LastErrorCode`
+
+```csharp
+public System.IObservable<IoT.DriverCore.S7PlcRx.Enums.ErrorCode> LastErrorCode { get; }
+```
+Gets an observable sequence of the most recent error codes.
+
+- Value: The `LastErrorCode` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.IRxS7.ObserveAll`
+
+```csharp
+public System.IObservable<IoT.DriverCore.S7PlcRx.Tag> ObserveAll { get; }
+```
+Gets an observable sequence that emits all tag updates as they occur.
+
+- Value: The `ObserveAll` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.IRxS7.PLCType`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Enums.CpuType PLCType { get; }
+```
+Gets the type of programmable logic controller (PLC) associated with this instance.
+
+- Value: The `PLCType` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.IRxS7.Rack`
+
+```csharp
+public short Rack { get; }
+```
+Gets the rack number associated with the device or connection.
+
+- Value: The `Rack` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.IRxS7.ReadTime`
+
+```csharp
+public System.IObservable<long> ReadTime { get; }
+```
+Gets an observable sequence that provides the current read time in ticks.
+
+- Value: The `ReadTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.IRxS7.ShowWatchDogWriting`
+
+```csharp
+public bool ShowWatchDogWriting { get; set; }
+```
+Gets or sets a value indicating whether WatchDog writing operations are displayed.
+
+- Value: The `ShowWatchDogWriting` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.IRxS7.Slot`
+
+```csharp
+public short Slot { get; }
+```
+Gets the slot number associated with the current instance.
+
+- Value: The `Slot` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.IRxS7.Status`
+
+```csharp
+public System.IObservable<string> Status { get; }
+```
+Gets an observable sequence that provides status updates as strings.
+
+- Value: The `Status` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.IRxS7.TagList`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Tags TagList { get; }
+```
+Gets the collection of tags associated with the current instance.
+
+- Value: The `TagList` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.IRxS7.WatchDogAddress`
+
+```csharp
+public string WatchDogAddress { get; }
+```
+Gets the network address of the WatchDog service, if configured.
+
+- Value: The `WatchDogAddress` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.IRxS7.WatchDogValueToWrite`
+
+```csharp
+public ushort WatchDogValueToWrite { get; set; }
+```
+Gets or sets the value to be written to the watchdog register.
+
+- Value: The `WatchDogValueToWrite` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.IRxS7.WatchDogWritingTime`
+
+```csharp
+public int WatchDogWritingTime { get; }
+```
+Gets the time interval, in milliseconds, used by the watchdog for writing operations.
+
+- Value: The `WatchDogWritingTime` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.ITag`
+
+```csharp
+public interface IoT.DriverCore.S7PlcRx.ITag
+```
+Represents a tag that can be configured to control polling behavior.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.ITag.SetDoNotPoll(System.Boolean)`
+
+```csharp
+public void SetDoNotPoll(bool value)
+```
+Sets whether the object should be excluded from polling operations.
+
+- Parameter `value`: true to prevent the object from being polled; otherwise, false.
+
+#### `T:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient
+```
+Composes an S7 connection with the common logical-tag catalog, persistence, and client contracts.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.#ctor(IoT.DriverCore.S7PlcRx.IRxS7,IoT.DriverCore.Core.ILogicalTagCatalog)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient(IoT.DriverCore.S7PlcRx.IRxS7 plc, IoT.DriverCore.Core.ILogicalTagCatalog catalog)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient` class.
+
+- Parameter `plc`: The S7 connection.
+- Parameter `catalog`: The common logical-tag catalog.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.#ctor(IoT.DriverCore.S7PlcRx.IRxS7,IoT.DriverCore.Core.ILogicalTagCatalog,IoT.DriverCore.Core.LogicalTagSqliteStore)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient(IoT.DriverCore.S7PlcRx.IRxS7 plc, IoT.DriverCore.Core.ILogicalTagCatalog catalog, IoT.DriverCore.Core.LogicalTagSqliteStore store)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient` class.
+
+- Parameter `plc`: The S7 connection.
+- Parameter `catalog`: The common logical-tag catalog.
+- Parameter `store`: The SQLite store used by persistence forwarding methods, or .
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.#ctor(IoT.DriverCore.S7PlcRx.IRxS7,IoT.DriverCore.Core.ILogicalTagCatalog,IoT.DriverCore.Core.LogicalTagSqliteStore,System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient(IoT.DriverCore.S7PlcRx.IRxS7 plc, IoT.DriverCore.Core.ILogicalTagCatalog catalog, IoT.DriverCore.Core.LogicalTagSqliteStore store, System.TimeProvider timeProvider)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient` class.
+
+- Parameter `plc`: The S7 connection.
+- Parameter `catalog`: The common logical-tag catalog.
+- Parameter `store`: The SQLite store used by persistence forwarding methods, or .
+- Parameter `timeProvider`: The time provider.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.#ctor(IoT.DriverCore.S7PlcRx.IRxS7,IoT.DriverCore.Core.ILogicalTagCatalog,System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient(IoT.DriverCore.S7PlcRx.IRxS7 plc, IoT.DriverCore.Core.ILogicalTagCatalog catalog, System.TimeProvider timeProvider)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient` class.
+
+- Parameter `plc`: The S7 connection.
+- Parameter `catalog`: The common logical-tag catalog.
+- Parameter `timeProvider`: The time provider.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.CreateTag(IoT.DriverCore.Core.LogicalTag)`
+
+```csharp
+public IoT.DriverCore.Core.LogicalTag CreateTag(IoT.DriverCore.Core.LogicalTag tag)
+```
+Registers and returns an S7 logical tag.
+
+- Parameter `tag`: The logical tag to register.
+- Returns: The registered logical tag.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.DeleteGroupAsync(System.String)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> DeleteGroupAsync(string name)
+```
+Deletes a persisted logical group.
+
+- Parameter `name`: The logical group name.
+- Returns: True when the group was deleted.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.DeleteGroupAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> DeleteGroupAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Deletes a persisted logical group.
+
+- Parameter `name`: The logical group name.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: True when the group was deleted.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.DeleteTagAsync(System.String)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> DeleteTagAsync(string name)
+```
+Deletes a persisted tag and removes it from the live catalog when successful.
+
+- Parameter `name`: The logical tag name.
+- Returns: True when the tag was deleted.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.DeleteTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> DeleteTagAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Deletes a persisted tag and removes it from the live catalog when successful.
+
+- Parameter `name`: The logical tag name.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: True when the tag was deleted.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.Dispose`
+
+```csharp
+public void Dispose()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.EditTagAsync(IoT.DriverCore.Core.LogicalTag)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> EditTagAsync(IoT.DriverCore.Core.LogicalTag tag)
+```
+Edits an existing persisted logical tag and updates the live catalog when successful.
+
+- Parameter `tag`: The logical tag.
+- Returns: True when the tag was updated.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.EditTagAsync(IoT.DriverCore.Core.LogicalTag,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> EditTagAsync(IoT.DriverCore.Core.LogicalTag tag, System.Threading.CancellationToken cancellationToken)
+```
+Edits an existing persisted logical tag and updates the live catalog when successful.
+
+- Parameter `tag`: The logical tag.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: True when the tag was updated.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.ExportCsvAsync(System.IO.TextWriter)`
+
+```csharp
+public System.Threading.Tasks.Task ExportCsvAsync(System.IO.TextWriter writer)
+```
+Exports the catalog using the common RFC 4180 CSV representation.
+
+- Parameter `writer`: The CSV writer.
+- Returns: A task that represents the export operation.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.ExportCsvAsync(System.IO.TextWriter,System.Char)`
+
+```csharp
+public System.Threading.Tasks.Task ExportCsvAsync(System.IO.TextWriter writer, char delimiter)
+```
+Exports the catalog using the common CSV representation.
+
+- Parameter `writer`: The CSV writer.
+- Parameter `delimiter`: The CSV delimiter.
+- Returns: A task that represents the export operation.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.ExportCsvAsync(System.IO.TextWriter,System.Char,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task ExportCsvAsync(System.IO.TextWriter writer, char delimiter, System.Threading.CancellationToken cancellationToken)
+```
+Exports the catalog using the common CSV representation.
+
+- Parameter `writer`: The CSV writer.
+- Parameter `delimiter`: The CSV delimiter.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: A task that represents the export operation.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.GetGroupAsync(System.String)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.LogicalTagGroup> GetGroupAsync(string name)
+```
+Gets a persisted logical group.
+
+- Parameter `name`: The logical group name.
+- Returns: The persisted logical group, if found.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.GetGroupAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.LogicalTagGroup> GetGroupAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Gets a persisted logical group.
+
+- Parameter `name`: The logical group name.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The persisted logical group, if found.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.GetTagAsync(System.String)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.LogicalTag> GetTagAsync(string name)
+```
+Gets a persisted logical tag.
+
+- Parameter `name`: The logical tag name.
+- Returns: The persisted logical tag, if found.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.GetTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.LogicalTag> GetTagAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Gets a persisted logical tag.
+
+- Parameter `name`: The logical tag name.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The persisted logical tag, if found.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.ImportCsvAsync(System.IO.TextReader)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> ImportCsvAsync(System.IO.TextReader reader)
+```
+Imports RFC 4180 common-tag CSV and dynamically upserts every definition.
+
+- Parameter `reader`: The CSV reader.
+- Returns: The imported logical tags.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.ImportCsvAsync(System.IO.TextReader,System.Char)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> ImportCsvAsync(System.IO.TextReader reader, char delimiter)
+```
+Imports common-tag CSV and dynamically upserts every definition.
+
+- Parameter `reader`: The CSV reader.
+- Parameter `delimiter`: The CSV delimiter.
+- Returns: The imported logical tags.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.ImportCsvAsync(System.IO.TextReader,System.Char,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> ImportCsvAsync(System.IO.TextReader reader, char delimiter, System.Threading.CancellationToken cancellationToken)
+```
+Imports common-tag CSV and dynamically upserts every definition.
+
+- Parameter `reader`: The CSV reader.
+- Parameter `delimiter`: The CSV delimiter.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The imported logical tags.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.InitializeStoreAsync(IoT.DriverCore.Core.LogicalTagSqliteStore)`
+
+```csharp
+public System.Threading.Tasks.Task InitializeStoreAsync(IoT.DriverCore.Core.LogicalTagSqliteStore store)
+```
+Assigns and initializes the SQLite store used by this client.
+
+- Parameter `store`: The SQLite store.
+- Returns: A task that represents the initialization operation.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.InitializeStoreAsync(IoT.DriverCore.Core.LogicalTagSqliteStore,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task InitializeStoreAsync(IoT.DriverCore.Core.LogicalTagSqliteStore store, System.Threading.CancellationToken cancellationToken)
+```
+Assigns and initializes the SQLite store used by this client.
+
+- Parameter `store`: The SQLite store.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: A task that represents the initialization operation.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.InitializeStoreAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task InitializeStoreAsync(System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.ListGroupsAsync`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTagGroup>> ListGroupsAsync()
+```
+Lists persisted logical groups.
+
+- Returns: The persisted logical groups.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.ListGroupsAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTagGroup>> ListGroupsAsync(System.Threading.CancellationToken cancellationToken)
+```
+Lists persisted logical groups.
+
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The persisted logical groups.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.ListTagsAsync`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> ListTagsAsync()
+```
+Lists persisted logical tags.
+
+- Returns: The persisted logical tags.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.ListTagsAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> ListTagsAsync(System.Threading.CancellationToken cancellationToken)
+```
+Lists persisted logical tags.
+
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The persisted logical tags.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.LoadTagsAsync`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> LoadTagsAsync()
+```
+Loads every SQLite tag into the live catalog.
+
+- Returns: The loaded logical tags.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.LoadTagsAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> LoadTagsAsync(System.Threading.CancellationToken cancellationToken)
+```
+Loads every SQLite tag into the live catalog.
+
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The loaded logical tags.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.Observe(System.String)`
+
+```csharp
+public System.IObservable<IoT.DriverCore.Core.LogicalTagValue> Observe(string tagName)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Returns: A `System.IObservable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.ObserveAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue> ObserveAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.ObserveMany(System.Collections.Generic.IReadOnlyCollection`1{System.String})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.Core.LogicalTagValue> ObserveMany(System.Collections.Generic.IReadOnlyCollection<string> tagNames)
+```
+Executes the `ObserveMany` operation.
+
+- Parameter `tagNames`: The `tagNames` value.
+- Returns: A `System.IObservable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.ObserveManyAsync(System.Collections.Generic.IReadOnlyCollection`1{System.String},System.Threading.CancellationToken)`
+
+```csharp
+public System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue> ObserveManyAsync(System.Collections.Generic.IReadOnlyCollection<string> tagNames, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ObserveManyAsync` operation.
+
+- Parameter `tagNames`: The `tagNames` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.ReadAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>> ReadAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.ReadManyAsync(System.Collections.Generic.IReadOnlyCollection`1{System.String},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>> ReadManyAsync(System.Collections.Generic.IReadOnlyCollection<string> tagNames, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ReadManyAsync` operation.
+
+- Parameter `tagNames`: The `tagNames` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.RegisterTag(IoT.DriverCore.Core.LogicalTag)`
+
+```csharp
+public void RegisterTag(IoT.DriverCore.Core.LogicalTag tag)
+```
+Adds or replaces a logical definition and registers it with the S7 connection.
+
+- Parameter `tag`: The logical tag.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.RemoveTag(System.String)`
+
+```csharp
+public bool RemoveTag(string name)
+```
+Removes a logical definition and its S7 registration.
+
+- Parameter `name`: The logical tag name.
+- Returns: True when the tag existed.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.UpdateTagAsync(IoT.DriverCore.Core.LogicalTag)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> UpdateTagAsync(IoT.DriverCore.Core.LogicalTag tag)
+```
+Alias for `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.EditTagAsync(IoT.DriverCore.Core.LogicalTag)` .
+
+- Parameter `tag`: The logical tag.
+- Returns: True when the tag was updated.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.UpdateTagAsync(IoT.DriverCore.Core.LogicalTag,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> UpdateTagAsync(IoT.DriverCore.Core.LogicalTag tag, System.Threading.CancellationToken cancellationToken)
+```
+Alias for `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.EditTagAsync(IoT.DriverCore.Core.LogicalTag,System.Threading.CancellationToken)` .
+
+- Parameter `tag`: The logical tag.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: True when the tag was updated.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.UpsertGroupAsync(IoT.DriverCore.Core.LogicalTagGroup)`
+
+```csharp
+public System.Threading.Tasks.Task UpsertGroupAsync(IoT.DriverCore.Core.LogicalTagGroup group)
+```
+Persists a logical group.
+
+- Parameter `group`: The logical group.
+- Returns: A task that represents the persistence operation.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.UpsertGroupAsync(IoT.DriverCore.Core.LogicalTagGroup,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task UpsertGroupAsync(IoT.DriverCore.Core.LogicalTagGroup group, System.Threading.CancellationToken cancellationToken)
+```
+Persists a logical group.
+
+- Parameter `group`: The logical group.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: A task that represents the persistence operation.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.UpsertTagAsync(IoT.DriverCore.Core.LogicalTag)`
+
+```csharp
+public System.Threading.Tasks.Task UpsertTagAsync(IoT.DriverCore.Core.LogicalTag tag)
+```
+Persists and dynamically registers a logical tag.
+
+- Parameter `tag`: The logical tag.
+- Returns: A task that represents the persistence operation.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.UpsertTagAsync(IoT.DriverCore.Core.LogicalTag,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task UpsertTagAsync(IoT.DriverCore.Core.LogicalTag tag, System.Threading.CancellationToken cancellationToken)
+```
+Persists and dynamically registers a logical tag.
+
+- Parameter `tag`: The logical tag.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: A task that represents the persistence operation.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.WriteAsync(IoT.DriverCore.Core.LogicalTagValue,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>> WriteAsync(IoT.DriverCore.Core.LogicalTagValue value, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `value`: The `value` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.WriteManyAsync(System.Collections.Generic.IReadOnlyCollection`1{IoT.DriverCore.Core.LogicalTagValue},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>> WriteManyAsync(System.Collections.Generic.IReadOnlyCollection<IoT.DriverCore.Core.LogicalTagValue> values, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `WriteManyAsync` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>>` result.
+
+###### `P:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient.Catalog`
+
+```csharp
+public IoT.DriverCore.Core.ILogicalTagCatalog Catalog { get; }
+```
+Gets the mutable logical-tag catalog observed by this client.
+
+- Value: The `Catalog` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagExtensions`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagExtensions
+```
+Creates common logical clients and typed operation-result projections for S7 callers.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagExtensions.CreateLogicalTagCatalog(System.Collections.Generic.IEnumerable`1{IoT.DriverCore.S7PlcRx.Binding.S7TagDefinition})`
+
+```csharp
+public static IoT.DriverCore.Core.LogicalTagCatalog CreateLogicalTagCatalog(System.Collections.Generic.IEnumerable<IoT.DriverCore.S7PlcRx.Binding.S7TagDefinition> definitions)
+```
+Executes the `CreateLogicalTagCatalog` operation.
+
+- Parameter `definitions`: The `definitions` value.
+- Returns: A `IoT.DriverCore.Core.LogicalTagCatalog` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagExtensions.CreateLogicalTagClient(IoT.DriverCore.S7PlcRx.IRxS7,IoT.DriverCore.Core.ILogicalTagCatalog)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient CreateLogicalTagClient(IoT.DriverCore.S7PlcRx.IRxS7 plc, IoT.DriverCore.Core.ILogicalTagCatalog catalog)
+```
+Creates a dynamically synchronized logical client.
+
+- Parameter `plc`: The S7 connection.
+- Parameter `catalog`: The logical-tag catalog.
+- Returns: The dynamically synchronized logical client.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagExtensions.CreateLogicalTagClient(IoT.DriverCore.S7PlcRx.IRxS7,IoT.DriverCore.Core.ILogicalTagCatalog,IoT.DriverCore.Core.LogicalTagSqliteStore)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagClient CreateLogicalTagClient(IoT.DriverCore.S7PlcRx.IRxS7 plc, IoT.DriverCore.Core.ILogicalTagCatalog catalog, IoT.DriverCore.Core.LogicalTagSqliteStore store)
+```
+Creates a dynamically synchronized logical client with persistence.
+
+- Parameter `plc`: The S7 connection.
+- Parameter `catalog`: The logical-tag catalog.
+- Parameter `store`: The SQLite store.
+- Returns: The dynamically synchronized logical client.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagExtensions.ReadAsync``1(IoT.DriverCore.Core.ILogicalTagClient,System.String,``0)`
+
+```csharp
+public static System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<T>> ReadAsync<T>(IoT.DriverCore.Core.ILogicalTagClient client, string tagName, T type)
+```
+Reads and converts a common logical result to the requested payload type.
+
+- Parameter `client`: The logical-tag client.
+- Parameter `tagName`: The logical tag name.
+- Parameter `type`: A value that supplies the requested payload type.
+- Returns: The typed tag operation result.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagExtensions.ReadAsync``1(IoT.DriverCore.Core.ILogicalTagClient,System.String,``0,System.Threading.CancellationToken)`
+
+```csharp
+public static System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<T>> ReadAsync<T>(IoT.DriverCore.Core.ILogicalTagClient client, string tagName, T type, System.Threading.CancellationToken cancellationToken)
+```
+Reads and converts a common logical result to the requested payload type.
+
+- Parameter `client`: The logical-tag client.
+- Parameter `tagName`: The logical tag name.
+- Parameter `type`: A value that supplies the requested payload type.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The typed tag operation result.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagExtensions.WriteAsync``1(IoT.DriverCore.Core.ILogicalTagClient,System.String,``0,System.Threading.CancellationToken)`
+
+```csharp
+public static System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<T>> WriteAsync<T>(IoT.DriverCore.Core.ILogicalTagClient client, string tagName, T value, System.Threading.CancellationToken cancellationToken)
+```
+Writes a typed common logical value and projects the result payload.
+
+- Parameter `client`: The logical-tag client.
+- Parameter `tagName`: The logical tag name.
+- Parameter `value`: The value to write.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The typed tag operation result.
+
+###### `M:IoT.DriverCore.S7PlcRx.LogicalTags.S7LogicalTagExtensions.WriteAsync``1(IoT.DriverCore.Core.ILogicalTagClient,System.String,``0,System.TimeProvider,System.Threading.CancellationToken)`
+
+```csharp
+public static System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<T>> WriteAsync<T>(IoT.DriverCore.Core.ILogicalTagClient client, string tagName, T value, System.TimeProvider timeProvider, System.Threading.CancellationToken cancellationToken)
+```
+Writes a typed common logical value and projects the result payload.
+
+- Parameter `client`: The logical-tag client.
+- Parameter `tagName`: The logical tag name.
+- Parameter `value`: The value to write.
+- Parameter `timeProvider`: The time provider.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The typed tag operation result.
+
+#### `T:IoT.DriverCore.S7PlcRx.Optimization.OptimizationExtensions`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Optimization.OptimizationExtensions
+```
+Provides extension methods for IRxS7 to enable optimized tag monitoring, intelligent value caching, and cache management for PLC data access.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Optimization.OptimizationExtensions.ClearCache(IoT.DriverCore.S7PlcRx.IRxS7)`
+
+```csharp
+public static void ClearCache(IoT.DriverCore.S7PlcRx.IRxS7 plc)
+```
+Clears all cached values for the specified PLC instance.
+
+- Parameter `plc`: The PLC instance.
+
+###### `M:IoT.DriverCore.S7PlcRx.Optimization.OptimizationExtensions.ClearCache(IoT.DriverCore.S7PlcRx.IRxS7,System.String)`
+
+```csharp
+public static void ClearCache(IoT.DriverCore.S7PlcRx.IRxS7 plc, string tagName)
+```
+Clears a cached value for the specified PLC tag.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `tagName`: The name of the tag to clear from the cache.
+
+###### `M:IoT.DriverCore.S7PlcRx.Optimization.OptimizationExtensions.GetCacheStatistics(IoT.DriverCore.S7PlcRx.IRxS7)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.Cache.CacheStatistics GetCacheStatistics(IoT.DriverCore.S7PlcRx.IRxS7 plc)
+```
+Retrieves cache usage statistics for the specified PLC instance.
+
+- Parameter `plc`: The PLC instance.
+- Returns: A CacheStatistics object containing aggregated cache metrics for the specified PLC.
+
+###### `M:IoT.DriverCore.S7PlcRx.Optimization.OptimizationExtensions.GetCacheStatistics(IoT.DriverCore.S7PlcRx.IRxS7,System.TimeProvider)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.Cache.CacheStatistics GetCacheStatistics(IoT.DriverCore.S7PlcRx.IRxS7 plc, System.TimeProvider timeProvider)
+```
+Retrieves cache usage statistics for the specified PLC instance.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `timeProvider`: The time provider.
+- Returns: A CacheStatistics object containing aggregated cache metrics for the specified PLC.
+
+###### `M:IoT.DriverCore.S7PlcRx.Optimization.OptimizationExtensions.MonitorTagSmart``1(IoT.DriverCore.S7PlcRx.IRxS7,System.String,System.Collections.Generic.IEqualityComparer`1{``0},System.Double,System.Int32)`
+
+```csharp
+public static System.IObservable<IoT.DriverCore.S7PlcRx.Optimization.SmartTagChange<T>> MonitorTagSmart<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, string tagName, System.Collections.Generic.IEqualityComparer<T> comparer, double changeThreshold, int debounceMs)
+```
+Executes the `MonitorTagSmart` operation.
+
+- Parameter `plc`: The `plc` value.
+- Parameter `tagName`: The `tagName` value.
+- Parameter `comparer`: The `comparer` value.
+- Parameter `changeThreshold`: The `changeThreshold` value.
+- Parameter `debounceMs`: The `debounceMs` value.
+- Returns: A `System.IObservable<IoT.DriverCore.S7PlcRx.Optimization.SmartTagChange<T>>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.Optimization.OptimizationExtensions.MonitorTagSmart``1(IoT.DriverCore.S7PlcRx.IRxS7,System.String,System.Collections.Generic.IEqualityComparer`1{``0},System.Double,System.Int32,System.TimeProvider)`
+
+```csharp
+public static System.IObservable<IoT.DriverCore.S7PlcRx.Optimization.SmartTagChange<T>> MonitorTagSmart<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, string tagName, System.Collections.Generic.IEqualityComparer<T> comparer, double changeThreshold, int debounceMs, System.TimeProvider timeProvider)
+```
+Executes the `MonitorTagSmart` operation.
+
+- Parameter `plc`: The `plc` value.
+- Parameter `tagName`: The `tagName` value.
+- Parameter `comparer`: The `comparer` value.
+- Parameter `changeThreshold`: The `changeThreshold` value.
+- Parameter `debounceMs`: The `debounceMs` value.
+- Parameter `timeProvider`: The `timeProvider` value.
+- Returns: A `System.IObservable<IoT.DriverCore.S7PlcRx.Optimization.SmartTagChange<T>>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.Optimization.OptimizationExtensions.ValueCachedAsync``1(IoT.DriverCore.S7PlcRx.IRxS7,System.String,``0,System.TimeSpan)`
+
+```csharp
+public static System.Threading.Tasks.Task<T> ValueCachedAsync<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, string tagName, T fallbackValue, System.TimeSpan cacheTimeout)
+```
+Retrieves a PLC tag value, using a valid cached value when available.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `tagName`: The name of the PLC tag to read.
+- Parameter `fallbackValue`: The value returned when the PLC does not provide a value.
+- Parameter `cacheTimeout`: The maximum duration for which a cached value is considered valid.
+- Returns: A task that represents the asynchronous operation.
+
+###### `M:IoT.DriverCore.S7PlcRx.Optimization.OptimizationExtensions.ValueCachedAsync``1(IoT.DriverCore.S7PlcRx.IRxS7,System.String,``0,System.TimeSpan,System.TimeProvider)`
+
+```csharp
+public static System.Threading.Tasks.Task<T> ValueCachedAsync<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, string tagName, T fallbackValue, System.TimeSpan cacheTimeout, System.TimeProvider timeProvider)
+```
+Retrieves a PLC tag value, using a valid cached value when available.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `tagName`: The name of the PLC tag to read.
+- Parameter `fallbackValue`: The value returned when the PLC does not provide a value.
+- Parameter `cacheTimeout`: The maximum duration for which a cached value is considered valid.
+- Parameter `timeProvider`: The time provider.
+- Returns: A task that represents the asynchronous operation.
+
+#### `T:IoT.DriverCore.S7PlcRx.Optimization.OptimizationRequestPriority`
+
+```csharp
+public enum IoT.DriverCore.S7PlcRx.Optimization.OptimizationRequestPriority
+```
+Specifies the priority level for an optimization request.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.S7PlcRx.Optimization.OptimizationRequestPriority.Critical`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Optimization.OptimizationRequestPriority Critical
+```
+Critical priority.
+
+###### `F:IoT.DriverCore.S7PlcRx.Optimization.OptimizationRequestPriority.High`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Optimization.OptimizationRequestPriority High
+```
+High priority.
+
+###### `F:IoT.DriverCore.S7PlcRx.Optimization.OptimizationRequestPriority.Low`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Optimization.OptimizationRequestPriority Low
+```
+Low priority.
+
+###### `F:IoT.DriverCore.S7PlcRx.Optimization.OptimizationRequestPriority.Normal`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Optimization.OptimizationRequestPriority Normal
+```
+Normal priority.
+
+#### `T:IoT.DriverCore.S7PlcRx.Optimization.ReadOptimizationConfig`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Optimization.ReadOptimizationConfig
+```
+Provides configuration options for optimizing read operations, including parallelism, delays, concurrency limits, and timeouts within data block groups.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Optimization.ReadOptimizationConfig.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Optimization.ReadOptimizationConfig()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Optimization.ReadOptimizationConfig`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.ReadOptimizationConfig.EnableParallelReads`
+
+```csharp
+public bool EnableParallelReads { get; set; }
+```
+Gets or sets whether parallel reads within data block groups are enabled.
+
+- Value: The `EnableParallelReads` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.ReadOptimizationConfig.InterGroupDelayMs`
+
+```csharp
+public int InterGroupDelayMs { get; set; }
+```
+Gets or sets the delay between data block groups in milliseconds.
+
+- Value: The `InterGroupDelayMs` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.ReadOptimizationConfig.MaxConcurrentReads`
+
+```csharp
+public int MaxConcurrentReads { get; set; }
+```
+Gets or sets the maximum number of concurrent reads.
+
+- Value: The `MaxConcurrentReads` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.ReadOptimizationConfig.ReadTimeoutMs`
+
+```csharp
+public int ReadTimeoutMs { get; set; }
+```
+Gets or sets the read timeout in milliseconds.
+
+- Value: The `ReadTimeoutMs` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Optimization.SmartTagChange`1`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Optimization.SmartTagChange`1
+```
+Represents a change to a smart tag, including its name, previous and current values, the time of change, the amount of change for numeric types, and associated metadata.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Optimization.SmartTagChange`1.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Optimization.SmartTagChange<T>()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Optimization.SmartTagChange`1`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.SmartTagChange`1.ChangeAmount`
+
+```csharp
+public double ChangeAmount { get; set; }
+```
+Gets or sets the amount of change for numeric types.
+
+- Value: The `ChangeAmount` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.SmartTagChange`1.ChangeTime`
+
+```csharp
+public System.DateTimeOffset ChangeTime { get; set; }
+```
+Gets or sets the change timestamp.
+
+- Value: The `ChangeTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.SmartTagChange`1.CurrentValue`
+
+```csharp
+public T CurrentValue { get; set; }
+```
+Gets or sets the current value.
+
+- Value: The `CurrentValue` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.SmartTagChange`1.Metadata`
+
+```csharp
+public System.Collections.Generic.Dictionary<string, object> Metadata { get; }
+```
+Gets additional metadata about the change.
+
+- Value: The `Metadata` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.SmartTagChange`1.PreviousValue`
+
+```csharp
+public T PreviousValue { get; set; }
+```
+Gets or sets the previous value.
+
+- Value: The `PreviousValue` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.SmartTagChange`1.TagName`
+
+```csharp
+public string TagName { get; set; }
+```
+Gets or sets the tag name.
+
+- Value: The `TagName` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationConfig`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationConfig
+```
+Provides configuration options for optimizing write operations, including parallelism, verification, timing, and concurrency settings.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationConfig.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationConfig()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationConfig`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationConfig.EnableParallelWrites`
+
+```csharp
+public bool EnableParallelWrites { get; set; }
+```
+Gets or sets whether parallel writes within data block groups are enabled.
+
+- Value: The `EnableParallelWrites` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationConfig.InterGroupDelayMs`
+
+```csharp
+public int InterGroupDelayMs { get; set; }
+```
+Gets or sets the delay between data block groups in milliseconds.
+
+- Value: The `InterGroupDelayMs` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationConfig.MaxConcurrentWrites`
+
+```csharp
+public int MaxConcurrentWrites { get; set; }
+```
+Gets or sets the maximum number of concurrent writes.
+
+- Value: The `MaxConcurrentWrites` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationConfig.VerifyWrites`
+
+```csharp
+public bool VerifyWrites { get; set; }
+```
+Gets or sets a value indicating whether writes are verified by reading them back.
+
+- Value: The `VerifyWrites` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationConfig.WriteTimeoutMs`
+
+```csharp
+public int WriteTimeoutMs { get; set; }
+```
+Gets or sets the write timeout in milliseconds.
+
+- Value: The `WriteTimeoutMs` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationResult`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationResult
+```
+Represents the result of a write optimization operation, including timing information, per-write outcomes, and overall error details.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationResult.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationResult()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationResult`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationResult.EndTime`
+
+```csharp
+public System.DateTimeOffset EndTime { get; set; }
+```
+Gets or sets the operation end time.
+
+- Value: The `EndTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationResult.FailedWrites`
+
+```csharp
+public System.Collections.Generic.Dictionary<string, string> FailedWrites { get; }
+```
+Gets failed writes with error messages.
+
+- Value: The `FailedWrites` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationResult.OverallError`
+
+```csharp
+public string OverallError { get; set; }
+```
+Gets or sets any overall error message.
+
+- Value: The `OverallError` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationResult.StartTime`
+
+```csharp
+public System.DateTimeOffset StartTime { get; set; }
+```
+Gets or sets the operation start time.
+
+- Value: The `StartTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationResult.SuccessRate`
+
+```csharp
+public double SuccessRate { get; }
+```
+Gets the success rate.
+
+- Value: The `SuccessRate` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationResult.SuccessfulWrites`
+
+```csharp
+public System.Collections.Generic.Dictionary<string, System.TimeSpan> SuccessfulWrites { get; }
+```
+Gets successful writes with their durations.
+
+- Value: The `SuccessfulWrites` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationResult.TotalDuration`
+
+```csharp
+public System.TimeSpan TotalDuration { get; }
+```
+Gets the total operation duration.
+
+- Value: The `TotalDuration` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Performance.BenchmarkConfig`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Performance.BenchmarkConfig
+```
+Represents the configuration settings for benchmark tests, including parameters for latency, throughput, and reliability measurements.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Performance.BenchmarkConfig.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Performance.BenchmarkConfig()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Performance.BenchmarkConfig`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.BenchmarkConfig.LatencyTestCount`
+
+```csharp
+public int LatencyTestCount { get; set; }
+```
+Gets or sets the number of latency tests to perform.
+
+- Value: The `LatencyTestCount` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.BenchmarkConfig.ReliabilityTestCount`
+
+```csharp
+public int ReliabilityTestCount { get; set; }
+```
+Gets or sets the number of reliability tests to perform.
+
+- Value: The `ReliabilityTestCount` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.BenchmarkConfig.ThroughputTestDuration`
+
+```csharp
+public System.TimeSpan ThroughputTestDuration { get; set; }
+```
+Gets or sets the duration for throughput testing.
+
+- Value: The `ThroughputTestDuration` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Performance.BenchmarkResult`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Performance.BenchmarkResult
+```
+Represents the results of a performance benchmark, including timing, latency, throughput, reliability, and any errors encountered during execution.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Performance.BenchmarkResult.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Performance.BenchmarkResult()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Performance.BenchmarkResult`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.BenchmarkResult.AverageLatencyMs`
+
+```csharp
+public double AverageLatencyMs { get; set; }
+```
+Gets or sets the average latency in milliseconds.
+
+- Value: The `AverageLatencyMs` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.BenchmarkResult.EndTime`
+
+```csharp
+public System.DateTimeOffset EndTime { get; set; }
+```
+Gets or sets the benchmark end time.
+
+- Value: The `EndTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.BenchmarkResult.Errors`
+
+```csharp
+public System.Collections.Generic.List<string> Errors { get; }
+```
+Gets any errors encountered during benchmarking.
+
+- Value: The `Errors` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.BenchmarkResult.MaxLatencyMs`
+
+```csharp
+public double MaxLatencyMs { get; set; }
+```
+Gets or sets the maximum latency in milliseconds.
+
+- Value: The `MaxLatencyMs` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.BenchmarkResult.MinLatencyMs`
+
+```csharp
+public double MinLatencyMs { get; set; }
+```
+Gets or sets the minimum latency in milliseconds.
+
+- Value: The `MinLatencyMs` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.BenchmarkResult.OperationsPerSecond`
+
+```csharp
+public double OperationsPerSecond { get; set; }
+```
+Gets or sets the operations per second.
+
+- Value: The `OperationsPerSecond` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.BenchmarkResult.OverallScore`
+
+```csharp
+public double OverallScore { get; set; }
+```
+Gets or sets the overall benchmark score (0 to 100).
+
+- Value: The `OverallScore` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.BenchmarkResult.PLCIdentifier`
+
+```csharp
+public string PLCIdentifier { get; set; }
+```
+Gets or sets the PLC identifier.
+
+- Value: The `PLCIdentifier` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.BenchmarkResult.ReliabilityRate`
+
+```csharp
+public double ReliabilityRate { get; set; }
+```
+Gets or sets the reliability rate (0.0 to 1.0).
+
+- Value: The `ReliabilityRate` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.BenchmarkResult.StartTime`
+
+```csharp
+public System.DateTimeOffset StartTime { get; set; }
+```
+Gets or sets the benchmark start time.
+
+- Value: The `StartTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.BenchmarkResult.TotalDuration`
+
+```csharp
+public System.TimeSpan TotalDuration { get; }
+```
+Gets the total benchmark duration.
+
+- Value: The `TotalDuration` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Performance.HighPerformanceTagGroup`1`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Performance.HighPerformanceTagGroup`1
+```
+Provides high-performance batch operations for a group of PLC tags.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Performance.HighPerformanceTagGroup`1.#ctor(IoT.DriverCore.S7PlcRx.IRxS7,System.String,System.String[])`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Performance.HighPerformanceTagGroup<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, string groupName, string[] tagNames)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.Performance.HighPerformanceTagGroup`1` class, associating a set of tag names with a specified. PLC for optimized group operations.
+
+- Parameter `plc`: The PLC connection used to manage and access the specified tags.
+- Parameter `groupName`: The name assigned to this tag group. Cannot be null or whitespace.
+- Parameter `tagNames`: An array of tag names to include in the group. Cannot be null or empty.
+
+###### `M:IoT.DriverCore.S7PlcRx.Performance.HighPerformanceTagGroup`1.Dispose`
+
+```csharp
+public void Dispose()
+```
+Disposes this tag group.
+
+###### `M:IoT.DriverCore.S7PlcRx.Performance.HighPerformanceTagGroup`1.ObserveGroup`
+
+```csharp
+public System.IObservable<System.Collections.Generic.Dictionary<string, T>> ObserveGroup()
+```
+Observes changes to the group of tags and provides a stream of their current values.
+
+- Returns: An observable sequence that emits a dictionary containing the latest values for each tag in the group. Each dictionary maps tag names to their corresponding values of type T. The sequence emits a new dictionary whenever any tag value changes.
+
+###### `M:IoT.DriverCore.S7PlcRx.Performance.HighPerformanceTagGroup`1.ReadAllAsync`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<string, T>> ReadAllAsync()
+```
+Asynchronously reads the values of all configured PLC tags and returns a dictionary mapping tag names to their corresponding values.
+
+- Returns: A dictionary containing the tag names as keys and their associated values of type as values. If a tag value cannot be read, its value will be .
+
+###### `M:IoT.DriverCore.S7PlcRx.Performance.HighPerformanceTagGroup`1.WriteAllAsync(System.Collections.Generic.Dictionary`2{System.String,`0})`
+
+```csharp
+public System.Threading.Tasks.Task WriteAllAsync(System.Collections.Generic.Dictionary<string, T> values)
+```
+Executes the `WriteAllAsync` operation.
+
+- Parameter `values`: The `values` value.
+- Returns: A `System.Threading.Tasks.Task` result.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.HighPerformanceTagGroup`1.CurrentValues`
+
+```csharp
+public System.Collections.Generic.IReadOnlyDictionary<string, T> CurrentValues { get; }
+```
+Gets a read-only dictionary containing the current values associated with each key.
+
+- Value: The `CurrentValues` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.HighPerformanceTagGroup`1.GroupName`
+
+```csharp
+public string GroupName { get; }
+```
+Gets the name of the group associated with this instance.
+
+- Value: The `GroupName` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Performance.PerformanceAnalysis`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Performance.PerformanceAnalysis
+```
+Represents the results and metrics of a performance analysis, including time intervals, tag change statistics, and optimization recommendations.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Performance.PerformanceAnalysis.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Performance.PerformanceAnalysis()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Performance.PerformanceAnalysis`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceAnalysis.AverageChangesPerTag`
+
+```csharp
+public double AverageChangesPerTag { get; set; }
+```
+Gets or sets the average changes per tag.
+
+- Value: The `AverageChangesPerTag` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceAnalysis.EndTime`
+
+```csharp
+public System.DateTimeOffset EndTime { get; set; }
+```
+Gets or sets the end time of the analysis.
+
+- Value: The `EndTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceAnalysis.MonitoringDuration`
+
+```csharp
+public System.TimeSpan MonitoringDuration { get; set; }
+```
+Gets or sets the monitoring duration.
+
+- Value: The `MonitoringDuration` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceAnalysis.Recommendations`
+
+```csharp
+public System.Collections.Generic.List<string> Recommendations { get; }
+```
+Gets or sets the optimization recommendations.
+
+- Value: The `Recommendations` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceAnalysis.StartTime`
+
+```csharp
+public System.DateTimeOffset StartTime { get; set; }
+```
+Gets or sets the start time of the analysis.
+
+- Value: The `StartTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceAnalysis.TagChangeFrequencies`
+
+```csharp
+public System.Collections.Generic.Dictionary<string, int> TagChangeFrequencies { get; }
+```
+Gets or sets the tag change frequencies.
+
+- Value: The `TagChangeFrequencies` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceAnalysis.TotalTagChanges`
+
+```csharp
+public int TotalTagChanges { get; set; }
+```
+Gets or sets the total tag changes observed.
+
+- Value: The `TotalTagChanges` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Performance.PerformanceExtensions`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Performance.PerformanceExtensions
+```
+Provides compositional methods for IRxS7 PLC instances to enable advanced performance monitoring, optimized read and write operations, and benchmarking capabilities.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Performance.PerformanceExtensions.GetPerformanceStatistics(IoT.DriverCore.S7PlcRx.IRxS7)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.Performance.PerformanceStatistics GetPerformanceStatistics(IoT.DriverCore.S7PlcRx.IRxS7 plc)
+```
+Retrieves aggregated performance statistics for the specified PLC connection, including operation counts, error rates, response times, and connection metrics.
+
+- Parameter `plc`: The PLC for which to retrieve performance statistics.
+- Returns: A PerformanceStatistics object containing metrics such as total operations, error rate, average response time, connection uptime, and reconnection count for the specified PLC.
+
+###### `M:IoT.DriverCore.S7PlcRx.Performance.PerformanceExtensions.GetPerformanceStatistics(IoT.DriverCore.S7PlcRx.IRxS7,System.TimeProvider)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.Performance.PerformanceStatistics GetPerformanceStatistics(IoT.DriverCore.S7PlcRx.IRxS7 plc, System.TimeProvider timeProvider)
+```
+Retrieves aggregated performance statistics for the specified PLC connection, including operation counts, error rates, response times, and connection metrics.
+
+- Parameter `plc`: The PLC for which to retrieve performance statistics.
+- Parameter `timeProvider`: The time provider.
+- Returns: A PerformanceStatistics object containing metrics such as total operations, error rate, average response time, connection uptime, and reconnection count for the specified PLC.
+
+###### `M:IoT.DriverCore.S7PlcRx.Performance.PerformanceExtensions.MonitorPerformance(IoT.DriverCore.S7PlcRx.IRxS7,System.Nullable`1{System.TimeSpan})`
+
+```csharp
+public static System.IObservable<IoT.DriverCore.S7PlcRx.Performance.PerformanceMetrics> MonitorPerformance(IoT.DriverCore.S7PlcRx.IRxS7 plc, System.Nullable<System.TimeSpan> monitoringInterval)
+```
+Executes the `MonitorPerformance` operation.
+
+- Parameter `plc`: The `plc` value.
+- Parameter `monitoringInterval`: The `monitoringInterval` value.
+- Returns: A `System.IObservable<IoT.DriverCore.S7PlcRx.Performance.PerformanceMetrics>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.Performance.PerformanceExtensions.MonitorPerformance(IoT.DriverCore.S7PlcRx.IRxS7,System.Nullable`1{System.TimeSpan},System.TimeProvider)`
+
+```csharp
+public static System.IObservable<IoT.DriverCore.S7PlcRx.Performance.PerformanceMetrics> MonitorPerformance(IoT.DriverCore.S7PlcRx.IRxS7 plc, System.Nullable<System.TimeSpan> monitoringInterval, System.TimeProvider timeProvider)
+```
+Executes the `MonitorPerformance` operation.
+
+- Parameter `plc`: The `plc` value.
+- Parameter `monitoringInterval`: The `monitoringInterval` value.
+- Parameter `timeProvider`: The `timeProvider` value.
+- Returns: A `System.IObservable<IoT.DriverCore.S7PlcRx.Performance.PerformanceMetrics>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.Performance.PerformanceExtensions.ReadOptimizedAsync``1(IoT.DriverCore.S7PlcRx.IRxS7,System.Collections.Generic.IEnumerable`1{System.String},``0,IoT.DriverCore.S7PlcRx.Optimization.ReadOptimizationConfig)`
+
+```csharp
+public static System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<string, T>> ReadOptimizedAsync<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, System.Collections.Generic.IEnumerable<string> tagNames, T typeMarker, IoT.DriverCore.S7PlcRx.Optimization.ReadOptimizationConfig optimizationConfig)
+```
+Executes the `ReadOptimizedAsync` operation.
+
+- Parameter `plc`: The `plc` value.
+- Parameter `tagNames`: The `tagNames` value.
+- Parameter `typeMarker`: The `typeMarker` value.
+- Parameter `optimizationConfig`: The `optimizationConfig` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<string, T>>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.Performance.PerformanceExtensions.RunBenchmarkAsync(IoT.DriverCore.S7PlcRx.IRxS7,IoT.DriverCore.S7PlcRx.Performance.BenchmarkConfig)`
+
+```csharp
+public static System.Threading.Tasks.Task<IoT.DriverCore.S7PlcRx.Performance.BenchmarkResult> RunBenchmarkAsync(IoT.DriverCore.S7PlcRx.IRxS7 plc, IoT.DriverCore.S7PlcRx.Performance.BenchmarkConfig benchmarkConfig)
+```
+Runs latency, throughput, and reliability benchmarks.
+
+- Parameter `plc`: The PLC to benchmark.
+- Parameter `benchmarkConfig`: An optional configuration object specifying benchmark parameters. If null, default settings are used.
+- Returns: A task that represents the asynchronous operation. The result contains detailed benchmark metrics and scores for the PLC.
+
+###### `M:IoT.DriverCore.S7PlcRx.Performance.PerformanceExtensions.RunBenchmarkAsync(IoT.DriverCore.S7PlcRx.IRxS7,IoT.DriverCore.S7PlcRx.Performance.BenchmarkConfig,System.TimeProvider)`
+
+```csharp
+public static System.Threading.Tasks.Task<IoT.DriverCore.S7PlcRx.Performance.BenchmarkResult> RunBenchmarkAsync(IoT.DriverCore.S7PlcRx.IRxS7 plc, IoT.DriverCore.S7PlcRx.Performance.BenchmarkConfig benchmarkConfig, System.TimeProvider timeProvider)
+```
+Runs latency, throughput, and reliability benchmarks.
+
+- Parameter `plc`: The PLC to benchmark.
+- Parameter `benchmarkConfig`: An optional configuration object specifying benchmark parameters. If null, default settings are used.
+- Parameter `timeProvider`: The time provider.
+- Returns: A task that represents the asynchronous operation. The result contains detailed benchmark metrics and scores for the PLC.
+
+###### `M:IoT.DriverCore.S7PlcRx.Performance.PerformanceExtensions.WriteOptimizedAsync``1(IoT.DriverCore.S7PlcRx.IRxS7,System.Collections.Generic.Dictionary`2{System.String,``0},IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationConfig)`
+
+```csharp
+public static System.Threading.Tasks.Task<IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationResult> WriteOptimizedAsync<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, System.Collections.Generic.Dictionary<string, T> values, IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationConfig optimizationConfig)
+```
+Executes the `WriteOptimizedAsync` operation.
+
+- Parameter `plc`: The `plc` value.
+- Parameter `values`: The `values` value.
+- Parameter `optimizationConfig`: The `optimizationConfig` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationResult>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.Performance.PerformanceExtensions.WriteOptimizedAsync``1(IoT.DriverCore.S7PlcRx.IRxS7,System.Collections.Generic.Dictionary`2{System.String,``0},IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationConfig,System.TimeProvider)`
+
+```csharp
+public static System.Threading.Tasks.Task<IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationResult> WriteOptimizedAsync<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, System.Collections.Generic.Dictionary<string, T> values, IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationConfig optimizationConfig, System.TimeProvider timeProvider)
+```
+Executes the `WriteOptimizedAsync` operation.
+
+- Parameter `plc`: The `plc` value.
+- Parameter `values`: The `values` value.
+- Parameter `optimizationConfig`: The `optimizationConfig` value.
+- Parameter `timeProvider`: The `timeProvider` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.S7PlcRx.Optimization.WriteOptimizationResult>` result.
+
+#### `T:IoT.DriverCore.S7PlcRx.Performance.PerformanceMetrics`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Performance.PerformanceMetrics
+```
+Represents PLC performance metrics at a specific point in time.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Performance.PerformanceMetrics.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Performance.PerformanceMetrics()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Performance.PerformanceMetrics`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceMetrics.ActiveTagCount`
+
+```csharp
+public int ActiveTagCount { get; set; }
+```
+Gets or sets the number of active tags.
+
+- Value: The `ActiveTagCount` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceMetrics.AverageResponseTime`
+
+```csharp
+public double AverageResponseTime { get; set; }
+```
+Gets or sets the average response time in milliseconds.
+
+- Value: The `AverageResponseTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceMetrics.ConnectionUptime`
+
+```csharp
+public System.TimeSpan ConnectionUptime { get; set; }
+```
+Gets or sets the connection uptime.
+
+- Value: The `ConnectionUptime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceMetrics.ErrorRate`
+
+```csharp
+public double ErrorRate { get; set; }
+```
+Gets or sets the error rate (0.0 to 1.0).
+
+- Value: The `ErrorRate` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceMetrics.IsConnected`
+
+```csharp
+public bool IsConnected { get; set; }
+```
+Gets or sets a value indicating whether gets or sets whether the PLC is connected.
+
+- Value: The `IsConnected` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceMetrics.OperationsPerSecond`
+
+```csharp
+public double OperationsPerSecond { get; set; }
+```
+Gets or sets the operations per second.
+
+- Value: The `OperationsPerSecond` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceMetrics.PLCIdentifier`
+
+```csharp
+public string PLCIdentifier { get; set; }
+```
+Gets or sets the PLC identifier.
+
+- Value: The `PLCIdentifier` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceMetrics.ReconnectionCount`
+
+```csharp
+public int ReconnectionCount { get; set; }
+```
+Gets or sets the number of reconnections.
+
+- Value: The `ReconnectionCount` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceMetrics.TagCount`
+
+```csharp
+public int TagCount { get; set; }
+```
+Gets or sets the total number of tags.
+
+- Value: The `TagCount` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceMetrics.Timestamp`
+
+```csharp
+public System.DateTimeOffset Timestamp { get; set; }
+```
+Gets or sets the timestamp of these metrics.
+
+- Value: The `Timestamp` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Performance.PerformanceStatistics`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Performance.PerformanceStatistics
+```
+Represents a set of performance statistics for a programmable logic controller (PLC) connection, including operation counts, error metrics, response times, and connection status information.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Performance.PerformanceStatistics.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Performance.PerformanceStatistics()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Performance.PerformanceStatistics`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceStatistics.AverageResponseTime`
+
+```csharp
+public double AverageResponseTime { get; set; }
+```
+Gets or sets the average response time in milliseconds.
+
+- Value: The `AverageResponseTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceStatistics.ConnectionUptime`
+
+```csharp
+public System.TimeSpan ConnectionUptime { get; set; }
+```
+Gets or sets the connection uptime.
+
+- Value: The `ConnectionUptime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceStatistics.ErrorRate`
+
+```csharp
+public double ErrorRate { get; set; }
+```
+Gets or sets the error rate (0.0 to 1.0).
+
+- Value: The `ErrorRate` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceStatistics.LastUpdated`
+
+```csharp
+public System.DateTimeOffset LastUpdated { get; set; }
+```
+Gets or sets when these statistics were last updated.
+
+- Value: The `LastUpdated` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceStatistics.OperationsPerSecond`
+
+```csharp
+public double OperationsPerSecond { get; set; }
+```
+Gets or sets the operations per second.
+
+- Value: The `OperationsPerSecond` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceStatistics.PLCIdentifier`
+
+```csharp
+public string PLCIdentifier { get; set; }
+```
+Gets or sets the PLC identifier.
+
+- Value: The `PLCIdentifier` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceStatistics.ReconnectionCount`
+
+```csharp
+public int ReconnectionCount { get; set; }
+```
+Gets or sets the number of reconnections.
+
+- Value: The `ReconnectionCount` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceStatistics.TotalErrors`
+
+```csharp
+public long TotalErrors { get; set; }
+```
+Gets or sets the total number of errors.
+
+- Value: The `TotalErrors` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.PerformanceStatistics.TotalOperations`
+
+```csharp
+public long TotalOperations { get; set; }
+```
+Gets or sets the total number of operations.
+
+- Value: The `TotalOperations` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Performance.TagPerformanceMetrics`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Performance.TagPerformanceMetrics
+```
+Represents operation counts, timings, and success rates for a tag.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Performance.TagPerformanceMetrics.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Performance.TagPerformanceMetrics()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Performance.TagPerformanceMetrics`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.TagPerformanceMetrics.AverageReadTimeMs`
+
+```csharp
+public double AverageReadTimeMs { get; set; }
+```
+Gets or sets the average read time in milliseconds.
+
+- Value: The `AverageReadTimeMs` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.TagPerformanceMetrics.AverageWriteTimeMs`
+
+```csharp
+public double AverageWriteTimeMs { get; set; }
+```
+Gets or sets the average write time in milliseconds.
+
+- Value: The `AverageWriteTimeMs` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.TagPerformanceMetrics.FailedOperations`
+
+```csharp
+public long FailedOperations { get; set; }
+```
+Gets or sets the number of failed operations.
+
+- Value: The `FailedOperations` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.TagPerformanceMetrics.LastOperationTime`
+
+```csharp
+public System.DateTimeOffset LastOperationTime { get; set; }
+```
+Gets or sets the last operation timestamp.
+
+- Value: The `LastOperationTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.TagPerformanceMetrics.ReadOperations`
+
+```csharp
+public long ReadOperations { get; set; }
+```
+Gets or sets the total number of read operations.
+
+- Value: The `ReadOperations` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.TagPerformanceMetrics.SuccessRate`
+
+```csharp
+public double SuccessRate { get; set; }
+```
+Gets or sets the success rate (0.0 to 1.0).
+
+- Value: The `SuccessRate` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.TagPerformanceMetrics.TagName`
+
+```csharp
+public string TagName { get; set; }
+```
+Gets or sets the tag name.
+
+- Value: The `TagName` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Performance.TagPerformanceMetrics.WriteOperations`
+
+```csharp
+public long WriteOperations { get; set; }
+```
+Gets or sets the total number of write operations.
+
+- Value: The `WriteOperations` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcException`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcException
+```
+Represents errors that occur during communication with a programmable logic controller (PLC).
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcException.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.PlcException()
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.PlcException` class.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcException.#ctor(IoT.DriverCore.S7PlcRx.Enums.ErrorCode)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.PlcException(IoT.DriverCore.S7PlcRx.Enums.ErrorCode errorCode)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.PlcException` class.
+
+- Parameter `errorCode`: The error code.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcException.#ctor(IoT.DriverCore.S7PlcRx.Enums.ErrorCode,System.Exception)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.PlcException(IoT.DriverCore.S7PlcRx.Enums.ErrorCode errorCode, System.Exception innerException)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.PlcException` class.
+
+- Parameter `errorCode`: The error code.
+- Parameter `innerException`: The inner exception.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcException.#ctor(IoT.DriverCore.S7PlcRx.Enums.ErrorCode,System.String)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.PlcException(IoT.DriverCore.S7PlcRx.Enums.ErrorCode errorCode, string message)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.PlcException` class.
+
+- Parameter `errorCode`: The error code.
+- Parameter `message`: The message.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcException.#ctor(IoT.DriverCore.S7PlcRx.Enums.ErrorCode,System.String,System.Exception)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.PlcException(IoT.DriverCore.S7PlcRx.Enums.ErrorCode errorCode, string message, System.Exception inner)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.PlcException` class.
+
+- Parameter `errorCode`: The error code.
+- Parameter `message`: The message.
+- Parameter `inner`: The inner.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcException.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.PlcException(string message)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.PlcException` class.
+
+- Parameter `message`: The message that describes the error.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcException.#ctor(System.String,System.Exception)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.PlcException(string message, System.Exception innerException)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.PlcException` class.
+
+- Parameter `message`: The message that describes the error.
+- Parameter `innerException`: The exception that caused the current exception.
+
+###### `P:IoT.DriverCore.S7PlcRx.PlcException.ErrorCode`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Enums.ErrorCode ErrorCode { get; }
+```
+Gets the error code.
+
+- Value: The error code.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.Bit`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.Bit
+```
+Contains the conversion methods to convert Bit from S7 plc to C#.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Bit.FromByte(System.Byte,System.Byte)`
+
+```csharp
+public static bool FromByte(byte v, byte bitAdr)
+```
+Determines whether the specified bit in a byte value is set.
+
+- Parameter `v`: The byte value to examine.
+- Parameter `bitAdr`: The zero-based position of the bit to check. Must be in the range 0 to 7.
+- Returns: true if the bit at the specified position is set; otherwise, false.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Bit.FromSpan(System.ReadOnlySpan`1{System.Byte},System.Int32,System.Int32)`
+
+```csharp
+public static bool FromSpan(System.ReadOnlySpan<byte> bytes, int byteIndex, int bitIndex)
+```
+Executes the `FromSpan` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Parameter `byteIndex`: The `byteIndex` value.
+- Parameter `bitIndex`: The `bitIndex` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Bit.GetBits(System.ReadOnlySpan`1{System.Byte},System.ReadOnlySpan`1{System.ValueTuple`2{System.Int32,System.Int32}})`
+
+```csharp
+public static bool[] GetBits(System.ReadOnlySpan<byte> bytes, System.ReadOnlySpan<System.ValueTuple<int, int>> bitPositions)
+```
+Executes the `GetBits` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Parameter `bitPositions`: The `bitPositions` value.
+- Returns: A `bool[]` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Bit.SetBit(System.Span`1{System.Byte},System.Int32,System.Int32,System.Boolean)`
+
+```csharp
+public static void SetBit(System.Span<byte> bytes, int byteIndex, int bitIndex, bool value)
+```
+Executes the `SetBit` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Parameter `byteIndex`: The `byteIndex` value.
+- Parameter `bitIndex`: The `bitIndex` value.
+- Parameter `value`: The `value` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Bit.SetBits(System.Span`1{System.Byte},System.ReadOnlySpan`1{System.ValueTuple`3{System.Int32,System.Int32,System.Boolean}})`
+
+```csharp
+public static void SetBits(System.Span<byte> bytes, System.ReadOnlySpan<System.ValueTuple<int, int, bool>> bitUpdates)
+```
+Executes the `SetBits` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Parameter `bitUpdates`: The `bitUpdates` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Bit.ToBitArray(System.Byte[])`
+
+```csharp
+public static System.Collections.BitArray ToBitArray(byte[] bytes)
+```
+Converts bytes to a BitArray.
+
+- Parameter `bytes`: The byte array to convert. Each byte is interpreted in order, with the least significant bit first in each byte.
+- Returns: A BitArray containing the bits from the input byte array. If the input array is null or empty, returns an empty BitArray.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Bit.ToBitArray(System.Byte[],System.Nullable`1{System.Int32})`
+
+```csharp
+public static System.Collections.BitArray ToBitArray(byte[] bytes, System.Nullable<int> length)
+```
+Executes the `ToBitArray` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Parameter `length`: The `length` value.
+- Returns: A `System.Collections.BitArray` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Bit.ToBitArray(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static System.Collections.BitArray ToBitArray(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `ToBitArray` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `System.Collections.BitArray` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Bit.ToBitArray(System.ReadOnlySpan`1{System.Byte},System.Nullable`1{System.Int32})`
+
+```csharp
+public static System.Collections.BitArray ToBitArray(System.ReadOnlySpan<byte> bytes, System.Nullable<int> length)
+```
+Executes the `ToBitArray` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Parameter `length`: The `length` value.
+- Returns: A `System.Collections.BitArray` result.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.Boolean`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.Boolean
+```
+Provides static methods for manipulating individual bits within a byte value.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Boolean.ClearBit(System.Byte,System.Int32)`
+
+```csharp
+public static byte ClearBit(byte value, int bit)
+```
+Returns a copy of the value with the addressed bit cleared.
+
+- Parameter `value`: The input value to modify.
+- Parameter `bit`: The index (zero based) of the bit to clear.
+- Returns: The modified value with the bit at index cleared.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Boolean.ClearBit(System.Byte@,System.Int32)`
+
+```csharp
+public static void ClearBit(ref byte value, int bit)
+```
+Resets the value of a bit to 0 (false), given the address of the bit.
+
+- Parameter `value`: The input value to modify.
+- Parameter `bit`: The index (zero based) of the bit to clear.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Boolean.GetValue(System.Byte,System.Int32)`
+
+```csharp
+public static bool GetValue(byte value, int bit)
+```
+Determines whether the specified bit is set in the given byte value.
+
+- Parameter `value`: The byte value to examine for the specified bit.
+- Parameter `bit`: The zero-based position of the bit to check. Must be in the range 0 to 7.
+- Returns: true if the bit at the specified position is set; otherwise, false.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Boolean.SetBit(System.Byte,System.Int32)`
+
+```csharp
+public static byte SetBit(byte value, int bit)
+```
+Returns a copy of the value with the addressed bit set.
+
+- Parameter `value`: The input value to modify.
+- Parameter `bit`: The index (zero based) of the bit to set.
+- Returns: The modified value with the bit at index set.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Boolean.SetBit(System.Byte@,System.Int32)`
+
+```csharp
+public static void SetBit(ref byte value, int bit)
+```
+Sets the value of a bit to 1 (true), given the address of the bit.
+
+- Parameter `value`: The value to modify.
+- Parameter `bit`: The index (zero based) of the bit to set.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.Byte`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.Byte
+```
+Provides utility methods for converting and manipulating byte values and byte arrays.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Byte.FromByteArray(System.Byte[])`
+
+```csharp
+public static byte FromByteArray(byte[] bytes)
+```
+Creates a byte value from the specified byte array.
+
+- Parameter `bytes`: The array of bytes to convert. Must contain at least one element.
+- Returns: A byte value created from the first element of the specified array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Byte.FromSpan(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static byte FromSpan(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `FromSpan` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `byte` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Byte.ToByteArray(System.Byte)`
+
+```csharp
+public static byte[] ToByteArray(byte value)
+```
+Converts the specified byte value to a single-element byte array.
+
+- Parameter `value`: The byte value to include in the returned array.
+- Returns: A byte array containing the specified value as its only element.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Byte.ToSpan(System.Byte,System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(byte value, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `value`: The `value` value.
+- Parameter `destination`: The `destination` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Byte.ToSpan(System.ReadOnlySpan`1{System.Byte},System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(System.ReadOnlySpan<byte> values, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `destination`: The `destination` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray
+```
+Provides a growable pooled byte buffer.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray()
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray` class.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray.#ctor(System.Int32)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray(int size)
+```
+Provides a growable pooled byte buffer.
+
+- Parameter `size`: The initial capacity of the internal buffer, in bytes. Must be greater than zero.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray.Add(IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray)`
+
+```csharp
+public void Add(IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray byteArray)
+```
+Adds the contents of the specified `T:IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray` to the collection.
+
+- Parameter `byteArray`: The `T:IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray` instance whose contents will be added. Cannot be null.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray.Add(System.Byte)`
+
+```csharp
+public void Add(byte item)
+```
+Adds a byte value to the end of the buffer.
+
+- Parameter `item`: The byte value to add to the buffer.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray.Add(System.Byte[])`
+
+```csharp
+public void Add(byte[] items)
+```
+Adds the specified array of bytes to the collection.
+
+- Parameter `items`: An array of bytes to add. Cannot be null.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray.Add(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public void Add(System.ReadOnlySpan<byte> items)
+```
+Executes the `Add` operation.
+
+- Parameter `items`: The `items` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray.Clear`
+
+```csharp
+public void Clear()
+```
+Resets the current position to the beginning.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray.Dispose`
+
+```csharp
+public void Dispose()
+```
+Releases resources used by this instance.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray.TryCopyTo(System.Span`1{System.Byte})`
+
+```csharp
+public bool TryCopyTo(System.Span<byte> destination)
+```
+Executes the `TryCopyTo` operation.
+
+- Parameter `destination`: The `destination` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray.Array`
+
+```csharp
+public byte[] Array { get; }
+```
+Gets the array. Use Span property for better performance when possible.
+
+- Value: The array.
+
+###### `P:IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray.Length`
+
+```csharp
+public int Length { get; }
+```
+Gets the current position (length of data).
+
+- Value: The `Length` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray.Memory`
+
+```csharp
+public System.ReadOnlyMemory<byte> Memory { get; }
+```
+Gets the current data as memory.
+
+- Value: The current data as memory.
+
+###### `P:IoT.DriverCore.S7PlcRx.PlcTypes.ByteArray.Span`
+
+```csharp
+public System.ReadOnlySpan<byte> Span { get; }
+```
+Gets the current data as a span.
+
+- Value: The current data as a span.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.Class`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.Class
+```
+Provides static methods for serializing and deserializing class and struct instances to and from byte arrays, as well as calculating the size of a class in bytes for serialization purposes.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Class.FromBytes(System.Object,System.Byte[])`
+
+```csharp
+public static double FromBytes(object sourceClass, byte[] bytes)
+```
+Deserializes accessible properties from the beginning of a byte array.
+
+- Parameter `sourceClass`: The object whose properties receive deserialized values.
+- Parameter `bytes`: The source byte array.
+- Returns: The number of bytes consumed.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Class.FromBytes(System.Object,System.Byte[],System.Double)`
+
+```csharp
+public static double FromBytes(object sourceClass, byte[] bytes, double numBytes)
+```
+Deserializes accessible properties from a specified byte offset.
+
+- Parameter `sourceClass`: The object whose properties receive deserialized values.
+- Parameter `bytes`: The source byte array.
+- Parameter `numBytes`: The initial byte offset.
+- Returns: The number of bytes consumed.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Class.FromBytes(System.Object,System.Byte[],System.Double,System.Boolean)`
+
+```csharp
+public static double FromBytes(object sourceClass, byte[] bytes, double numBytes, bool isInnerClass)
+```
+Deserializes accessible properties from a specified byte offset.
+
+- Parameter `sourceClass`: The object whose properties receive deserialized values.
+- Parameter `bytes`: The source byte array.
+- Parameter `numBytes`: The initial byte offset.
+- Parameter `isInnerClass`: Whether the object is nested within another serialized object.
+- Returns: The number of bytes consumed.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Class.GetClassSize(System.Object)`
+
+```csharp
+public static double GetClassSize(object instance)
+```
+Calculates the aligned serialized size of an object's accessible properties.
+
+- Parameter `instance`: The object whose accessible properties are measured.
+- Returns: The aligned serialized size in bytes.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Class.GetClassSize(System.Object,System.Double)`
+
+```csharp
+public static double GetClassSize(object instance, double numBytes)
+```
+Calculates the aligned serialized size from a specified byte offset.
+
+- Parameter `instance`: The object whose accessible properties are measured.
+- Parameter `numBytes`: The initial byte offset.
+- Returns: The aligned serialized size in bytes.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Class.GetClassSize(System.Object,System.Double,System.Boolean)`
+
+```csharp
+public static double GetClassSize(object instance, double numBytes, bool isInnerProperty)
+```
+Calculates the serialized size from a specified byte offset.
+
+- Parameter `instance`: The object whose accessible properties are measured.
+- Parameter `numBytes`: The initial byte offset.
+- Parameter `isInnerProperty`: Whether the object is nested and should not receive final alignment.
+- Returns: The serialized size in bytes.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Class.ToBytes(System.Object,System.Byte[])`
+
+```csharp
+public static double ToBytes(object sourceClass, byte[] bytes)
+```
+Serializes accessible properties to the beginning of a byte array.
+
+- Parameter `sourceClass`: The object whose properties are serialized.
+- Parameter `bytes`: The destination byte array.
+- Returns: The number of bytes written.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Class.ToBytes(System.Object,System.Byte[],System.Double)`
+
+```csharp
+public static double ToBytes(object sourceClass, byte[] bytes, double numBytes)
+```
+Serializes accessible properties to a specified byte offset.
+
+- Parameter `sourceClass`: The object whose properties are serialized.
+- Parameter `bytes`: The destination byte array.
+- Parameter `numBytes`: The initial byte offset.
+- Returns: The number of bytes written.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.Counter`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.Counter
+```
+Converts between S7 Counter bytes and unsigned 16-bit values.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Counter.FromByteArray(System.Byte[])`
+
+```csharp
+public static ushort FromByteArray(byte[] bytes)
+```
+Converts a byte array to a 16-bit unsigned integer.
+
+- Parameter `bytes`: The byte array containing the bytes to convert. Must contain at least two bytes representing the value in the expected byte order.
+- Returns: A 16-bit unsigned integer represented by the first two bytes of the array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Counter.FromByteArray(System.Byte[],System.Int32)`
+
+```csharp
+public static ushort FromByteArray(byte[] bytes, int start)
+```
+Reads an unsigned 16-bit value from bytes at an index.
+
+- Parameter `bytes`: The byte array containing the data to convert. Cannot be null.
+- Parameter `start`: The zero-based index in the array at which to begin reading bytes. Must be within the bounds of the array.
+- Returns: A 16-bit unsigned integer represented by the bytes at the specified position in the array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Counter.FromBytes(System.Byte,System.Byte)`
+
+```csharp
+public static ushort FromBytes(byte lowValue, byte highValue)
+```
+Creates an unsigned 16-bit value from low and high bytes.
+
+- Parameter `lowValue`: The low-order byte of the resulting 16-bit unsigned integer.
+- Parameter `highValue`: The high-order byte of the resulting 16-bit unsigned integer.
+- Returns: A 16-bit unsigned integer composed from the specified low and high bytes.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Counter.FromSpan(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static ushort FromSpan(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `FromSpan` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `ushort` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Counter.ToArray(System.Byte[])`
+
+```csharp
+public static ushort[] ToArray(byte[] bytes)
+```
+Converts a byte array to an array of 16-bit unsigned integers.
+
+- Parameter `bytes`: The byte array to convert. The length must be a multiple of 2.
+- Returns: An array of `T:System.UInt16` values representing the converted data from the input byte array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Counter.ToArray(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static ushort[] ToArray(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `ToArray` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `ushort[]` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Counter.ToByteArray(System.UInt16)`
+
+```csharp
+public static byte[] ToByteArray(ushort value)
+```
+Converts the specified 16-bit unsigned integer to a byte array in little-endian order.
+
+- Parameter `value`: The 16-bit unsigned integer to convert to a byte array.
+- Returns: A two-element byte array containing the little-endian representation of the specified value.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Counter.ToByteArray(System.UInt16[])`
+
+```csharp
+public static byte[] ToByteArray(ushort[] value)
+```
+Converts an array of 16-bit unsigned integers to a byte array.
+
+- Parameter `value`: An array of `T:System.UInt16` values to convert. Cannot be .
+- Returns: A byte array representing the binary data of the input `T:System.UInt16` array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Counter.ToSpan(System.ReadOnlySpan`1{System.UInt16},System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(System.ReadOnlySpan<ushort> values, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `destination`: The `destination` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Counter.ToSpan(System.UInt16,System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(ushort value, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `value`: The `value` value.
+- Parameter `destination`: The `destination` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.DInt`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.DInt
+```
+Provides static methods for converting between Siemens S7 DInt (32-bit signed integer) representations and .NET int values.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DInt.CDWord(System.Int64)`
+
+```csharp
+public static int CDWord(long value)
+```
+Converts a 64-bit signed value to the S7 32-bit signed representation.
+
+- Parameter `value`: The 64-bit signed integer value to convert.
+- Returns: A 32-bit signed integer representing the converted value. For values greater than `F:System.Int32.MaxValue` , a custom transformation is applied before conversion.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DInt.FromByteArray(System.Byte[])`
+
+```csharp
+public static int FromByteArray(byte[] bytes)
+```
+Creates an integer value from the specified byte array.
+
+- Parameter `bytes`: The byte array containing the bytes to convert to an integer. The array must contain at least the number of bytes required to represent an integer.
+- Returns: An integer value represented by the specified byte array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DInt.FromByteArray(System.Byte[],System.Int32)`
+
+```csharp
+public static int FromByteArray(byte[] bytes, int start)
+```
+Creates an integer value from a byte array starting at the specified index.
+
+- Parameter `bytes`: The byte array containing the data to convert.
+- Parameter `start`: The zero-based index in the array at which to begin reading bytes.
+- Returns: The integer value represented by the bytes starting at the specified index.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DInt.FromBytes(System.Byte,System.Byte,System.Byte,System.Byte)`
+
+```csharp
+public static int FromBytes(byte v1, byte v2, byte v3, byte v4)
+```
+Creates a 32-bit signed integer from four bytes, using little-endian byte order.
+
+- Parameter `v1`: The least significant byte of the resulting integer.
+- Parameter `v2`: The second byte of the resulting integer.
+- Parameter `v3`: The third byte of the resulting integer.
+- Parameter `v4`: The most significant byte of the resulting integer.
+- Returns: A 32-bit signed integer composed from the specified bytes in little-endian order.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DInt.FromSpan(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static int FromSpan(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `FromSpan` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DInt.ToArray(System.Byte[])`
+
+```csharp
+public static int[] ToArray(byte[] bytes)
+```
+Converts a byte array to an array of 32-bit integers.
+
+- Parameter `bytes`: The byte array to convert. The length must be a multiple of 4.
+- Returns: An array of 32-bit integers representing the converted values from the input byte array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DInt.ToArray(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static int[] ToArray(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `ToArray` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `int[]` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DInt.ToByteArray(System.Int32)`
+
+```csharp
+public static byte[] ToByteArray(int value)
+```
+Converts the specified 32-bit signed integer to a byte array in little-endian order.
+
+- Parameter `value`: The 32-bit signed integer to convert to a byte array.
+- Returns: A 4-element byte array containing the little-endian representation of the specified integer.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DInt.ToByteArray(System.Int32[])`
+
+```csharp
+public static byte[] ToByteArray(int[] value)
+```
+Converts an array of 32-bit integers to its equivalent byte array representation.
+
+- Parameter `value`: An array of 32-bit integers to convert. Cannot be null.
+- Returns: A byte array containing the binary representation of the input integer array. The length of the returned array is four times the length of the input array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DInt.ToSpan(System.Int32,System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(int value, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `value`: The `value` value.
+- Parameter `destination`: The `destination` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DInt.ToSpan(System.ReadOnlySpan`1{System.Int32},System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(System.ReadOnlySpan<int> values, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `destination`: The `destination` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.DWord`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.DWord
+```
+Converts between S7 DWord bytes and unsigned 32-bit values.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DWord.FromByteArray(System.Byte[])`
+
+```csharp
+public static uint FromByteArray(byte[] bytes)
+```
+Creates a 32-bit unsigned integer from a byte array.
+
+- Parameter `bytes`: The byte array containing the bytes to convert. Must contain at least four bytes starting at the beginning of the array.
+- Returns: A 32-bit unsigned integer represented by the first four bytes of the array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DWord.FromByteArray(System.Byte[],System.Int32)`
+
+```csharp
+public static uint FromByteArray(byte[] bytes, int start)
+```
+Reads an unsigned 32-bit value from bytes at an index.
+
+- Parameter `bytes`: The array containing the bytes to convert.
+- Parameter `start`: The zero-based index in the array at which to begin reading bytes.
+- Returns: A 32-bit unsigned integer representing the converted value from the specified byte sequence.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DWord.FromBytes(System.Byte,System.Byte,System.Byte,System.Byte)`
+
+```csharp
+public static uint FromBytes(byte v1, byte v2, byte v3, byte v4)
+```
+Creates a 32-bit unsigned integer from four individual bytes, using little-endian byte order.
+
+- Parameter `v1`: The least significant byte of the resulting 32-bit unsigned integer.
+- Parameter `v2`: The second byte, which becomes the second least significant byte of the resulting value.
+- Parameter `v3`: The third byte, which becomes the third least significant byte of the resulting value.
+- Parameter `v4`: The most significant byte of the resulting 32-bit unsigned integer.
+- Returns: A 32-bit unsigned integer composed from the specified bytes in little-endian order.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DWord.FromSpan(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static uint FromSpan(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `FromSpan` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `uint` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DWord.ToArray(System.Byte[])`
+
+```csharp
+public static uint[] ToArray(byte[] bytes)
+```
+Converts the specified byte array to an array of 32-bit unsigned integers.
+
+- Parameter `bytes`: The byte array to convert. The length must be a multiple of 4.
+- Returns: An array of 32-bit unsigned integers representing the converted values from the input byte array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DWord.ToArray(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static uint[] ToArray(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `ToArray` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `uint[]` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DWord.ToByteArray(System.UInt32)`
+
+```csharp
+public static byte[] ToByteArray(uint value)
+```
+Converts the specified 32-bit unsigned integer to a byte array in little-endian order.
+
+- Parameter `value`: The 32-bit unsigned integer to convert to a byte array.
+- Returns: A 4-element byte array containing the bytes of the specified value in little-endian order.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DWord.ToByteArray(System.UInt32[])`
+
+```csharp
+public static byte[] ToByteArray(uint[] value)
+```
+Converts the specified array of 32-bit unsigned integers to a byte array.
+
+- Parameter `value`: An array of 32-bit unsigned integers to convert. Cannot be null.
+- Returns: A byte array containing the binary representation of the input values. The length of the returned array is four times the length of the input array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DWord.ToSpan(System.ReadOnlySpan`1{System.UInt32},System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(System.ReadOnlySpan<uint> values, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `destination`: The `destination` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DWord.ToSpan(System.UInt32,System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(uint value, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `value`: The `value` value.
+- Parameter `destination`: The `destination` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.DateTime`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.DateTime
+```
+Converts offset-aware values to and from the S7 date-time representation.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.S7PlcRx.PlcTypes.DateTime.SpecMaximumDateTime`
+
+```csharp
+public static System.DateTimeOffset SpecMaximumDateTime
+```
+The maximum value supported by the specification.
+
+###### `F:IoT.DriverCore.S7PlcRx.PlcTypes.DateTime.SpecMinimumDateTime`
+
+```csharp
+public static System.DateTimeOffset SpecMinimumDateTime
+```
+The minimum value supported by the specification.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DateTime.FromByteArray(System.Byte[])`
+
+```csharp
+public static System.DateTimeOffset FromByteArray(byte[] bytes)
+```
+Parses a `T:System.DateTimeOffset` value from bytes.
+
+- Parameter `bytes`: Input bytes read from PLC.
+- Returns: A value representing the date and time read from the PLC.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DateTime.FromSpan(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static System.DateTimeOffset FromSpan(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `FromSpan` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `System.DateTimeOffset` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DateTime.ToArray(System.Byte[])`
+
+```csharp
+public static System.DateTimeOffset[] ToArray(byte[] bytes)
+```
+Parses an array of `T:System.DateTimeOffset` values from bytes.
+
+- Parameter `bytes`: Input bytes read from PLC.
+- Returns: An array of values representing the dates and times read from the PLC.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DateTime.ToArray(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static System.DateTimeOffset[] ToArray(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `ToArray` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `System.DateTimeOffset[]` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DateTime.ToByteArray(System.DateTimeOffset)`
+
+```csharp
+public static byte[] ToByteArray(System.DateTimeOffset dateTime)
+```
+Converts a `T:System.DateTimeOffset` value to a byte array.
+
+- Parameter `dateTime`: The date and time value to convert.
+- Returns: A byte array containing the S7 date time representation of `dateTime` .
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DateTime.ToByteArray(System.DateTimeOffset[])`
+
+```csharp
+public static byte[] ToByteArray(System.DateTimeOffset[] dateTimes)
+```
+Converts an array of date and time values to a byte array.
+
+- Parameter `dateTimes`: The date and time values to convert.
+- Returns: A byte array containing the S7 date time representations of `dateTimes` .
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DateTime.ToSpan(System.DateTimeOffset,System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(System.DateTimeOffset dateTime, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `dateTime`: The `dateTime` value.
+- Parameter `destination`: The `destination` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DateTime.ToSpan(System.ReadOnlySpan`1{System.DateTimeOffset},System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(System.ReadOnlySpan<System.DateTimeOffset> dateTimes, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `dateTimes`: The `dateTimes` value.
+- Parameter `destination`: The `destination` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.DateTimeLong`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.DateTimeLong
+```
+Converts offset-aware values to and from the S7 DateTimeLong representation.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.S7PlcRx.PlcTypes.DateTimeLong.SpecMaximumDateTime`
+
+```csharp
+public static System.DateTimeOffset SpecMaximumDateTime
+```
+The maximum value supported by the specification.
+
+###### `F:IoT.DriverCore.S7PlcRx.PlcTypes.DateTimeLong.SpecMinimumDateTime`
+
+```csharp
+public static System.DateTimeOffset SpecMinimumDateTime
+```
+The minimum value supported by the specification.
+
+###### `F:IoT.DriverCore.S7PlcRx.PlcTypes.DateTimeLong.TypeLengthInBytes`
+
+```csharp
+public static int TypeLengthInBytes
+```
+The type length in bytes.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DateTimeLong.FromByteArray(System.Byte[])`
+
+```csharp
+public static System.DateTimeOffset FromByteArray(byte[] bytes)
+```
+Parses a `T:System.DateTimeOffset` value from bytes.
+
+- Parameter `bytes`: Input bytes read from PLC.
+- Returns: A value representing the date and time read from the PLC.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DateTimeLong.FromSpan(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static System.DateTimeOffset FromSpan(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `FromSpan` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `System.DateTimeOffset` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DateTimeLong.ToArray(System.Byte[])`
+
+```csharp
+public static System.DateTimeOffset[] ToArray(byte[] bytes)
+```
+Parses an array of `T:System.DateTime` values from bytes.
+
+- Parameter `bytes`: Input bytes read from PLC.
+- Returns: An array of `T:System.DateTime` objects representing the values read from PLC.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DateTimeLong.ToArray(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static System.DateTimeOffset[] ToArray(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `ToArray` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `System.DateTimeOffset[]` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DateTimeLong.ToByteArray(System.DateTimeOffset)`
+
+```csharp
+public static byte[] ToByteArray(System.DateTimeOffset dateTime)
+```
+Converts a `T:System.DateTime` value to a byte array.
+
+- Parameter `dateTime`: The DateTime value to convert.
+- Returns: A byte array containing the S7 DateTimeLong representation of `dateTime` .
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DateTimeLong.ToByteArray(System.DateTimeOffset[])`
+
+```csharp
+public static byte[] ToByteArray(System.DateTimeOffset[] dateTimes)
+```
+Converts an array of `T:System.DateTime` values to a byte array.
+
+- Parameter `dateTimes`: The DateTime values to convert.
+- Returns: A byte array containing the S7 DateTimeLong representations of `dateTimes` .
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DateTimeLong.ToSpan(System.DateTimeOffset,System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(System.DateTimeOffset dateTime, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `dateTime`: The `dateTime` value.
+- Parameter `destination`: The `destination` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.DateTimeLong.ToSpan(System.ReadOnlySpan`1{System.DateTimeOffset},System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(System.ReadOnlySpan<System.DateTimeOffset> dateTimes, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `dateTimes`: The `dateTimes` value.
+- Parameter `destination`: The `destination` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.Int`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.Int
+```
+Provides static methods for converting between S7 Int (16-bit signed integer) representations and .NET types, including byte arrays and spans.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Int.CWord(System.Int32)`
+
+```csharp
+public static short CWord(int value)
+```
+Converts a 32-bit signed integer to a 16-bit signed integer, applying a custom transformation for values greater than 32,767.
+
+- Parameter `value`: The 32-bit signed integer to convert.
+- Returns: A 16-bit signed integer representing the converted value.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Int.FromByteArray(System.Byte[])`
+
+```csharp
+public static short FromByteArray(byte[] bytes)
+```
+Converts a byte array to a 16-bit signed integer.
+
+- Parameter `bytes`: The byte array containing the bytes to convert. Must contain at least two bytes starting at index zero.
+- Returns: A 16-bit signed integer represented by the first two bytes of the array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Int.FromByteArray(System.Byte[],System.Int32)`
+
+```csharp
+public static short FromByteArray(byte[] bytes, int start)
+```
+Reads a signed 16-bit value from bytes at an index.
+
+- Parameter `bytes`: The byte array containing the data to convert.
+- Parameter `start`: The zero-based index in the array at which to begin reading the bytes.
+- Returns: A 16-bit signed integer represented by the two bytes starting at the specified index in the array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Int.FromBytes(System.Byte,System.Byte)`
+
+```csharp
+public static short FromBytes(byte lowValue, byte highValue)
+```
+Creates a 16-bit signed integer from two bytes, using the specified low and high byte values.
+
+- Parameter `lowValue`: The low-order byte of the 16-bit value.
+- Parameter `highValue`: The high-order byte of the 16-bit value.
+- Returns: A 16-bit signed integer formed by combining the specified low and high bytes.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Int.FromSpan(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static short FromSpan(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `FromSpan` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `short` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Int.ToArray(System.Byte[])`
+
+```csharp
+public static short[] ToArray(byte[] bytes)
+```
+Converts the specified byte array to an array of 16-bit signed integers.
+
+- Parameter `bytes`: The byte array to convert. The length must be a multiple of 2.
+- Returns: An array of 16-bit signed integers representing the converted values from the input byte array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Int.ToArray(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static short[] ToArray(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `ToArray` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `short[]` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Int.ToByteArray(System.Int16)`
+
+```csharp
+public static byte[] ToByteArray(short value)
+```
+Converts the specified 16-bit signed integer to a byte array.
+
+- Parameter `value`: The 16-bit signed integer to convert.
+- Returns: A byte array containing the two bytes that represent the specified value.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Int.ToByteArray(System.Int16[])`
+
+```csharp
+public static byte[] ToByteArray(short[] value)
+```
+Converts an array of 16-bit signed integers to a byte array.
+
+- Parameter `value`: An array of 16-bit signed integers to convert. Cannot be null.
+- Returns: A byte array containing the binary representation of the input values.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Int.ToSpan(System.Int16,System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(short value, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `value`: The `value` value.
+- Parameter `destination`: The `destination` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Int.ToSpan(System.ReadOnlySpan`1{System.Int16},System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(System.ReadOnlySpan<short> values, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `destination`: The `destination` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.LReal`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.LReal
+```
+Converts between S7 LReal bytes and .NET double values.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.LReal.FromByteArray(System.Byte[])`
+
+```csharp
+public static double FromByteArray(byte[] bytes)
+```
+Converts a byte array to a double-precision floating-point number.
+
+- Parameter `bytes`: The byte array containing the binary representation of a double-precision floating-point value. Must be at least 8 bytes in length.
+- Returns: A double-precision floating-point number represented by the specified byte array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.LReal.FromByteArray(System.Byte[],System.Int32)`
+
+```csharp
+public static double FromByteArray(byte[] bytes, int start)
+```
+Converts a sequence of bytes from the specified array, starting at the given index, to a double-precision floating-point number.
+
+- Parameter `bytes`: The byte array containing the value to convert.
+- Parameter `start`: The zero-based index in the array at which to begin reading the bytes.
+- Returns: A double-precision floating-point number represented by the specified bytes.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.LReal.FromDWord(System.Int32)`
+
+```csharp
+public static double FromDWord(int value)
+```
+Converts an S7 32-bit signed value to a double.
+
+- Parameter `value`: The 32-bit signed integer value in DWord format to convert.
+- Returns: A double-precision floating-point value that represents the specified DWord.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.LReal.FromDWord(System.UInt32)`
+
+```csharp
+public static double FromDWord(uint value)
+```
+Converts an unsigned 32-bit value to a double.
+
+- Parameter `value`: The 32-bit unsigned integer value to convert.
+- Returns: A double-precision floating-point number that represents the specified 32-bit unsigned integer.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.LReal.FromSpan(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static double FromSpan(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `FromSpan` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `double` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.LReal.ToArray(System.Byte[])`
+
+```csharp
+public static double[] ToArray(byte[] bytes)
+```
+Converts a byte array to an array of double-precision floating-point values.
+
+- Parameter `bytes`: The byte array to convert. The length must be a multiple of the size of a double (8 bytes).
+- Returns: An array of double values created from the input byte array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.LReal.ToArray(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static double[] ToArray(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `ToArray` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `double[]` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.LReal.ToByteArray(System.Double)`
+
+```csharp
+public static byte[] ToByteArray(double value)
+```
+Converts a double to its 8-byte representation.
+
+- Parameter `value`: The double-precision floating-point number to convert.
+- Returns: A byte array containing the 8-byte binary representation of the specified value.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.LReal.ToByteArray(System.Double[])`
+
+```csharp
+public static byte[] ToByteArray(double[] value)
+```
+Converts an array of double-precision floating-point numbers to a byte array representation.
+
+- Parameter `value`: The array of double values to convert. Cannot be null.
+- Returns: A byte array containing the binary representation of the input double array. The array will be empty if the input array is empty.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.LReal.ToSpan(System.Double,System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(double value, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `value`: The `value` value.
+- Parameter `destination`: The `destination` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.LReal.ToSpan(System.ReadOnlySpan`1{System.Double},System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(System.ReadOnlySpan<double> values, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `destination`: The `destination` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.Real`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.Real
+```
+Provides static methods for converting between Siemens S7 Real (4-byte IEEE 754 floating-point) representations and .NET float values.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Real.FromByteArray(System.Byte[])`
+
+```csharp
+public static float FromByteArray(byte[] bytes)
+```
+Converts a byte array to a single-precision floating-point value.
+
+- Parameter `bytes`: The byte array containing the bytes to convert. Must contain at least four bytes representing a 32-bit floating-point value in the expected format.
+- Returns: A single-precision floating-point value represented by the specified byte array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Real.FromSpan(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static float FromSpan(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `FromSpan` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `float` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Real.ToArray(System.Byte[])`
+
+```csharp
+public static float[] ToArray(byte[] bytes)
+```
+Converts a byte array to an array of single-precision floating-point values.
+
+- Parameter `bytes`: The byte array containing the binary representation of the floating-point values. The length must be a multiple of 4.
+- Returns: An array of `T:System.Single` values converted from the specified byte array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Real.ToArray(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static float[] ToArray(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `ToArray` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `float[]` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Real.ToByteArray(System.Single)`
+
+```csharp
+public static byte[] ToByteArray(float value)
+```
+Converts a float to its byte-array representation.
+
+- Parameter `value`: The single-precision floating-point value to convert.
+- Returns: A 4-byte array containing the binary representation of `value` .
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Real.ToByteArray(System.Single[])`
+
+```csharp
+public static byte[] ToByteArray(float[] value)
+```
+Converts an array of single-precision floating-point values to a byte array.
+
+- Parameter `value`: The array of `T:System.Single` values to convert. Cannot be null.
+- Returns: A byte array containing the binary representation of the input values.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Real.ToSpan(System.ReadOnlySpan`1{System.Single},System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(System.ReadOnlySpan<float> values, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `destination`: The `destination` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Real.ToSpan(System.Single,System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(float value, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `value`: The `value` value.
+- Parameter `destination`: The `destination` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.S7String`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.S7String
+```
+Encodes and decodes S7 strings in the S7 protocol format.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.S7String.FromByteArray(System.Byte[])`
+
+```csharp
+public static string FromByteArray(byte[] bytes)
+```
+Converts S7 bytes to a string.
+
+- Parameter `bytes`: The bytes.
+- Returns: A string.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.S7String.FromSpan(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static string FromSpan(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `FromSpan` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.S7String.GetByteLength(System.Int32)`
+
+```csharp
+public static int GetByteLength(int reservedLength)
+```
+Gets the total byte length for an S7 string with the specified reserved length.
+
+- Parameter `reservedLength`: The reserved length for the string.
+- Returns: The total byte length including header.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.S7String.ToByteArray(System.String,System.Int32)`
+
+```csharp
+public static byte[] ToByteArray(string value, int reservedLength)
+```
+Converts a `T:string` to S7 string with 2-byte header.
+
+- Parameter `value`: The string to convert to byte array.
+- Parameter `reservedLength`: The length (in characters) allocated in PLC for the string.
+- Returns: A `T:byte[]` containing the string header and string value with a maximum length of `reservedLength` + 2.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.S7String.ToSpan(System.String,System.Int32,System.Span`1{System.Byte})`
+
+```csharp
+public static int ToSpan(string value, int reservedLength, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `value`: The `value` value.
+- Parameter `reservedLength`: The `reservedLength` value.
+- Parameter `destination`: The `destination` value.
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.S7String.TryToSpan(System.String,System.Int32,System.Span`1{System.Byte},System.Int32@)`
+
+```csharp
+public static bool TryToSpan(string value, int reservedLength, System.Span<byte> destination, out int bytesWritten)
+```
+Executes the `TryToSpan` operation.
+
+- Parameter `value`: The `value` value.
+- Parameter `reservedLength`: The `reservedLength` value.
+- Parameter `destination`: The `destination` value.
+- Parameter `bytesWritten`: The `bytesWritten` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.S7PlcRx.PlcTypes.S7String.StringEncoding`
+
+```csharp
+public System.Text.Encoding StringEncoding { get; set; }
+```
+Gets or sets the encoding used for S7String serialization.
+
+- Value: The string encoding.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.S7StringAttribute`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.S7StringAttribute
+```
+Maps a member to an S7 string with a reserved length.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.S7StringAttribute.#ctor(IoT.DriverCore.S7PlcRx.Enums.S7StringType,System.Int32)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.PlcTypes.S7StringAttribute(IoT.DriverCore.S7PlcRx.Enums.S7StringType type, int reservedLength)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.PlcTypes.S7StringAttribute` class.
+
+- Parameter `type`: The type of S7 string to use. Must be a defined value of the S7StringType enumeration.
+- Parameter `reservedLength`: The reserved length for the string. Specifies the maximum number of characters the string can hold.
+
+###### `P:IoT.DriverCore.S7PlcRx.PlcTypes.S7StringAttribute.ReservedLength`
+
+```csharp
+public int ReservedLength { get; }
+```
+Gets the number of characters reserved for the value.
+
+- Value: The `ReservedLength` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.PlcTypes.S7StringAttribute.ReservedLengthInBytes`
+
+```csharp
+public int ReservedLengthInBytes { get; }
+```
+Gets the total bytes reserved for the string.
+
+- Value: The `ReservedLengthInBytes` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.PlcTypes.S7StringAttribute.Type`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Enums.S7StringType Type { get; }
+```
+Gets the type of the S7 string represented by this instance.
+
+- Value: The `Type` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.S7WString`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.S7WString
+```
+Provides static methods for converting between S7 WString byte arrays and .NET strings.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.S7WString.FromByteArray(System.Byte[])`
+
+```csharp
+public static string FromByteArray(byte[] bytes)
+```
+Decodes an S7 WString byte array to a .NET string.
+
+- Parameter `bytes`: The byte array containing the S7 WString data, including the 4-byte header. Must not be null and must have a length of at least 4 bytes.
+- Returns: A string representing the decoded S7 WString value from the specified byte array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.S7WString.ToByteArray(System.String,System.Int32)`
+
+```csharp
+public static byte[] ToByteArray(string value, int reservedLength)
+```
+Encodes a string as big-endian Unicode with a length prefix.
+
+- Parameter `value`: The string to convert to a byte array. Cannot be null.
+- Parameter `reservedLength`: The number of characters to reserve in the output buffer. Must be less than or equal to 16,382 and greater than or equal to the length of `value` .
+- Returns: A byte array containing a 4-byte header followed by the big-endian Unicode bytes of the string, padded to the reserved length if necessary.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.String`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.String
+```
+Provides utility methods for converting between strings and byte arrays using ASCII encoding.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.String.FromByteArray(System.Byte[])`
+
+```csharp
+public static string FromByteArray(byte[] bytes)
+```
+Decodes a UTF-8 encoded byte array into a string.
+
+- Parameter `bytes`: The byte array containing the UTF-8 encoded text to decode. Cannot be null.
+- Returns: A string representation of the decoded UTF-8 text. Returns an empty string if the array is empty.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.String.FromByteArray(System.Byte[],System.Int32,System.Int32)`
+
+```csharp
+public static string FromByteArray(byte[] bytes, int start, int length)
+```
+Converts a specified range of bytes from a byte array to a string.
+
+- Parameter `bytes`: The byte array containing the data to convert.
+- Parameter `start`: The zero-based index in the array at which to begin conversion.
+- Parameter `length`: The number of bytes to convert starting from `start` .
+- Returns: A string representation of the specified range of bytes, or an empty string if the range exceeds the bounds of the array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.String.FromSpan(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static string FromSpan(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `FromSpan` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.String.ToByteArray(System.String)`
+
+```csharp
+public static byte[] ToByteArray(string value)
+```
+Converts the specified string to a byte array using ASCII encoding.
+
+- Parameter `value`: The string to convert to a byte array. If null or empty, an empty array is returned.
+- Returns: A byte array containing the ASCII-encoded bytes of the input string, or an empty array if the input is null or empty.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.String.ToSpan(System.String,System.Span`1{System.Byte})`
+
+```csharp
+public static int ToSpan(string value, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `value`: The `value` value.
+- Parameter `destination`: The `destination` value.
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.String.TryToSpan(System.String,System.Span`1{System.Byte},System.Int32@)`
+
+```csharp
+public static bool TryToSpan(string value, System.Span<byte> destination, out int bytesWritten)
+```
+Executes the `TryToSpan` operation.
+
+- Parameter `value`: The `value` value.
+- Parameter `destination`: The `destination` value.
+- Parameter `bytesWritten`: The `bytesWritten` value.
+- Returns: A `bool` result.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.Struct`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.Struct
+```
+Provides utility methods for working with struct types, including calculating their size in bytes and converting between structs and byte arrays.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Struct.FromBytes(System.Type,System.Byte[])`
+
+```csharp
+public static object FromBytes(System.Type structType, byte[] bytes)
+```
+Deserializes a byte array into an instance of the specified structure type.
+
+- Parameter `structType`: The type of the structure to deserialize the byte array into. Must be a type with a parameterless constructor and supported field types.
+- Parameter `bytes`: The byte array containing the serialized data for the structure. The length must match the expected size of the structure.
+- Returns: An object representing the deserialized structure, or null if the byte array is null or does not match the expected size.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Struct.GetStructSize(System.Type)`
+
+```csharp
+public static int GetStructSize(System.Type structType)
+```
+Calculates the total size, in bytes, required to store an instance of the specified struct type, based on its fields and their types.
+
+- Parameter `structType`: The type of the struct for which to calculate the size. Must not be null.
+- Returns: The total size, in bytes, needed to represent an instance of the specified struct type.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Struct.ToBytes(System.Object)`
+
+```csharp
+public static byte[] ToBytes(object structValue)
+```
+Converts the specified structure object to its byte array representation.
+
+- Parameter `structValue`: The structure object to convert to a byte array. Must not be null. The object's fields must be of supported types.
+- Returns: A byte array containing the serialized representation of the structure. Returns an empty array if `structValue` is null.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.TimeSpan`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.TimeSpan
+```
+Converts between S7 PLC time values and .NET TimeSpan values.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.S7PlcRx.PlcTypes.TimeSpan.SpecMaximumTimeSpan`
+
+```csharp
+public static System.TimeSpan SpecMaximumTimeSpan
+```
+Represents the maximum allowable time span for specification purposes, set to the largest value expressible in milliseconds as an integer.
+
+###### `F:IoT.DriverCore.S7PlcRx.PlcTypes.TimeSpan.SpecMinimumTimeSpan`
+
+```csharp
+public static System.TimeSpan SpecMinimumTimeSpan
+```
+Gets the minimum S7 time value.
+
+###### `F:IoT.DriverCore.S7PlcRx.PlcTypes.TimeSpan.TypeLengthInBytes`
+
+```csharp
+public static int TypeLengthInBytes
+```
+The size, in bytes, of the type.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.TimeSpan.FromByteArray(System.Byte[])`
+
+```csharp
+public static System.TimeSpan FromByteArray(byte[] bytes)
+```
+Creates a TimeSpan structure from its binary representation in a byte array.
+
+- Parameter `bytes`: A byte array containing the binary representation of a TimeSpan. The array must be at least 8 bytes in length and encoded in the expected format.
+- Returns: A TimeSpan value represented by the specified byte array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.TimeSpan.FromSpan(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static System.TimeSpan FromSpan(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `FromSpan` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `System.TimeSpan` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.TimeSpan.ToArray(System.Byte[])`
+
+```csharp
+public static System.TimeSpan[] ToArray(byte[] bytes)
+```
+Converts a byte array to an array of `T:System.TimeSpan` values.
+
+- Parameter `bytes`: The byte array containing the binary representation of one or more `T:System.TimeSpan` values. The array length must be a multiple of the size of a `T:System.TimeSpan` structure.
+- Returns: An array of `T:System.TimeSpan` values deserialized from the specified byte array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.TimeSpan.ToArray(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static System.TimeSpan[] ToArray(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `ToArray` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `System.TimeSpan[]` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.TimeSpan.ToByteArray(System.TimeSpan)`
+
+```csharp
+public static byte[] ToByteArray(System.TimeSpan timeSpan)
+```
+Converts a TimeSpan to its S7 byte representation.
+
+- Parameter `timeSpan`: The `T:System.TimeSpan` value to convert to a byte array.
+- Returns: A byte array containing the binary representation of the specified `T:System.TimeSpan` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.TimeSpan.ToByteArray(System.TimeSpan[])`
+
+```csharp
+public static byte[] ToByteArray(System.TimeSpan[] timeSpans)
+```
+Converts an array of `T:System.TimeSpan` values to a byte array representation.
+
+- Parameter `timeSpans`: An array of `T:System.TimeSpan` values to convert. Cannot be null.
+- Returns: A byte array containing the serialized representation of the input `T:System.TimeSpan` values. The length of the array is proportional to the number of elements in `timeSpans` .
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.TimeSpan.ToSpan(System.ReadOnlySpan`1{System.TimeSpan},System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(System.ReadOnlySpan<System.TimeSpan> timeSpans, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `timeSpans`: The `timeSpans` value.
+- Parameter `destination`: The `destination` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.TimeSpan.ToSpan(System.TimeSpan,System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(System.TimeSpan timeSpan, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `timeSpan`: The `timeSpan` value.
+- Parameter `destination`: The `destination` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.Timer`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.Timer
+```
+Converts between S7 Timer bytes and .NET numeric types.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Timer.FromByteArray(System.Byte[])`
+
+```csharp
+public static double FromByteArray(byte[] bytes)
+```
+Converts a byte array to a double-precision floating-point number.
+
+- Parameter `bytes`: The byte array containing the bytes to convert. Must represent a valid double value in the expected byte order.
+- Returns: A double-precision floating-point number represented by the specified byte array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Timer.FromByteArray(System.Byte[],System.Int32)`
+
+```csharp
+public static double FromByteArray(byte[] bytes, int start)
+```
+Converts a sequence of bytes from the specified array, starting at the given index, to a double-precision floating-point number.
+
+- Parameter `bytes`: The byte array containing the value to convert.
+- Parameter `start`: The zero-based index in the array at which to begin reading the bytes.
+- Returns: A double-precision floating-point number represented by the eight bytes starting at the specified index in the array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Timer.FromByteArray(System.ReadOnlySpan`1{System.Byte},System.Int32)`
+
+```csharp
+public static double FromByteArray(System.ReadOnlySpan<byte> bytes, int start)
+```
+Executes the `FromByteArray` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Parameter `start`: The `start` value.
+- Returns: A `double` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Timer.FromSpan(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static double FromSpan(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `FromSpan` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `double` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Timer.ToArray(System.Byte[])`
+
+```csharp
+public static double[] ToArray(byte[] bytes)
+```
+Converts a byte array to an array of double-precision floating-point values.
+
+- Parameter `bytes`: The byte array to convert. The length must be a multiple of the size of a double (8 bytes).
+- Returns: An array of double values created from the input byte array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Timer.ToArray(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static double[] ToArray(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `ToArray` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `double[]` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Timer.ToByteArray(System.UInt16)`
+
+```csharp
+public static byte[] ToByteArray(ushort value)
+```
+Converts the specified 16-bit unsigned integer to a byte array.
+
+- Parameter `value`: The 16-bit unsigned integer to convert to a byte array.
+- Returns: A byte array containing the two bytes of the specified value in platform endianness.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Timer.ToByteArray(System.UInt16[])`
+
+```csharp
+public static byte[] ToByteArray(ushort[] value)
+```
+Converts an array of 16-bit unsigned integers to a byte array.
+
+- Parameter `value`: The array of 16-bit unsigned integers to convert. Cannot be null.
+- Returns: A byte array containing the binary representation of the input values.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Timer.ToSpan(System.ReadOnlySpan`1{System.UInt16},System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(System.ReadOnlySpan<ushort> values, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `destination`: The `destination` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Timer.ToSpan(System.UInt16,System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(ushort value, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `value`: The `value` value.
+- Parameter `destination`: The `destination` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.PlcTypes.Word`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.PlcTypes.Word
+```
+Provides utility methods for converting between 16-bit unsigned integers (words) and their byte array or span representations, using big-endian (high byte first) byte order.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Word.FromByteArray(System.Byte[])`
+
+```csharp
+public static ushort FromByteArray(byte[] bytes)
+```
+Creates a 16-bit unsigned integer from a byte array.
+
+- Parameter `bytes`: The byte array containing the bytes to convert. Must contain at least two elements.
+- Returns: A 16-bit unsigned integer represented by the first two bytes of the array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Word.FromByteArray(System.Byte[],System.Int32)`
+
+```csharp
+public static ushort FromByteArray(byte[] bytes, int start)
+```
+Creates a 16-bit unsigned integer from a byte array starting at the specified index.
+
+- Parameter `bytes`: The byte array containing the data to convert.
+- Parameter `start`: The zero-based index in the array at which to begin reading the value.
+- Returns: A 16-bit unsigned integer formed from the specified bytes.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Word.FromBytes(System.Byte,System.Byte)`
+
+```csharp
+public static ushort FromBytes(byte lowValue, byte highValue)
+```
+Creates an unsigned 16-bit value from low and high bytes.
+
+- Parameter `lowValue`: The low-order byte of the resulting 16-bit unsigned integer.
+- Parameter `highValue`: The high-order byte of the resulting 16-bit unsigned integer.
+- Returns: A 16-bit unsigned integer composed from the specified low and high bytes.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Word.FromSpan(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static ushort FromSpan(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `FromSpan` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `ushort` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Word.ToArray(System.Byte[])`
+
+```csharp
+public static ushort[] ToArray(byte[] bytes)
+```
+Converts a byte array to an array of 16-bit unsigned integers.
+
+- Parameter `bytes`: The byte array to convert. The length must be a multiple of 2.
+- Returns: An array of 16-bit unsigned integers representing the converted values from the input byte array.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Word.ToArray(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public static ushort[] ToArray(System.ReadOnlySpan<byte> bytes)
+```
+Executes the `ToArray` operation.
+
+- Parameter `bytes`: The `bytes` value.
+- Returns: A `ushort[]` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Word.ToByteArray(System.UInt16)`
+
+```csharp
+public static byte[] ToByteArray(ushort value)
+```
+Converts the specified 16-bit unsigned integer to a byte array.
+
+- Parameter `value`: The 16-bit unsigned integer to convert.
+- Returns: A byte array containing the bytes of the specified value in little-endian order.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Word.ToByteArray(System.UInt16,System.Array,System.Int32)`
+
+```csharp
+public static void ToByteArray(ushort value, System.Array destination, int start)
+```
+Copies the byte representation of the specified 16-bit unsigned integer into the given array starting at the specified index.
+
+- Parameter `value`: The 16-bit unsigned integer to convert to bytes.
+- Parameter `destination`: The array that will receive the bytes representing the value. Must have sufficient space to accommodate two bytes starting at the specified index.
+- Parameter `start`: The zero-based index in the destination array at which to begin copying the bytes.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Word.ToByteArray(System.UInt16[])`
+
+```csharp
+public static byte[] ToByteArray(ushort[] value)
+```
+Converts an array of 16-bit unsigned integers to a byte array.
+
+- Parameter `value`: The array of 16-bit unsigned integers to convert. Cannot be null.
+- Returns: A byte array containing the binary representation of the input values.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Word.ToSpan(System.ReadOnlySpan`1{System.UInt16},System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(System.ReadOnlySpan<ushort> values, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `destination`: The `destination` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.PlcTypes.Word.ToSpan(System.UInt16,System.Span`1{System.Byte})`
+
+```csharp
+public static void ToSpan(ushort value, System.Span<byte> destination)
+```
+Executes the `ToSpan` operation.
+
+- Parameter `value`: The `value` value.
+- Parameter `destination`: The `destination` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Production.CircuitBreaker`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Production.CircuitBreaker
+```
+Provides a thread-safe circuit breaker that prevents repeated failing operations.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Production.CircuitBreaker.#ctor(IoT.DriverCore.S7PlcRx.Production.ProductionErrorConfig,System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Production.CircuitBreaker(IoT.DriverCore.S7PlcRx.Production.ProductionErrorConfig config, System.TimeProvider timeProvider)
+```
+Provides a thread-safe circuit breaker that prevents repeated failing operations.
+
+- Parameter `config`: The configuration settings that control circuit-breaker thresholds, retry behavior, and timeouts.
+- Parameter `timeProvider`: The time provider; defaults to `P:System.TimeProvider.System` .
+
+###### `M:IoT.DriverCore.S7PlcRx.Production.CircuitBreaker.ExecuteAsync``1(System.Func`1{System.Threading.Tasks.Task`1{``0}})`
+
+```csharp
+public System.Threading.Tasks.Task<T> ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> operation)
+```
+Executes the `ExecuteAsync` operation.
+
+- Parameter `operation`: The `operation` value.
+- Returns: A `System.Threading.Tasks.Task<T>` result.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.CircuitBreaker.FailedOperations`
+
+```csharp
+public long FailedOperations { get; }
+```
+Gets the total number of operations that have failed.
+
+- Value: The `FailedOperations` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.CircuitBreaker.State`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Production.CircuitBreakerState State { get; }
+```
+Gets the current state of the circuit breaker.
+
+- Value: The `State` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.CircuitBreaker.SuccessRate`
+
+```csharp
+public double SuccessRate { get; }
+```
+Gets the percentage of operations that completed successfully.
+
+- Value: The `SuccessRate` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.CircuitBreaker.SuccessfulOperations`
+
+```csharp
+public long SuccessfulOperations { get; }
+```
+Gets the total number of operations that have completed successfully.
+
+- Value: The `SuccessfulOperations` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.CircuitBreaker.TotalOperations`
+
+```csharp
+public long TotalOperations { get; }
+```
+Gets the total number of operations that have been performed.
+
+- Value: The `TotalOperations` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Production.CircuitBreakerState`
+
+```csharp
+public enum IoT.DriverCore.S7PlcRx.Production.CircuitBreakerState
+```
+Specifies the operational state of a circuit breaker.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.S7PlcRx.Production.CircuitBreakerState.Closed`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Production.CircuitBreakerState Closed
+```
+Circuit is closed (normal operation).
+
+###### `F:IoT.DriverCore.S7PlcRx.Production.CircuitBreakerState.HalfOpen`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Production.CircuitBreakerState HalfOpen
+```
+Circuit is half-open (testing recovery).
+
+###### `F:IoT.DriverCore.S7PlcRx.Production.CircuitBreakerState.Open`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.Production.CircuitBreakerState Open
+```
+Circuit is open (blocking operations).
+
+#### `T:IoT.DriverCore.S7PlcRx.Production.ProductionDiagnostics`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Production.ProductionDiagnostics
+```
+Represents diagnostic information collected from a production programmable logic controller (PLC) connection, including connection details, performance metrics, and recommendations.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Production.ProductionDiagnostics.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Production.ProductionDiagnostics()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Production.ProductionDiagnostics`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionDiagnostics.CPUInformation`
+
+```csharp
+public System.Collections.Generic.List<string> CPUInformation { get; }
+```
+Gets or sets the CPU information.
+
+- Value: The `CPUInformation` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionDiagnostics.ConnectionLatencyMs`
+
+```csharp
+public double ConnectionLatencyMs { get; set; }
+```
+Gets or sets the connection latency in milliseconds.
+
+- Value: The `ConnectionLatencyMs` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionDiagnostics.DiagnosticTime`
+
+```csharp
+public System.DateTimeOffset DiagnosticTime { get; set; }
+```
+Gets or sets when diagnostics were collected.
+
+- Value: The `DiagnosticTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionDiagnostics.Errors`
+
+```csharp
+public System.Collections.Generic.List<string> Errors { get; }
+```
+Gets or sets any errors encountered during diagnostics.
+
+- Value: The `Errors` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionDiagnostics.IPAddress`
+
+```csharp
+public string IPAddress { get; set; }
+```
+Gets or sets the IP address.
+
+- Value: The `IPAddress` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionDiagnostics.IsConnected`
+
+```csharp
+public bool IsConnected { get; set; }
+```
+Gets or sets a value indicating whether gets or sets the connection status.
+
+- Value: The `IsConnected` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionDiagnostics.PLCType`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Enums.CpuType PLCType { get; set; }
+```
+Gets or sets the PLC type.
+
+- Value: The `PLCType` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionDiagnostics.Rack`
+
+```csharp
+public short Rack { get; set; }
+```
+Gets or sets the rack number.
+
+- Value: The `Rack` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionDiagnostics.Recommendations`
+
+```csharp
+public System.Collections.Generic.List<string> Recommendations { get; }
+```
+Gets or sets the optimization recommendations.
+
+- Value: The `Recommendations` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionDiagnostics.Slot`
+
+```csharp
+public short Slot { get; set; }
+```
+Gets or sets the slot number.
+
+- Value: The `Slot` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionDiagnostics.TagMetrics`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Production.ProductionTagMetrics TagMetrics { get; set; }
+```
+Gets or sets the tag metrics.
+
+- Value: The `TagMetrics` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Production.ProductionErrorConfig`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Production.ProductionErrorConfig
+```
+Represents production error-handling and retry configuration.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Production.ProductionErrorConfig.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Production.ProductionErrorConfig()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Production.ProductionErrorConfig`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionErrorConfig.BaseRetryDelayMs`
+
+```csharp
+public int BaseRetryDelayMs { get; set; }
+```
+Gets or sets the base retry delay in milliseconds.
+
+- Value: The `BaseRetryDelayMs` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionErrorConfig.CircuitBreakerThreshold`
+
+```csharp
+public int CircuitBreakerThreshold { get; set; }
+```
+Gets or sets the circuit breaker failure threshold.
+
+- Value: The `CircuitBreakerThreshold` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionErrorConfig.CircuitBreakerTimeout`
+
+```csharp
+public System.TimeSpan CircuitBreakerTimeout { get; set; }
+```
+Gets or sets the circuit breaker timeout.
+
+- Value: The `CircuitBreakerTimeout` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionErrorConfig.MaxRetryAttempts`
+
+```csharp
+public int MaxRetryAttempts { get; set; }
+```
+Gets or sets the maximum retry attempts.
+
+- Value: The `MaxRetryAttempts` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionErrorConfig.UseExponentialBackoff`
+
+```csharp
+public bool UseExponentialBackoff { get; set; }
+```
+Gets or sets a value indicating whether gets or sets whether to use exponential backoff.
+
+- Value: The `UseExponentialBackoff` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Production.ProductionErrorHandler`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Production.ProductionErrorHandler
+```
+Provides error handling for production environments by executing operations with circuit breaker protection and configurable error handling policies.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Production.ProductionErrorHandler.#ctor(IoT.DriverCore.S7PlcRx.Production.ProductionErrorConfig)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Production.ProductionErrorHandler(IoT.DriverCore.S7PlcRx.Production.ProductionErrorConfig config)
+```
+Provides error handling for production environments by executing operations with circuit breaker protection and configurable error handling policies.
+
+- Parameter `config`: The non-null settings that define error handling, circuit breaking, and retries.
+
+###### `M:IoT.DriverCore.S7PlcRx.Production.ProductionErrorHandler.ExecuteAsync``1(System.Func`1{System.Threading.Tasks.Task`1{``0}})`
+
+```csharp
+public System.Threading.Tasks.Task<T> ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> operation)
+```
+Executes the `ExecuteAsync` operation.
+
+- Parameter `operation`: The `operation` value.
+- Returns: A `System.Threading.Tasks.Task<T>` result.
+
+#### `T:IoT.DriverCore.S7PlcRx.Production.ProductionExtensions`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Production.ProductionExtensions
+```
+Provides extension methods for enabling production-grade error handling, retry logic, and system validation on PLC instances using the circuit breaker pattern.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Production.ProductionExtensions.EnableProductionErrorHandling(IoT.DriverCore.S7PlcRx.IRxS7,IoT.DriverCore.S7PlcRx.Production.ProductionErrorConfig)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.Production.ProductionErrorHandler EnableProductionErrorHandling(IoT.DriverCore.S7PlcRx.IRxS7 plc, IoT.DriverCore.S7PlcRx.Production.ProductionErrorConfig config)
+```
+Enables production error handling for the specified PLC using the provided configuration.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `config`: The configuration settings to use for production error handling.
+- Returns: A new instance of `T:IoT.DriverCore.S7PlcRx.Production.ProductionErrorHandler` configured for the specified PLC.
+
+###### `M:IoT.DriverCore.S7PlcRx.Production.ProductionExtensions.ExecuteWithErrorHandlingAsync``1(IoT.DriverCore.S7PlcRx.IRxS7,System.Func`1{System.Threading.Tasks.Task`1{``0}})`
+
+```csharp
+public static System.Threading.Tasks.Task<T> ExecuteWithErrorHandlingAsync<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, System.Func<System.Threading.Tasks.Task<T>> operation)
+```
+Executes the `ExecuteWithErrorHandlingAsync` operation.
+
+- Parameter `plc`: The `plc` value.
+- Parameter `operation`: The `operation` value.
+- Returns: A `System.Threading.Tasks.Task<T>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.Production.ProductionExtensions.ExecuteWithErrorHandlingAsync``1(IoT.DriverCore.S7PlcRx.IRxS7,System.Func`1{System.Threading.Tasks.Task`1{``0}},IoT.DriverCore.S7PlcRx.Production.ProductionErrorConfig)`
+
+```csharp
+public static System.Threading.Tasks.Task<T> ExecuteWithErrorHandlingAsync<T>(IoT.DriverCore.S7PlcRx.IRxS7 plc, System.Func<System.Threading.Tasks.Task<T>> operation, IoT.DriverCore.S7PlcRx.Production.ProductionErrorConfig config)
+```
+Executes the `ExecuteWithErrorHandlingAsync` operation.
+
+- Parameter `plc`: The `plc` value.
+- Parameter `operation`: The `operation` value.
+- Parameter `config`: The `config` value.
+- Returns: A `System.Threading.Tasks.Task<T>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.Production.ProductionExtensions.ValidateProductionReadinessAsync(IoT.DriverCore.S7PlcRx.IRxS7)`
+
+```csharp
+public static System.Threading.Tasks.Task<IoT.DriverCore.S7PlcRx.Production.SystemValidationResult> ValidateProductionReadinessAsync(IoT.DriverCore.S7PlcRx.IRxS7 plc)
+```
+Validates production readiness using the default validation configuration.
+
+- Parameter `plc`: The PLC instance.
+- Returns: A task that represents the asynchronous operation.
+
+###### `M:IoT.DriverCore.S7PlcRx.Production.ProductionExtensions.ValidateProductionReadinessAsync(IoT.DriverCore.S7PlcRx.IRxS7,IoT.DriverCore.S7PlcRx.Production.ProductionValidationConfig)`
+
+```csharp
+public static System.Threading.Tasks.Task<IoT.DriverCore.S7PlcRx.Production.SystemValidationResult> ValidateProductionReadinessAsync(IoT.DriverCore.S7PlcRx.IRxS7 plc, IoT.DriverCore.S7PlcRx.Production.ProductionValidationConfig validationConfig)
+```
+Validates whether the PLC is ready for production deployment.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `validationConfig`: The validation parameters and thresholds.
+- Returns: A task that represents the asynchronous operation.
+
+###### `M:IoT.DriverCore.S7PlcRx.Production.ProductionExtensions.ValidateProductionReadinessAsync(IoT.DriverCore.S7PlcRx.IRxS7,IoT.DriverCore.S7PlcRx.Production.ProductionValidationConfig,System.TimeProvider)`
+
+```csharp
+public static System.Threading.Tasks.Task<IoT.DriverCore.S7PlcRx.Production.SystemValidationResult> ValidateProductionReadinessAsync(IoT.DriverCore.S7PlcRx.IRxS7 plc, IoT.DriverCore.S7PlcRx.Production.ProductionValidationConfig validationConfig, System.TimeProvider timeProvider)
+```
+Validates whether the PLC is ready for production deployment.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `validationConfig`: The validation parameters and thresholds.
+- Parameter `timeProvider`: The time provider.
+- Returns: A task that represents the asynchronous operation.
+
+#### `T:IoT.DriverCore.S7PlcRx.Production.ProductionMetrics`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Production.ProductionMetrics
+```
+Represents a set of metrics related to the monitoring and connectivity status of a PLC (Programmable Logic Controller) over a specified period.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Production.ProductionMetrics.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Production.ProductionMetrics()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Production.ProductionMetrics`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionMetrics.ActiveTagCount`
+
+```csharp
+public int ActiveTagCount { get; set; }
+```
+Gets or sets the number of active tags.
+
+- Value: The `ActiveTagCount` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionMetrics.ConnectedTime`
+
+```csharp
+public System.TimeSpan ConnectedTime { get; set; }
+```
+Gets or sets the total connected time.
+
+- Value: The `ConnectedTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionMetrics.DisconnectedTime`
+
+```csharp
+public System.TimeSpan DisconnectedTime { get; set; }
+```
+Gets or sets the total disconnected time.
+
+- Value: The `DisconnectedTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionMetrics.IsConnected`
+
+```csharp
+public bool IsConnected { get; set; }
+```
+Gets or sets a value indicating whether gets or sets whether the PLC is currently connected.
+
+- Value: The `IsConnected` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionMetrics.LastUpdateTime`
+
+```csharp
+public System.DateTimeOffset LastUpdateTime { get; set; }
+```
+Gets or sets the last update time.
+
+- Value: The `LastUpdateTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionMetrics.PLCIdentifier`
+
+```csharp
+public string PLCIdentifier { get; set; }
+```
+Gets or sets the PLC identifier.
+
+- Value: The `PLCIdentifier` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionMetrics.StartTime`
+
+```csharp
+public System.DateTimeOffset StartTime { get; set; }
+```
+Gets or sets when monitoring started.
+
+- Value: The `StartTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionMetrics.TotalTagCount`
+
+```csharp
+public int TotalTagCount { get; set; }
+```
+Gets or sets the total number of tags.
+
+- Value: The `TotalTagCount` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionMetrics.UptimePercentage`
+
+```csharp
+public double UptimePercentage { get; set; }
+```
+Gets or sets the uptime percentage.
+
+- Value: The `UptimePercentage` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Production.ProductionTagMetrics`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Production.ProductionTagMetrics
+```
+Represents aggregate production-tag metrics.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Production.ProductionTagMetrics.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Production.ProductionTagMetrics()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Production.ProductionTagMetrics`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionTagMetrics.ActiveTags`
+
+```csharp
+public int ActiveTags { get; set; }
+```
+Gets or sets the number of active tags.
+
+- Value: The `ActiveTags` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionTagMetrics.DataBlockDistribution`
+
+```csharp
+public System.Collections.Generic.Dictionary<string, int> DataBlockDistribution { get; }
+```
+Gets or sets the distribution of tags by data block.
+
+- Value: The `DataBlockDistribution` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionTagMetrics.InactiveTags`
+
+```csharp
+public int InactiveTags { get; set; }
+```
+Gets or sets the number of inactive tags.
+
+- Value: The `InactiveTags` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionTagMetrics.TotalTags`
+
+```csharp
+public int TotalTags { get; set; }
+```
+Gets or sets the total number of tags.
+
+- Value: The `TotalTags` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Production.ProductionValidationConfig`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Production.ProductionValidationConfig
+```
+Represents configuration settings for validating production system performance and reliability.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Production.ProductionValidationConfig.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Production.ProductionValidationConfig()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Production.ProductionValidationConfig`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionValidationConfig.MaxAcceptableResponseTime`
+
+```csharp
+public System.TimeSpan MaxAcceptableResponseTime { get; set; }
+```
+Gets or sets the maximum acceptable response time.
+
+- Value: The `MaxAcceptableResponseTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionValidationConfig.MinimumProductionScore`
+
+```csharp
+public double MinimumProductionScore { get; set; }
+```
+Gets or sets the minimum production score (0 to 100).
+
+- Value: The `MinimumProductionScore` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionValidationConfig.MinimumReliabilityRate`
+
+```csharp
+public double MinimumReliabilityRate { get; set; }
+```
+Gets or sets the minimum reliability rate (0.0 to 1.0).
+
+- Value: The `MinimumReliabilityRate` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ProductionValidationConfig.ReliabilityTestCount`
+
+```csharp
+public int ReliabilityTestCount { get; set; }
+```
+Gets or sets the number of operations to test for reliability.
+
+- Value: The `ReliabilityTestCount` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Production.SystemValidationResult`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Production.SystemValidationResult
+```
+Represents the result of system validation.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Production.SystemValidationResult.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Production.SystemValidationResult()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Production.SystemValidationResult`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.SystemValidationResult.CriticalErrors`
+
+```csharp
+public System.Collections.Generic.List<string> CriticalErrors { get; }
+```
+Gets critical errors that prevent production use.
+
+- Value: The `CriticalErrors` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.SystemValidationResult.IsProductionReady`
+
+```csharp
+public bool IsProductionReady { get; set; }
+```
+Gets or sets a value indicating whether the system is production ready.
+
+- Value: The `IsProductionReady` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.SystemValidationResult.OverallScore`
+
+```csharp
+public double OverallScore { get; set; }
+```
+Gets or sets the overall validation score (0-100).
+
+- Value: The `OverallScore` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.SystemValidationResult.PLCIdentifier`
+
+```csharp
+public string PLCIdentifier { get; set; }
+```
+Gets or sets the PLC identifier.
+
+- Value: The `PLCIdentifier` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.SystemValidationResult.TotalValidationTime`
+
+```csharp
+public System.TimeSpan TotalValidationTime { get; }
+```
+Gets the total validation time.
+
+- Value: The `TotalValidationTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.SystemValidationResult.ValidationEndTime`
+
+```csharp
+public System.DateTimeOffset ValidationEndTime { get; set; }
+```
+Gets or sets the validation end time.
+
+- Value: The `ValidationEndTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.SystemValidationResult.ValidationStartTime`
+
+```csharp
+public System.DateTimeOffset ValidationStartTime { get; set; }
+```
+Gets or sets the validation start time.
+
+- Value: The `ValidationStartTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.SystemValidationResult.ValidationTests`
+
+```csharp
+public System.Collections.Generic.List<IoT.DriverCore.S7PlcRx.Production.ValidationTest> ValidationTests { get; }
+```
+Gets the individual validation tests.
+
+- Value: The `ValidationTests` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Production.ValidationTest`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Production.ValidationTest
+```
+Represents the result and metadata of a validation test.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Production.ValidationTest.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Production.ValidationTest()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Production.ValidationTest`.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ValidationTest.Details`
+
+```csharp
+public System.Collections.Generic.List<string> Details { get; }
+```
+Gets additional test details.
+
+- Value: The `Details` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ValidationTest.Duration`
+
+```csharp
+public System.TimeSpan Duration { get; }
+```
+Gets the test duration.
+
+- Value: The `Duration` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ValidationTest.EndTime`
+
+```csharp
+public System.DateTimeOffset EndTime { get; set; }
+```
+Gets or sets the test end time.
+
+- Value: The `EndTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ValidationTest.ErrorMessage`
+
+```csharp
+public string ErrorMessage { get; set; }
+```
+Gets or sets any error message.
+
+- Value: The `ErrorMessage` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ValidationTest.StartTime`
+
+```csharp
+public System.DateTimeOffset StartTime { get; set; }
+```
+Gets or sets the test start time.
+
+- Value: The `StartTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ValidationTest.Success`
+
+```csharp
+public bool Success { get; set; }
+```
+Gets or sets a value indicating whether gets or sets whether the test was successful.
+
+- Value: The `Success` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Production.ValidationTest.TestName`
+
+```csharp
+public string TestName { get; set; }
+```
+Gets or sets the test name.
+
+- Value: The `TestName` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.RxS7`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.RxS7
+```
+Contains address parsing members for `T:IoT.DriverCore.S7PlcRx.RxS7` .
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.RxS7.#ctor(IoT.DriverCore.S7PlcRx.RxS7Options)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.RxS7(IoT.DriverCore.S7PlcRx.RxS7Options options)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.RxS7` class from composed connection settings.
+
+- Parameter `options`: The composed PLC connection settings.
+
+###### `M:IoT.DriverCore.S7PlcRx.RxS7.#ctor(IoT.DriverCore.S7PlcRx.RxS7Options,System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.RxS7(IoT.DriverCore.S7PlcRx.RxS7Options options, System.TimeProvider timeProvider)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.RxS7` class from composed connection settings.
+
+- Parameter `options`: The composed PLC connection settings.
+- Parameter `timeProvider`: The time provider.
+
+###### `M:IoT.DriverCore.S7PlcRx.RxS7.Dispose`
+
+```csharp
+public void Dispose()
+```
+Releases resources used by this instance.
+
+###### `M:IoT.DriverCore.S7PlcRx.RxS7.GetCpuInfo`
+
+```csharp
+public System.IObservable<string[]> GetCpuInfo()
+```
+Retrieves detailed information about the connected CPU as an observable sequence.
+
+- Returns: An observable sequence that emits CPU information fields, such as the AS name, module name, copyright, serial number, module type name, order code, and version numbers. The sequence completes after emitting the data.
+
+###### `M:IoT.DriverCore.S7PlcRx.RxS7.Observe``1(IoT.DriverCore.Core.LogicalTagKey`1{``0})`
+
+```csharp
+public System.IObservable<T> Observe<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag)
+```
+Executes the `Observe` operation.
+
+- Parameter `tag`: The `tag` value.
+- Returns: A `System.IObservable<T>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.RxS7.ReadAsync``1(IoT.DriverCore.Core.LogicalTagKey`1{``0})`
+
+```csharp
+public System.Threading.Tasks.Task<T> ReadAsync<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag)
+```
+Executes the `ReadAsync` operation.
+
+- Parameter `tag`: The `tag` value.
+- Returns: A `System.Threading.Tasks.Task<T>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.RxS7.ReadAsync``1(IoT.DriverCore.Core.LogicalTagKey`1{``0},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<T> ReadAsync<T>(IoT.DriverCore.Core.LogicalTagKey<T> tag, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ReadAsync` operation.
+
+- Parameter `tag`: The `tag` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<T>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.RxS7.Value``1(System.String,``0)`
+
+```csharp
+public void Value<T>(string variable, T value)
+```
+Sets a variable value when it exists and the value is compatible with its type.
+
+- Parameter `variable`: The name of the variable whose value is to be set. Cannot be null.
+- Parameter `value`: The value to assign to the variable. Must be compatible with the variable's type.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7.IP`
+
+```csharp
+public string IP { get; }
+```
+Gets the IP address associated with the current instance.
+
+- Value: The `IP` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7.IsConnected`
+
+```csharp
+public System.IObservable<bool> IsConnected { get; }
+```
+Gets an observable sequence that indicates whether the connection is currently established.
+
+- Value: The `IsConnected` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7.IsConnectedValue`
+
+```csharp
+public bool IsConnectedValue { get; }
+```
+Gets a value indicating whether the connection is currently established.
+
+- Value: The `IsConnectedValue` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7.IsDisposed`
+
+```csharp
+public bool IsDisposed { get; }
+```
+Gets a value indicating whether gets a value that indicates whether the object is disposed.
+
+- Value: The `IsDisposed` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7.IsPaused`
+
+```csharp
+public System.IObservable<bool> IsPaused { get; }
+```
+Gets an observable sequence that indicates whether the operation is currently paused.
+
+- Value: The `IsPaused` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7.LastError`
+
+```csharp
+public System.IObservable<string> LastError { get; }
+```
+Gets an observable sequence of the component's most recent error messages.
+
+- Value: The `LastError` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7.LastErrorCode`
+
+```csharp
+public System.IObservable<IoT.DriverCore.S7PlcRx.Enums.ErrorCode> LastErrorCode { get; }
+```
+Gets an observable sequence that emits the most recent error code reported by the system.
+
+- Value: The `LastErrorCode` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7.ObserveAll`
+
+```csharp
+public System.IObservable<IoT.DriverCore.S7PlcRx.Tag> ObserveAll { get; }
+```
+Gets an observable sequence that emits all tag updates as they occur.
+
+- Value: The `ObserveAll` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7.PLCType`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Enums.CpuType PLCType { get; }
+```
+Gets the type of PLC (Programmable Logic Controller) associated with this instance.
+
+- Value: The `PLCType` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7.Rack`
+
+```csharp
+public short Rack { get; }
+```
+Gets the rack number associated with the device or component.
+
+- Value: The `Rack` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7.ReadTime`
+
+```csharp
+public System.IObservable<long> ReadTime { get; }
+```
+Gets an observable sequence that emits each read operation's duration in ticks.
+
+- Value: The `ReadTime` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7.ShowWatchDogWriting`
+
+```csharp
+public bool ShowWatchDogWriting { get; set; }
+```
+Gets or sets a value indicating whether WatchDog writing output is displayed.
+
+- Value: The `ShowWatchDogWriting` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7.Slot`
+
+```csharp
+public short Slot { get; }
+```
+Gets the slot number associated with this instance.
+
+- Value: The `Slot` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7.Status`
+
+```csharp
+public System.IObservable<string> Status { get; }
+```
+Gets an observable sequence that provides status updates as strings.
+
+- Value: The `Status` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7.TagList`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Tags TagList { get; }
+```
+Gets the collection of tags associated with the current instance.
+
+- Value: The `TagList` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7.WatchDogAddress`
+
+```csharp
+public string WatchDogAddress { get; }
+```
+Gets the network address of the WatchDog service, if configured.
+
+- Value: The `WatchDogAddress` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7.WatchDogValueToWrite`
+
+```csharp
+public ushort WatchDogValueToWrite { get; set; }
+```
+Gets or sets the value to be written to the watchdog timer.
+
+- Value: The `WatchDogValueToWrite` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7.WatchDogWritingTime`
+
+```csharp
+public int WatchDogWritingTime { get; }
+```
+Gets the interval, in seconds, that the watchdog uses when writing status updates.
+
+- Value: The `WatchDogWritingTime` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.RxS7Options`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.RxS7Options
+```
+Composes connection, polling, and optional watchdog settings for `T:IoT.DriverCore.S7PlcRx.RxS7` .
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.RxS7Options.#ctor(IoT.DriverCore.S7PlcRx.S7ConnectionOptions,IoT.DriverCore.S7PlcRx.S7PollingOptions,IoT.DriverCore.S7PlcRx.S7WatchdogOptions)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.RxS7Options(IoT.DriverCore.S7PlcRx.S7ConnectionOptions connection, IoT.DriverCore.S7PlcRx.S7PollingOptions polling, IoT.DriverCore.S7PlcRx.S7WatchdogOptions watchdog)
+```
+Composes connection, polling, and optional watchdog settings for `T:IoT.DriverCore.S7PlcRx.RxS7` .
+
+- Parameter `connection`: The PLC endpoint settings.
+- Parameter `polling`: The polling settings, or to use defaults.
+- Parameter `watchdog`: The optional watchdog settings.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7Options.Connection`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.S7ConnectionOptions Connection { get; }
+```
+Gets the PLC endpoint settings.
+
+- Value: The `Connection` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7Options.Polling`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.S7PollingOptions Polling { get; }
+```
+Gets the polling settings.
+
+- Value: The `Polling` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.RxS7Options.Watchdog`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.S7WatchdogOptions Watchdog { get; }
+```
+Gets the optional watchdog settings.
+
+- Value: The `Watchdog` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.S71200`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.S71200
+```
+Creates connections to Siemens S7-1200 PLC devices.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.S71200.Create(System.String)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.IRxS7 Create(string ip)
+```
+Creates an S7-1200 connection with standard settings.
+
+- Parameter `ip`: The PLC IP address.
+- Returns: The configured PLC connection.
+
+###### `M:IoT.DriverCore.S7PlcRx.S71200.Create(System.String,System.Int16)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.IRxS7 Create(string ip, short rack)
+```
+Creates an S7-1200 connection for a rack with standard settings.
+
+- Parameter `ip`: The PLC IP address.
+- Parameter `rack`: The PLC rack number.
+- Returns: The configured PLC connection.
+
+###### `M:IoT.DriverCore.S7PlcRx.S71200.Create(System.String,System.Int16,IoT.DriverCore.S7PlcRx.S7PollingOptions,IoT.DriverCore.S7PlcRx.S7WatchdogOptions)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.IRxS7 Create(string ip, short rack, IoT.DriverCore.S7PlcRx.S7PollingOptions polling, IoT.DriverCore.S7PlcRx.S7WatchdogOptions watchdog)
+```
+Creates an S7-1200 connection with explicit settings.
+
+- Parameter `ip`: The PLC IP address.
+- Parameter `rack`: The PLC rack number.
+- Parameter `polling`: The polling configuration.
+- Parameter `watchdog`: The optional watchdog configuration.
+- Returns: The configured PLC connection.
+
+#### `T:IoT.DriverCore.S7PlcRx.S71500`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.S71500
+```
+Creates connections to Siemens S7-1500 PLC devices.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.S71500.Create(System.String)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.IRxS7 Create(string ip)
+```
+Creates an S7-1500 connection with standard settings.
+
+- Parameter `ip`: The PLC IP address.
+- Returns: The configured PLC connection.
+
+###### `M:IoT.DriverCore.S7PlcRx.S71500.Create(System.String,System.Double)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.IRxS7 Create(string ip, double interval)
+```
+Creates an S7-1500 connection with an explicit polling interval.
+
+- Parameter `ip`: The PLC IP address.
+- Parameter `interval`: The polling interval in milliseconds.
+- Returns: The configured PLC connection.
+
+###### `M:IoT.DriverCore.S7PlcRx.S71500.Create(System.String,System.Int16,System.Int16)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.IRxS7 Create(string ip, short rack, short slot)
+```
+Creates an S7-1500 connection at a rack and slot with standard polling.
+
+- Parameter `ip`: The PLC IP address.
+- Parameter `rack`: The PLC rack number.
+- Parameter `slot`: The PLC CPU slot.
+- Returns: The configured PLC connection.
+
+###### `M:IoT.DriverCore.S7PlcRx.S71500.Create(System.String,System.Int16,System.Int16,IoT.DriverCore.S7PlcRx.S7PollingOptions,IoT.DriverCore.S7PlcRx.S7WatchdogOptions)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.IRxS7 Create(string ip, short rack, short slot, IoT.DriverCore.S7PlcRx.S7PollingOptions polling, IoT.DriverCore.S7PlcRx.S7WatchdogOptions watchdog)
+```
+Creates an S7-1500 connection with explicit settings.
+
+- Parameter `ip`: The PLC IP address.
+- Parameter `rack`: The PLC rack number.
+- Parameter `slot`: The PLC CPU slot.
+- Parameter `polling`: The polling configuration.
+- Parameter `watchdog`: The optional watchdog configuration.
+- Returns: The configured PLC connection.
+
+###### `M:IoT.DriverCore.S7PlcRx.S71500.Create(System.String,System.Int16,System.Int16,System.String,System.Double)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.IRxS7 Create(string ip, short rack, short slot, string watchDogAddress, double interval)
+```
+Creates an S7-1500 connection with legacy scalar settings.
+
+- Parameter `ip`: The PLC IP address.
+- Parameter `rack`: The PLC rack number.
+- Parameter `slot`: The PLC CPU slot.
+- Parameter `watchDogAddress`: The optional watchdog address.
+- Parameter `interval`: The polling interval in milliseconds.
+- Returns: The configured PLC connection.
+
+#### `T:IoT.DriverCore.S7PlcRx.S7200`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.S7200
+```
+Creates connections to Siemens S7-200 PLC devices.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.S7200.Create(System.String,System.Int16,System.Int16)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.IRxS7 Create(string ip, short rack, short slot)
+```
+Creates an S7-200 connection with standard polling.
+
+- Parameter `ip`: The PLC IP address.
+- Parameter `rack`: The PLC rack number.
+- Parameter `slot`: The PLC CPU slot.
+- Returns: The configured PLC connection.
+
+###### `M:IoT.DriverCore.S7PlcRx.S7200.Create(System.String,System.Int16,System.Int16,IoT.DriverCore.S7PlcRx.S7PollingOptions,IoT.DriverCore.S7PlcRx.S7WatchdogOptions)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.IRxS7 Create(string ip, short rack, short slot, IoT.DriverCore.S7PlcRx.S7PollingOptions polling, IoT.DriverCore.S7PlcRx.S7WatchdogOptions watchdog)
+```
+Creates an S7-200 connection with explicit settings.
+
+- Parameter `ip`: The PLC IP address.
+- Parameter `rack`: The PLC rack number.
+- Parameter `slot`: The PLC CPU slot.
+- Parameter `polling`: The polling configuration.
+- Parameter `watchdog`: The optional watchdog configuration.
+- Returns: The configured PLC connection.
+
+#### `T:IoT.DriverCore.S7PlcRx.S7300`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.S7300
+```
+Creates connections to Siemens S7-300 PLC devices.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.S7300.Create(System.String,System.Int16,System.Int16)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.IRxS7 Create(string ip, short rack, short slot)
+```
+Creates an S7-300 connection with standard polling.
+
+- Parameter `ip`: The PLC IP address.
+- Parameter `rack`: The PLC rack number.
+- Parameter `slot`: The PLC CPU slot.
+- Returns: The configured PLC connection.
+
+###### `M:IoT.DriverCore.S7PlcRx.S7300.Create(System.String,System.Int16,System.Int16,IoT.DriverCore.S7PlcRx.S7PollingOptions,IoT.DriverCore.S7PlcRx.S7WatchdogOptions)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.IRxS7 Create(string ip, short rack, short slot, IoT.DriverCore.S7PlcRx.S7PollingOptions polling, IoT.DriverCore.S7PlcRx.S7WatchdogOptions watchdog)
+```
+Creates an S7-300 connection with explicit settings.
+
+- Parameter `ip`: The PLC IP address.
+- Parameter `rack`: The PLC rack number.
+- Parameter `slot`: The PLC CPU slot.
+- Parameter `polling`: The polling configuration.
+- Parameter `watchdog`: The optional watchdog configuration.
+- Returns: The configured PLC connection.
+
+#### `T:IoT.DriverCore.S7PlcRx.S7400`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.S7400
+```
+Creates connections to Siemens S7-400 PLC devices.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.S7400.Create(System.String,System.Int16,System.Int16)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.IRxS7 Create(string ip, short rack, short slot)
+```
+Creates an S7-400 connection with standard polling.
+
+- Parameter `ip`: The PLC IP address.
+- Parameter `rack`: The PLC rack number.
+- Parameter `slot`: The PLC CPU slot.
+- Returns: The configured PLC connection.
+
+###### `M:IoT.DriverCore.S7PlcRx.S7400.Create(System.String,System.Int16,System.Int16,IoT.DriverCore.S7PlcRx.S7PollingOptions,IoT.DriverCore.S7PlcRx.S7WatchdogOptions)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.IRxS7 Create(string ip, short rack, short slot, IoT.DriverCore.S7PlcRx.S7PollingOptions polling, IoT.DriverCore.S7PlcRx.S7WatchdogOptions watchdog)
+```
+Creates an S7-400 connection with explicit settings.
+
+- Parameter `ip`: The PLC IP address.
+- Parameter `rack`: The PLC rack number.
+- Parameter `slot`: The PLC CPU slot.
+- Parameter `polling`: The polling configuration.
+- Parameter `watchdog`: The optional watchdog configuration.
+- Returns: The configured PLC connection.
+
+#### `T:IoT.DriverCore.S7PlcRx.S7ConnectionOptions`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.S7ConnectionOptions
+```
+Describes the PLC endpoint used by an `T:IoT.DriverCore.S7PlcRx.RxS7` connection.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.S7ConnectionOptions.#ctor(IoT.DriverCore.S7PlcRx.Enums.CpuType,System.String,System.Int16,System.Int16)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.S7ConnectionOptions(IoT.DriverCore.S7PlcRx.Enums.CpuType cpuType, string address, short rack, short slot)
+```
+Describes the PLC endpoint used by an `T:IoT.DriverCore.S7PlcRx.RxS7` connection.
+
+- Parameter `cpuType`: The PLC CPU family.
+- Parameter `address`: The PLC IP address.
+- Parameter `rack`: The PLC rack number.
+- Parameter `slot`: The PLC CPU slot number.
+
+###### `P:IoT.DriverCore.S7PlcRx.S7ConnectionOptions.CpuType`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Enums.CpuType CpuType { get; }
+```
+Gets the PLC CPU family.
+
+- Value: The `CpuType` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.S7ConnectionOptions.IpAddress`
+
+```csharp
+public string IpAddress { get; }
+```
+Gets the PLC IP address.
+
+- Value: The `IpAddress` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.S7ConnectionOptions.Rack`
+
+```csharp
+public short Rack { get; }
+```
+Gets the PLC rack number.
+
+- Value: The `Rack` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.S7ConnectionOptions.Slot`
+
+```csharp
+public short Slot { get; }
+```
+Gets the PLC CPU slot number.
+
+- Value: The `Slot` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.S7Exception`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.S7Exception
+```
+Represents errors that occur during S7 protocol operations.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.S7Exception.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.S7Exception()
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.S7Exception` class.
+
+###### `M:IoT.DriverCore.S7PlcRx.S7Exception.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.S7Exception(string message)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.S7Exception` class.
+
+- Parameter `message`: The message that describes the error.
+
+###### `M:IoT.DriverCore.S7PlcRx.S7Exception.#ctor(System.String,System.Exception)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.S7Exception(string message, System.Exception innerException)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.S7Exception` class.
+
+- Parameter `message`: The error message that explains the reason for the exception.
+- Parameter `innerException`: The exception that caused the current exception.
+
+#### `T:IoT.DriverCore.S7PlcRx.S7PollingOptions`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.S7PollingOptions
+```
+Describes periodic PLC tag polling.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.S7PlcRx.S7PollingOptions.DefaultIntervalMilliseconds`
+
+```csharp
+public static double DefaultIntervalMilliseconds
+```
+The default polling interval in milliseconds.
+
+###### `M:IoT.DriverCore.S7PlcRx.S7PollingOptions.#ctor(System.Double)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.S7PollingOptions(double intervalMilliseconds)
+```
+Describes periodic PLC tag polling.
+
+- Parameter `intervalMilliseconds`: The polling interval in milliseconds.
+
+###### `P:IoT.DriverCore.S7PlcRx.S7PollingOptions.IntervalMilliseconds`
+
+```csharp
+public double IntervalMilliseconds { get; }
+```
+Gets the polling interval in milliseconds.
+
+- Value: The `IntervalMilliseconds` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.S7WatchdogOptions`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.S7WatchdogOptions
+```
+Describes optional PLC watchdog writes.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.S7PlcRx.S7WatchdogOptions.DefaultIntervalSeconds`
+
+```csharp
+public static int DefaultIntervalSeconds
+```
+The default watchdog interval in seconds.
+
+###### `F:IoT.DriverCore.S7PlcRx.S7WatchdogOptions.DefaultValueToWrite`
+
+```csharp
+public static ushort DefaultValueToWrite
+```
+The default value written during each watchdog cycle.
+
+###### `M:IoT.DriverCore.S7PlcRx.S7WatchdogOptions.#ctor(System.String,System.UInt16,System.Int32)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.S7WatchdogOptions(string address, ushort valueToWrite, int intervalSeconds)
+```
+Describes optional PLC watchdog writes.
+
+- Parameter `address`: The DBW watchdog address.
+- Parameter `valueToWrite`: The value written during each watchdog cycle.
+- Parameter `intervalSeconds`: The watchdog interval in seconds.
+
+###### `P:IoT.DriverCore.S7PlcRx.S7WatchdogOptions.Address`
+
+```csharp
+public string Address { get; }
+```
+Gets the DBW watchdog address.
+
+- Value: The `Address` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.S7WatchdogOptions.IntervalSeconds`
+
+```csharp
+public int IntervalSeconds { get; }
+```
+Gets the watchdog interval in seconds.
+
+- Value: The `IntervalSeconds` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.S7WatchdogOptions.ValueToWrite`
+
+```csharp
+public ushort ValueToWrite { get; }
+```
+Gets the value written during each watchdog cycle.
+
+- Value: The `ValueToWrite` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.SourceGeneration.S7PlcBindingAttribute`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.SourceGeneration.S7PlcBindingAttribute
+```
+Marks a class as an S7 PLC binding target.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.SourceGeneration.S7PlcBindingAttribute.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.SourceGeneration.S7PlcBindingAttribute()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.SourceGeneration.S7PlcBindingAttribute`.
+
+#### `T:IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagAttribute`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagAttribute
+```
+Marks a partial property as a PLC tag binding target.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagAttribute.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagAttribute(string address)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagAttribute` class.
+
+- Parameter `address`: The PLC tag address.
+
+###### `P:IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagAttribute.Address`
+
+```csharp
+public string Address { get; }
+```
+Gets the PLC tag address.
+
+- Value: The `Address` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagAttribute.ArrayLength`
+
+```csharp
+public int ArrayLength { get; set; }
+```
+Gets or sets the PLC array length.
+
+- Value: The `ArrayLength` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagAttribute.Direction`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagDirection Direction { get; set; }
+```
+Gets or sets the binding direction.
+
+- Value: The `Direction` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagAttribute.PollIntervalMs`
+
+```csharp
+public int PollIntervalMs { get; set; }
+```
+Gets or sets the polling interval in milliseconds.
+
+- Value: The `PollIntervalMs` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagDirection`
+
+```csharp
+public enum IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagDirection
+```
+Defines PLC tag binding direction.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagDirection.ReadOnly`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagDirection ReadOnly
+```
+Reads the PLC tag only.
+
+###### `F:IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagDirection.ReadWrite`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagDirection ReadWrite
+```
+Reads and writes the PLC tag.
+
+###### `F:IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagDirection.WriteOnly`
+
+```csharp
+public static const IoT.DriverCore.S7PlcRx.SourceGeneration.S7TagDirection WriteOnly
+```
+Writes the PLC tag only.
+
+#### `T:IoT.DriverCore.S7PlcRx.Tag`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Tag
+```
+Represents a data tag with a name, address, value, type, and optional array length, typically used for storing or transferring typed values identified by address or name.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Tag.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Tag()
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.Tag` class.
+
+###### `M:IoT.DriverCore.S7PlcRx.Tag.#ctor(System.String,System.String,System.Object,System.Type)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Tag(string name, string address, object value, System.Type type)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.Tag` class.
+
+- Parameter `name`: The name.
+- Parameter `address`: The address.
+- Parameter `value`: The value.
+- Parameter `type`: The type.
+
+###### `M:IoT.DriverCore.S7PlcRx.Tag.#ctor(System.String,System.String,System.Type)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Tag(string name, string address, System.Type type)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.Tag` class.
+
+- Parameter `name`: The name.
+- Parameter `address`: The address.
+- Parameter `type`: The type.
+
+###### `M:IoT.DriverCore.S7PlcRx.Tag.#ctor(System.String,System.String,System.Type,System.Int32)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Tag(string name, string address, System.Type type, int arrayLength)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.Tag` class.
+
+- Parameter `name`: The name.
+- Parameter `address`: The address.
+- Parameter `type`: The type.
+- Parameter `arrayLength`: Length of the array.
+
+###### `M:IoT.DriverCore.S7PlcRx.Tag.#ctor(System.String,System.Type)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Tag(string address, System.Type type)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.Tag` class.
+
+- Parameter `address`: The address.
+- Parameter `type`: The type.
+
+###### `M:IoT.DriverCore.S7PlcRx.Tag.#ctor(System.String,System.Type,System.Int32)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Tag(string address, System.Type type, int arrayLength)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.Tag` class.
+
+- Parameter `address`: The address.
+- Parameter `type`: The type.
+- Parameter `arrayLength`: Length of the array.
+
+###### `M:IoT.DriverCore.S7PlcRx.Tag.SetDoNotPoll(System.Boolean)`
+
+```csharp
+public void SetDoNotPoll(bool value)
+```
+Sets a value indicating whether polling operations should be disabled.
+
+- Parameter `value`: true to disable polling; otherwise, false.
+
+###### `P:IoT.DriverCore.S7PlcRx.Tag.Address`
+
+```csharp
+public string Address { get; set; }
+```
+Gets or sets the address associated with the entity.
+
+- Value: The `Address` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Tag.ArrayLength`
+
+```csharp
+public System.Nullable<int> ArrayLength { get; }
+```
+Gets the length of the array, if known.
+
+- Value: The `ArrayLength` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Tag.DoNotPoll`
+
+```csharp
+public bool DoNotPoll { get; }
+```
+Gets a value indicating whether polling operations should be suppressed for this instance.
+
+- Value: The `DoNotPoll` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Tag.Name`
+
+```csharp
+public string Name { get; set; }
+```
+Gets or sets the name associated with the object.
+
+- Value: The `Name` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Tag.NewValue`
+
+```csharp
+public object NewValue { get; }
+```
+Gets the new value associated with the change event.
+
+- Value: The `NewValue` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Tag.Type`
+
+```csharp
+public System.Type Type { get; }
+```
+Gets the runtime type information associated with the current instance.
+
+- Value: The `Type` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Tag.Value`
+
+```csharp
+public object Value { get; set; }
+```
+Gets or sets the value associated with this instance.
+
+- Value: The `Value` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException
+```
+Thrown when a tag address is outside the valid range.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException()
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException` class.
+
+###### `M:IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException.#ctor(IoT.DriverCore.S7PlcRx.Tag)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException(IoT.DriverCore.S7PlcRx.Tag tag)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException` class.
+
+- Parameter `tag`: The Tag that caused the exception.
+
+###### `M:IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException.#ctor(IoT.DriverCore.S7PlcRx.Tag,System.Exception)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException(IoT.DriverCore.S7PlcRx.Tag tag, System.Exception innerException)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException` class.
+
+- Parameter `tag`: The Tag that caused the exception.
+- Parameter `innerException`: The exception that caused the current exception, or if no inner exception is specified.
+
+###### `M:IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException.#ctor(IoT.DriverCore.S7PlcRx.Tag,System.Object,System.String)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException(IoT.DriverCore.S7PlcRx.Tag tag, object actualValue, string message)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException` class.
+
+- Parameter `tag`: The Tag that caused the exception.
+- Parameter `actualValue`: The value of the argument that causes this exception.
+- Parameter `message`: The message that describes the error.
+
+###### `M:IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException.#ctor(IoT.DriverCore.S7PlcRx.Tag,System.String)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException(IoT.DriverCore.S7PlcRx.Tag tag, string message)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException` class.
+
+- Parameter `tag`: The Tag that caused the exception.
+- Parameter `message`: The message that describes the error.
+
+###### `M:IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException(string message)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException` class.
+
+- Parameter `message`: The message that describes the error.
+
+###### `M:IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException.#ctor(System.String,System.Exception)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException(string message, System.Exception innerException)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException` class.
+
+- Parameter `message`: The message that describes the error.
+- Parameter `innerException`: The exception that caused the current exception.
+
+###### `M:IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException.#ctor(System.String,System.Object,System.String)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException(string paramName, object actualValue, string message)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException` class.
+
+- Parameter `paramName`: The parameter name.
+- Parameter `actualValue`: The invalid value.
+- Parameter `message`: The error message.
+
+###### `M:IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException.#ctor(System.String,System.String)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException(string paramName, string message)
+```
+Initializes a new instance of the `T:IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException` class.
+
+- Parameter `paramName`: The parameter name.
+- Parameter `message`: The error message.
+
+###### `P:IoT.DriverCore.S7PlcRx.TagAddressOutOfRangeException.ParamName`
+
+```csharp
+public string ParamName { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `ParamName` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.TagOperations`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.TagOperations
+```
+Provides compositional operations for managing S7 tags.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.TagOperations.AddUpdateTagItem(IoT.DriverCore.S7PlcRx.IRxS7,System.Type,System.String,System.String)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.TagRegistration AddUpdateTagItem(IoT.DriverCore.S7PlcRx.IRxS7 plc, System.Type type, string tagName, string address)
+```
+Adds or updates a scalar tag.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `type`: The tag value type.
+- Parameter `tagName`: The tag name.
+- Parameter `address`: The PLC address.
+- Returns: The registered tag and PLC.
+
+###### `M:IoT.DriverCore.S7PlcRx.TagOperations.AddUpdateTagItem(IoT.DriverCore.S7PlcRx.IRxS7,System.Type,System.String,System.String,System.Int32)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.TagRegistration AddUpdateTagItem(IoT.DriverCore.S7PlcRx.IRxS7 plc, System.Type type, string tagName, string address, int arrayLength)
+```
+Adds or updates an array or fixed-length string tag.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `type`: The tag value type.
+- Parameter `tagName`: The tag name.
+- Parameter `address`: The PLC address.
+- Parameter `arrayLength`: The fixed array or string length.
+- Returns: The registered tag and PLC.
+
+###### `M:IoT.DriverCore.S7PlcRx.TagOperations.AddUpdateTagItem(IoT.DriverCore.S7PlcRx.IRxS7,System.Type,System.String,System.String,System.Nullable`1{System.Int32})`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.TagRegistration AddUpdateTagItem(IoT.DriverCore.S7PlcRx.IRxS7 plc, System.Type type, string tagName, string address, System.Nullable<int> arrayLength)
+```
+Executes the `AddUpdateTagItem` operation.
+
+- Parameter `plc`: The `plc` value.
+- Parameter `type`: The `type` value.
+- Parameter `tagName`: The `tagName` value.
+- Parameter `address`: The `address` value.
+- Parameter `arrayLength`: The `arrayLength` value.
+- Returns: A `IoT.DriverCore.S7PlcRx.TagRegistration` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.TagOperations.GetTag(IoT.DriverCore.S7PlcRx.IRxS7,System.String)`
+
+```csharp
+public static IoT.DriverCore.S7PlcRx.TagRegistration GetTag(IoT.DriverCore.S7PlcRx.IRxS7 plc, string tagName)
+```
+Gets a tag by name.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `tagName`: The tag name.
+- Returns: The tag registration.
+
+###### `M:IoT.DriverCore.S7PlcRx.TagOperations.RemoveTagItem(IoT.DriverCore.S7PlcRx.IRxS7,System.String)`
+
+```csharp
+public static void RemoveTagItem(IoT.DriverCore.S7PlcRx.IRxS7 plc, string tagName)
+```
+Removes a named tag.
+
+- Parameter `plc`: The PLC instance.
+- Parameter `tagName`: The tag name.
+
+###### `M:IoT.DriverCore.S7PlcRx.TagOperations.TagToDictionary(System.IObservable`1{IoT.DriverCore.S7PlcRx.Tag})`
+
+```csharp
+public static System.IObservable<System.Collections.Generic.IDictionary<string, object>> TagToDictionary(System.IObservable<IoT.DriverCore.S7PlcRx.Tag> source)
+```
+Executes the `TagToDictionary` operation.
+
+- Parameter `source`: The `source` value.
+- Returns: A `System.IObservable<System.Collections.Generic.IDictionary<string, object>>` result.
+
+###### `M:IoT.DriverCore.S7PlcRx.TagOperations.ToTagValue``1(System.IObservable`1{``0},System.String)`
+
+```csharp
+public static System.IObservable<System.ValueTuple<string, TValue>> ToTagValue<TValue>(System.IObservable<TValue> source, string tag)
+```
+Executes the `ToTagValue` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `tag`: The `tag` value.
+- Returns: A `System.IObservable<System.ValueTuple<string, TValue>>` result.
+
+#### `T:IoT.DriverCore.S7PlcRx.TagRegistration`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.TagRegistration
+```
+Represents a tag and the PLC to which it is registered.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.TagRegistration.Deconstruct(IoT.DriverCore.S7PlcRx.ITag@,IoT.DriverCore.S7PlcRx.IRxS7@)`
+
+```csharp
+public void Deconstruct(out IoT.DriverCore.S7PlcRx.ITag tag, out IoT.DriverCore.S7PlcRx.IRxS7 plc)
+```
+Deconstructs the registration.
+
+- Parameter `tag`: The registered tag.
+- Parameter `plc`: The PLC instance.
+
+###### `M:IoT.DriverCore.S7PlcRx.TagRegistration.SetPolling`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.TagRegistration SetPolling()
+```
+Enables polling for the tag.
+
+- Returns: This registration.
+
+###### `M:IoT.DriverCore.S7PlcRx.TagRegistration.SetPolling(System.Boolean)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.TagRegistration SetPolling(bool polling)
+```
+Enables or disables polling for the tag.
+
+- Parameter `polling`: Whether polling is enabled.
+- Returns: This registration.
+
+###### `P:IoT.DriverCore.S7PlcRx.TagRegistration.Plc`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.IRxS7 Plc { get; }
+```
+Gets the PLC instance.
+
+- Value: The `Plc` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.TagRegistration.Tag`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.ITag Tag { get; }
+```
+Gets the registered tag.
+
+- Value: The `Tag` value.
+
+#### `T:IoT.DriverCore.S7PlcRx.Tags`
+
+```csharp
+public class IoT.DriverCore.S7PlcRx.Tags
+```
+Represents a thread-safe collection of tag objects, providing methods for adding, retrieving, and managing tags by key, name, or tag instance.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.S7PlcRx.Tags.#ctor`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Tags()
+```
+Initializes a new instance of `IoT.DriverCore.S7PlcRx.Tags`.
+
+###### `M:IoT.DriverCore.S7PlcRx.Tags.Add(IoT.DriverCore.S7PlcRx.Tag)`
+
+```csharp
+public void Add(IoT.DriverCore.S7PlcRx.Tag tag)
+```
+Adds the specified tag to the collection.
+
+- Parameter `tag`: The tag to add to the collection. Cannot be null.
+
+###### `M:IoT.DriverCore.S7PlcRx.Tags.Add(System.Object,IoT.DriverCore.S7PlcRx.Tag)`
+
+```csharp
+public void Add(object key, IoT.DriverCore.S7PlcRx.Tag tag)
+```
+Adds the specified tag to the collection with the associated key.
+
+- Parameter `key`: The key with which the specified tag is to be associated. Cannot be null.
+- Parameter `tag`: The tag to add to the collection. Cannot be null.
+
+###### `M:IoT.DriverCore.S7PlcRx.Tags.Add(System.Object,IoT.DriverCore.S7PlcRx.Tags)`
+
+```csharp
+public void Add(object key, IoT.DriverCore.S7PlcRx.Tags tags)
+```
+Adds the specified key and associated tags to the collection.
+
+- Parameter `key`: The key with which the specified tags are to be associated. Cannot be null.
+- Parameter `tags`: The tags to associate with the specified key. Cannot be null.
+
+###### `M:IoT.DriverCore.S7PlcRx.Tags.Add(System.Object,System.Object)`
+
+```csharp
+public void Add(object key, object value)
+```
+Adds an element with the specified key and value to the collection in a thread-safe manner.
+
+- Parameter `key`: The key of the element to add. Cannot be null.
+- Parameter `value`: The value of the element to add. Can be null.
+
+###### `M:IoT.DriverCore.S7PlcRx.Tags.AddRange(System.Collections.Generic.IEnumerable`1{IoT.DriverCore.S7PlcRx.Tag})`
+
+```csharp
+public void AddRange(System.Collections.Generic.IEnumerable<IoT.DriverCore.S7PlcRx.Tag> tags)
+```
+Executes the `AddRange` operation.
+
+- Parameter `tags`: The `tags` value.
+
+###### `M:IoT.DriverCore.S7PlcRx.Tags.Get(IoT.DriverCore.S7PlcRx.Tag)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Tag Get(IoT.DriverCore.S7PlcRx.Tag tag)
+```
+Gets the tag from the collection that matches the specified tag's name, if present.
+
+- Parameter `tag`: The tag whose name identifies the collection entry.
+- Returns: The matching tag, or when no tag matches.
+
+###### `M:IoT.DriverCore.S7PlcRx.Tags.GetTags`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Tags GetTags()
+```
+Retrieves a collection of tags that have non-null values.
+
+- Returns: A collection containing every tag with a non-null value.
+
+###### `M:IoT.DriverCore.S7PlcRx.Tags.ToList`
+
+```csharp
+public System.Collections.Generic.List<IoT.DriverCore.S7PlcRx.Tag> ToList()
+```
+Returns a list containing all tags in the collection.
+
+- Returns: A snapshot of the tags, or an empty list when retrieval fails.
+
+###### `P:IoT.DriverCore.S7PlcRx.Tags.Item(System.Object)`
+
+```csharp
+public object Item[object key] { get; set; }
+```
+Gets or sets the value associated with the specified key.
+
+- Parameter `key`: The key whose value to get or set. Cannot be null.
+- Returns: The associated value, or when the key is absent.
+- Value: The `Item` value.
+
+###### `P:IoT.DriverCore.S7PlcRx.Tags.Item(System.String)`
+
+```csharp
+public IoT.DriverCore.S7PlcRx.Tag Item[string name] { get; }
+```
+Gets the tag with the specified name, if it exists.
+
+- Parameter `name`: The tag name.
+- Returns: The tag associated with the specified name, or null if no tag with that name exists.
+- Value: The `Item` value.
+
+<!-- END GENERATED PUBLIC API -->

--- a/packagereadme/SerialPortRx/README.md
+++ b/packagereadme/SerialPortRx/README.md
@@ -1,9 +1,60 @@
 # SerialPortRx
 A Reactive Serial, TCP, and UDP I/O library that exposes incoming data as IObservable streams and accepts writes via simple methods. Ideal for event-driven, message-framed, and polling scenarios.
 
-[![SerialPortRx CI-Build](https://github.com/ChrisPulman/SerialPortRx/actions/workflows/dotnet.yml/badge.svg)](https://github.com/ChrisPulman/SerialPortRx/actions/workflows/dotnet.yml)
-![Nuget](https://img.shields.io/nuget/dt/SerialPortRx)
-[![NuGet Stats](https://img.shields.io/nuget/v/SerialPortRx.svg)](https://www.nuget.org/packages/SerialPortRx)
+## Overview
+
+The package is named `SerialPortRx`; migrated application code imports `IoT.DriverCore.Serial`. It provides one receive contract over serial ports, TCP streams, UDP datagrams, deterministic in-memory links, request/response coordination, observables, async-observables, and a bundled source generator. `SerialPortRx.Reactive` mirrors the implementation under `IoT.DriverCore.Serial.Reactive` for System.Reactive-oriented consumers.
+
+Choose exactly one receive owner for each connection: automatic observable reception, an explicit `StartDataReception` lease, or manual `Read*` calls. Combining these models makes bytes compete and breaks protocol framing.
+
+## Safety
+
+- Treat serial and network input as untrusted. Set device-appropriate timeouts, bound buffers/message sizes in your parser, validate commands, and authenticate any application protocol.
+- Configure serial settings and `EnableAutoDataReceive` **before** `OpenAsync`. Subscribe to `ErrorReceived` and state before command traffic.
+- Hold every subscription, reception lease, message handler, and port in an owned disposal scope. Call `Close` or `Dispose` before changing wires or reconfiguring endpoints.
+- A TCP read is not a message boundary. Frame TCP chunks yourself. UDP batches preserve datagram boundaries but still need application validation.
+
+## Package matrix and installation
+
+| Package | Namespace | When to choose it | Generator |
+|---|---|---|---|
+| `SerialPortRx` | `IoT.DriverCore.Serial` | New code using ReactiveUI.Primitives | Includes the serial analyzer asset. |
+| `SerialPortRx.Reactive` | `IoT.DriverCore.Serial.Reactive` | Existing System.Reactive-facing code | Includes the same analyzer behavior. |
+
+```bash
+dotnet add package SerialPortRx
+# Or, for the reactive compatibility surface:
+dotnet add package SerialPortRx.Reactive
+```
+
+Target frameworks are `net462`, `net472`, `net481`, `net8.0`, `net9.0`, `net10.0`, and `net11.0`; Windows-specific pin APIs are conditionally compiled for Windows-capable targets.
+
+## Lifecycle and error model
+
+`OpenAsync` starts a configured transport and starts the automatic receiver when enabled. `Close` and `Dispose` release the underlying port/socket and complete owned streams; a disposed object must not be reopened. `ErrorReceived` reports transport/parser errors; `IsOpenObservable` reports state transitions. `ReadAsync`, `ReadLineAsync`, and `ReadToAsync` can throw timeout, cancellation, I/O, and invalid-operation exceptions. Observe errors before opening and use a cancellation token/finite timeout for request paths.
+
+```csharp
+using IoT.DriverCore.Serial;
+
+using var port = new SerialPortRx("COM3", 115200)
+{
+    NewLine = "\r\n",
+    ReadTimeout = 1000,
+    WriteTimeout = 1000,
+    EnableAutoDataReceive = true,
+};
+using var state = port.IsOpenObservable.Subscribe(open => Console.WriteLine($"Open={open}"));
+using var errors = port.ErrorReceived.Subscribe(Console.Error.WriteLine);
+await port.OpenAsync();
+try
+{
+    port.WriteLine("AT");
+}
+finally
+{
+    port.Close();
+}
+```
 
 ## Features
 - SerialPortRx: Reactive wrapper for System.IO.Ports.SerialPort using ReactiveUI.Primitives
@@ -64,7 +115,7 @@ The package includes the SerialPortRx source generator as an analyzer. No separa
 ## Quick start (Serial)
 ```csharp
 using System;
-using CP.IO.Ports;
+using IoT.DriverCore.Serial;
 using ReactiveUI.Primitives;
 
 var port = new SerialPortRx("COM3", 115200) { ReadTimeout = -1, WriteTimeout = -1 };
@@ -124,7 +175,7 @@ using var portNamesSubscription = SerialPortRx.PortNames()
 SerialPortRx uses ReactiveUI.Primitives async observables for consumers that need asynchronous observer callbacks and full `IObservableAsync<T>` operators.
 
 ```csharp
-using CP.IO.Ports;
+using IoT.DriverCore.Serial;
 using ReactiveUI.Primitives;
 using ReactiveUI.Primitives.Async;
 
@@ -217,28 +268,55 @@ Notes:
 By default, `EnableAutoDataReceive = true` automatically feeds incoming data to `DataReceived` and `DataReceivedBytes` observables. Set this to `false` before calling `OpenAsync()` if you want to use synchronous read methods instead.
 
 ```csharp
-// Automatic mode (default) - data flows to observables
-var port = new SerialPortRx("COM3", 115200);
-port.DataReceived.Subscribe(ch => Console.Write(ch));
-await port.OpenAsync();
-
-// Manual mode - use synchronous reads
-var port = new SerialPortRx("COM3", 115200) { EnableAutoDataReceive = false };
-await port.OpenAsync();
-string data = port.ReadExisting();
+// Automatic mode owns receive bytes and publishes them to observers.
+using var automaticPort = new SerialPortRx("COM3", 115200);
+using var automaticData = automaticPort.DataReceived.Subscribe(ch => Console.Write(ch));
+await automaticPort.OpenAsync();
+try
+{
+    automaticPort.WriteLine("STATUS?");
+}
+finally
+{
+    automaticPort.Close();
+}
 ```
 
-If you disable auto-receive but later want reactive streaming, call `StartDataReception()`:
+Manual mode is a separate connection. Disable automatic reception before opening it, then use only the synchronous/manual receive methods:
+
 ```csharp
-port.EnableAutoDataReceive = false;
-await port.OpenAsync();
+using var manualPort = new SerialPortRx("COM4", 115200)
+{
+    EnableAutoDataReceive = false,
+    ReadTimeout = 1000,
+};
+await manualPort.OpenAsync();
+try
+{
+    string data = manualPort.ReadExisting();
+    Console.WriteLine(data);
+}
+finally
+{
+    manualPort.Close();
+}
+```
 
-// Later, enable reactive streaming manually
-var reception = port.StartDataReception(pollingIntervalMs: 10);
-port.DataReceived.Subscribe(ch => Console.Write(ch));
+If a manually configured port later needs observable reception, start exactly one reception lease after opening it; do not also call `Read*` while that lease is active:
 
-// Stop when done
-reception.Dispose();
+```csharp
+using var switchedPort = new SerialPortRx("COM5", 115200)
+{
+    EnableAutoDataReceive = false,
+};
+using var switchedData = switchedPort.DataReceived.Subscribe(ch => Console.Write(ch));
+await switchedPort.OpenAsync();
+using (var reception = switchedPort.StartDataReception(pollingIntervalMs: 10))
+{
+    // While this scope is active, the reactive receiver owns the serial bytes.
+}
+
+switchedPort.Close();
 ```
 
 ## Synchronous Read Methods
@@ -310,8 +388,8 @@ port.Lines.Subscribe(line => Console.WriteLine($"LINE: {line}"));
 The package includes a source generator that can turn serial protocol messages into strongly typed properties with classic and async observable streams. Mark a partial class with one or more `SerialPortReactiveStream` attributes, then connect it to an `ISerialPortRx`.
 
 ```csharp
-using CP.IO.Ports;
-using CP.IO.Ports.SourceGeneration;
+using IoT.DriverCore.Serial;
+using IoT.DriverCore.Serial.SourceGeneration;
 using ReactiveUI.Primitives;
 using ReactiveUI.Primitives.Async;
 
@@ -427,11 +505,144 @@ new UdpClientRx(12345).DataReceivedBatches
     .Subscribe(datagram => Console.WriteLine($"UDP datagram size: {datagram.Length}"));
 ```
 
+## Request/response coordination, deterministic testing, and generated values
+
+`SerialPortRxMessageHandler` is the ownership boundary for line-oriented command devices. Construct it with an open-capable `ISerialPortRx` and any device error prefixes. `RequestAsync(command)` waits for the next non-echo response; the overload accepting `Action<string>` parses/applies that response before completing. It uses `ReadTimeout` (or three seconds) and faults/cancels on error lines or timeout. `ResponsePrefix` supports devices that prefix replies. `PollingTasks`, `StartPolling`, `StopPolling`, and `WithPollingStoppedAsync` let periodic polling coexist safely with exclusive commands. Dispose the handler to stop polling and unsubscribe from `Lines`.
+
+```csharp
+using IoT.DriverCore.Serial;
+
+using var port = new SerialPortRx("COM3", 115200) { NewLine = "\r\n", ReadTimeout = 1500 };
+using var handler = new SerialPortRxMessageHandler(port, "ERR", "ERROR")
+{
+    ResponsePrefix = "1",
+};
+await port.OpenAsync();
+
+string? identity = null;
+await handler.RequestAsync("ID?", response => identity = response);
+Console.WriteLine(identity);
+
+handler.PollingTasks = () => handler.RequestAsync("MEAS?");
+handler.StartPolling();
+await handler.WithPollingStoppedAsync(() => handler.RequestAsync("CALIBRATE"));
+handler.StopPolling();
+```
+
+`PendingRequest` is the immutable record used by the handler's correlation queue; application code normally consumes the handler instead of constructing it. `InMemoryPortRxPair` provides two connected `SerialPortRx` endpoints (`First`/`Second`) plus deterministic error injection. Use it for unit/integration tests without COM hardware; dispose the pair to dispose both endpoints. The physical-serial runtime adapters are implementation details and are deliberately not part of the package's public application API.
+
+```csharp
+using IoT.DriverCore.Serial;
+
+using var pair = new InMemoryPortRxPair("TEST-A", "TEST-B");
+pair.First.NewLine = pair.Second.NewLine = "\n";
+using var received = pair.Second.Lines.Subscribe(Console.WriteLine);
+await pair.First.OpenAsync();
+await pair.Second.OpenAsync();
+pair.First.WriteLine("TEMP:21.5");
+pair.InjectFirstError(new IOException("Simulated cable fault"));
+```
+
+The packaged analyzer emits the `SerialPortReactiveStream` attribute and `SerialPortReactiveSource` enum in `IoT.DriverCore.Serial.SourceGeneration`. A partial target class receives a typed property, classic `IObservable<T>`, `IObservableAsync<T>`, and `ConnectReactiveSerialPort(ISerialPortRx)`. Use the optional regex `Pattern`, named `GroupName`/numeric `GroupNumber`, `IgnoreCase`, and `Source` settings to select and parse a stream. `SerialPortReactiveValueConverter.TryConvertMatch<T>` is public for applying the identical parsing/conversion rules manually; it returns `false` rather than throwing for a non-match/unconvertible value.
+
+```csharp
+using IoT.DriverCore.Serial;
+using IoT.DriverCore.Serial.SourceGeneration;
+
+[SerialPortReactiveStream(
+    "AlarmCode", typeof(int), @"^ALARM:(?<value>\d+)$",
+    GroupName = "value", IgnoreCase = true)]
+[SerialPortReactiveStream(
+    "Open", typeof(bool), Source = SerialPortReactiveSource.IsOpen)]
+public partial class HmiState;
+
+var state = new HmiState();
+using var binding = state.ConnectReactiveSerialPort(port);
+using var alarms = state.AlarmCodeObservable.Subscribe(code => Console.WriteLine($"Alarm {code}"));
+
+if (SerialPortReactiveValueConverter.TryConvertMatch(
+        "ALARM:42", @"^ALARM:(?<value>\d+)$", "value", 1, false, out int code))
+{
+    Console.WriteLine(code);
+}
+```
+
+## Combined workflows
+
+### Combined workflow 1: framed command channel with exclusive configuration
+
+This combines automatic line reception, a `BufferUntil` parser for unsolicited frames, a message handler for correlated replies, error/state observation, and polling suspension around an exclusive command. The same serial bytes must have one parser owner; both subscriptions here are line/observable consumers, not manual reads.
+
+```csharp
+using IoT.DriverCore.Serial;
+
+using var port = new SerialPortRx("COM7", 57600) { NewLine = "\r\n", ReadTimeout = 2000 };
+using var errors = port.ErrorReceived.Subscribe(Console.Error.WriteLine);
+using var handler = new SerialPortRxMessageHandler(port, "ERR");
+var start = SerialPortRxMixins.AsObservable((byte)'!');
+var end = SerialPortRxMixins.AsObservable((byte)'\n');
+using var unsolicited = SerialPortRxMixins.BufferUntil(port.DataReceived, start, end, 500)
+    .Subscribe(frame => Console.WriteLine($"Event: {frame}"));
+
+await port.OpenAsync();
+handler.PollingTasks = () => handler.RequestAsync("STATUS?");
+handler.StartPolling();
+await handler.WithPollingStoppedAsync(() => handler.RequestAsync("SET MODE=SERVICE"));
+```
+
+### Combined workflow 2: TCP/UDP telemetry with batch framing and async processing
+
+This combines network lifecycle, preserved batch boundaries, application framing, and the async-observable bridge. TCP chunks are arbitrary; accumulate them in a protocol parser. UDP batches are datagrams and can normally be handled one-at-a-time.
+
+```csharp
+using IoT.DriverCore.Serial;
+
+using var tcp = new TcpClientRx();
+tcp.Connect("192.168.10.15", 9000);
+using var tcpErrors = tcp.DataReceivedBatches.Subscribe(chunk => ParseTcpBytes(chunk));
+await tcp.OpenAsync();
+
+using var udp = new UdpClientRx(5000) { EnableBroadcast = true };
+using var datagrams = udp.DataReceivedBatches.Subscribe(ParseTelemetryDatagram);
+await udp.OpenAsync();
+
+var asyncBatches = tcp.DataReceivedBatches.ToAsyncObservable();
+await using var logger = await asyncBatches.SubscribeAsync(
+    (batch, cancellationToken) => LogBatchAsync(batch, cancellationToken));
+```
+
+## Complete public API reference
+
+| Type/member family | Purpose, overloads, return/error/lifecycle behavior |
+|---|---|
+| `IPortRx` | Common `BytesReceived`, `InfiniteTimeout`, read/write timeout properties; `OpenAsync`, `Close`, `Dispose`, `DiscardInBuffer`, and `ReadAsync(byte[]?, offset, count)`/`Write(byte[]?, offset, count)`. The task returns count; I/O/timeout exceptions propagate. |
+| `IReceiveBatchPortRx` | Adds `DataReceivedBatches`; batches are original serial receive chunks, TCP reads, or UDP datagrams depending on implementation. |
+| `ISerialPortRx` | Serial configuration and hardware state properties; character/byte/line/error/open streams; `DiscardOutBuffer`; all string, byte-array, char-array, and modern span/memory `Write` overloads; `WriteLine`; synchronous `Read`/`ReadByte`/`ReadChar`/`ReadExisting`/`ReadLine`/`ReadTo`; cancelable `ReadLineAsync`/`ReadToAsync`; `StartDataReception()` and interval overload. Pin stream is conditional. |
+| `SerialPortRx` | Constructors for port-only through baud/data/parity/stop/handshake; all interface members plus raw byte batches, `DataReceived*Async`, `BytesReceivedAsync`, `LinesAsync`, `ErrorReceivedAsync`, `IsOpenObservableAsync`, conditional `PinChangedAsync`, and static `PortNames()`, `PortNames(interval)`, `PortNames(interval, limit)`. Configure before open; dispose/cancel the returned reception lease. |
+| `TcpClientRx` | Constructors from client, endpoint, address family, hostname/port; `Connect` overloads for host, IP, endpoint, IP array; `Client`, `Stream`, timeouts; classic/async byte and batch streams; common open/read/write/close/dispose. Do not infer messages from a TCP batch. |
+| `UdpClientRx` | Constructors for client, local endpoint, port, address family, host/port; `Available`, `Ttl`, `DontFragment`, `MulticastLoopback`, `EnableBroadcast`, `ExclusiveAddressUse`, `Client`; `AllowNatTraversal`, three `Connect` overloads, `ReceiveAsync`, `SendAsync`, and common port API. Validate source/endpoints at the application layer. |
+| `SerialPortRxMixins` | Four classic and four async `BufferUntil` overloads (default/explicit timeout and boundaries); async observable bridges for every interface stream; serial event observers; `WhileIsOpen` and async counterpart; `AsObservable`/`AsAsyncObservable` for byte/int/short delimiters; async `PortNames` overloads. Dispose every subscription/async subscription. |
+| `ObservableAsync` and `ObservableAsyncBridgeExtensions` | `Return<T>`, `ToAsyncObservable<T>`, and `ToObservable<T>` bridge the classic and Primitives async models. Use a single model per pipeline boundary, then dispose the produced subscription. |
+| `SerialPortRxMessageHandler` / `PendingRequest` | Constructor, `ResponsePrefix`, `PollingTasks`, both `RequestAsync` overloads, polling controls, `WithPollingStoppedAsync`, `SendCommandAsync`, `Dispose`; request cancellation follows read timeout and device error lines. |
+| `InMemoryPortRxPair` | Creates deterministic paired `SerialPortRx` endpoints for tests without physical COM hardware. Own it with `using`/`Dispose`; the package deliberately keeps its transport/runtime adapters internal. |
+| `SerialPortReactiveValueConverter` / `SerialPortReactiveStreamGenerator` | Public `TryConvertMatch<T>` parsing helper and the analyzer implementation that emits the internal attribute/enum and typed members. Resolve generator diagnostics instead of hand-editing emitted code. |
+
+## Operations and troubleshooting
+
+| Symptom | Corrective action |
+|---|---|
+| No serial data or open failure | Verify port ownership, baud/data bits/parity/stop bits/handshake, driver permissions, and subscribe to `ErrorReceived` before `OpenAsync`. |
+| Lines/frames are missing or corrupt | Set `NewLine`/encoding before open, select automatic **or** manual receive, and use a single framing parser with a realistic timeout. |
+| Request times out | Confirm device echoes/error prefixes and `ResponsePrefix`, configure `ReadTimeout`, and keep the message handler alive/subscribed. |
+| TCP parser loses messages | Accumulate `DataReceivedBatches`; a TCP read may split or join protocol frames. |
+| Generator output is absent | Reference the runtime package/analyzer, use a partial class, fix stream attribute metadata and regex group/type conversion. |
+| Tests need hardware independence | Use `InMemoryPortRxPair` and error injection; reserve physical/virtual COM tests for explicit integration coverage. |
+
 ## Testing
 The test suite uses TUnit on Microsoft.Testing.Platform. Run it with:
 
 ```bash
-dotnet test --project src/SerialPortRx.Test/SerialPortRx.Test.csproj -c Debug -f net8.0
+dotnet test src/SerialPortRx.Test/SerialPortRx.Tests.csproj -c Debug -f net8.0
 ```
 
 Serial integration tests expect a virtual COM port pair named `COM1` and `COM2`. The source-generator tests do not require serial hardware.
@@ -441,7 +652,7 @@ Serial integration tests expect a virtual COM port pair named `COM1` and `COM2`.
 - ReadAsync uses a lightweight lock and offloads blocking reads, avoiding CPU spin.
 
 ## Tips and best practices
-- Subscribe before calling OpenAsync() to ensure you don’t miss events.
+- Subscribe before calling `OpenAsync()` to ensure you do not miss events.
 - Tune Encoding (default ASCII), BaudRate, Parity, StopBits, and Handshake to match your device.
 - Use BufferUntil for delimited protocols. For binary protocols, use ReadAsync with fixed sizes.
 - Use Lines when dealing with text protocols; use ReadLineAsync when you need a one-shot line.
@@ -452,7 +663,7 @@ Serial integration tests expect a virtual COM port pair named `COM1` and `COM2`.
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using CP.IO.Ports;
+using IoT.DriverCore.Serial;
 using ReactiveUI.Primitives;
 
 internal static class Program
@@ -516,11 +727,11 @@ internal static class Program
 ```
 
 
-## 📄 License
+## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License; see the repository [LICENSE](https://github.com/ChrisPulman/IoT-DriverCore/blob/main/LICENSE).
 
-## 🤝 Contributing
+## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
 
@@ -530,4 +741,2582 @@ If you find this library useful and would like to support its development, consi
 
 ---
 
-**SerialPortRx** - Empowering Industrial Automation with Reactive Technology ⚡🏭
+**SerialPortRx** - reactive transport primitives for industrial automation.
+
+## AI skill
+
+Load [`skills/serial-port-rx/SKILL.md`](../../skills/serial-port-rx/SKILL.md) for an agent-oriented checklist. This README is the full API, configuration, and combined-workflow reference.
+
+<!-- BEGIN GENERATED PUBLIC API -->
+
+## Exhaustive public API reference
+
+This catalogue is generated from the packaged runtime assemblies and their XML documentation. It includes exported public types and their declared public members; inherited members and non-public implementation details are intentionally omitted.
+
+### `SerialPortRx`
+
+Exported public types: 13; declared public members: 258.
+
+#### `T:IoT.DriverCore.Serial.IPortRx`
+
+```csharp
+public interface IoT.DriverCore.Serial.IPortRx
+```
+Represents a reactive receive port.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.Serial.IPortRx.Close`
+
+```csharp
+public void Close()
+```
+Closes this instance.
+
+###### `M:IoT.DriverCore.Serial.IPortRx.DiscardInBuffer`
+
+```csharp
+public void DiscardInBuffer()
+```
+Purges the receive buffer.
+
+###### `M:IoT.DriverCore.Serial.IPortRx.OpenAsync`
+
+```csharp
+public System.Threading.Tasks.Task OpenAsync()
+```
+Opens this instance.
+
+- Returns: A Task.
+
+###### `M:IoT.DriverCore.Serial.IPortRx.ReadAsync(System.Byte[],System.Int32,System.Int32)`
+
+```csharp
+public System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count)
+```
+Reads bytes from the input buffer into a buffer segment.
+
+- Parameter `buffer`: The byte array to write the input to.
+- Parameter `offset`: The offset in the buffer array to begin writing.
+- Parameter `count`: The number of bytes to read.
+- Returns: The number of bytes read.
+
+###### `M:IoT.DriverCore.Serial.IPortRx.Write(System.Byte[],System.Int32,System.Int32)`
+
+```csharp
+public void Write(byte[] buffer, int offset, int count)
+```
+Writes a buffer segment to the port.
+
+- Parameter `buffer`: The byte array that contains the data to write to the port.
+- Parameter `offset`: The offset in the buffer array to begin writing.
+- Parameter `count`: The number of bytes to write.
+
+###### `P:IoT.DriverCore.Serial.IPortRx.BytesReceived`
+
+```csharp
+public System.IObservable<int> BytesReceived { get; }
+```
+Gets the data received after opening the receive port.
+
+- Value: The byte read as a stream.
+
+###### `P:IoT.DriverCore.Serial.IPortRx.InfiniteTimeout`
+
+```csharp
+public int InfiniteTimeout { get; }
+```
+Gets indicates that no timeout should occur.
+
+- Value: The `InfiniteTimeout` value.
+
+###### `P:IoT.DriverCore.Serial.IPortRx.ReadTimeout`
+
+```csharp
+public int ReadTimeout { get; set; }
+```
+Gets or sets the read timeout in milliseconds.
+
+- Value: The `ReadTimeout` value.
+
+###### `P:IoT.DriverCore.Serial.IPortRx.WriteTimeout`
+
+```csharp
+public int WriteTimeout { get; set; }
+```
+Gets or sets the write timeout in milliseconds.
+
+- Value: The `WriteTimeout` value.
+
+#### `T:IoT.DriverCore.Serial.IReceiveBatchPortRx`
+
+```csharp
+public interface IoT.DriverCore.Serial.IReceiveBatchPortRx
+```
+Represents a receive port that publishes the original boundaries of received byte batches.
+
+##### Declared public members
+
+###### `P:IoT.DriverCore.Serial.IReceiveBatchPortRx.DataReceivedBatches`
+
+```csharp
+public System.IObservable<byte[]> DataReceivedBatches { get; }
+```
+Gets the raw byte batches received after opening the port.
+
+- Value: The `DataReceivedBatches` value.
+
+#### `T:IoT.DriverCore.Serial.ISerialPortRx`
+
+```csharp
+public interface IoT.DriverCore.Serial.ISerialPortRx
+```
+Serial Port Rx interface.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.DiscardOutBuffer`
+
+```csharp
+public void DiscardOutBuffer()
+```
+Discards the out buffer.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.Read(System.Byte[],System.Int32,System.Int32)`
+
+```csharp
+public int Read(byte[] buffer, int offset, int count)
+```
+Reads the specified buffer.
+
+- Parameter `buffer`: The buffer.
+- Parameter `offset`: The offset.
+- Parameter `count`: The count.
+- Returns: An integer.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.Read(System.Char[],System.Int32,System.Int32)`
+
+```csharp
+public int Read(char[] buffer, int offset, int count)
+```
+Reads the specified buffer.
+
+- Parameter `buffer`: The buffer.
+- Parameter `offset`: The offset.
+- Parameter `count`: The count.
+- Returns: An integer.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.ReadByte`
+
+```csharp
+public int ReadByte()
+```
+Reads the byte.
+
+- Returns: An integer.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.ReadChar`
+
+```csharp
+public int ReadChar()
+```
+Reads the character.
+
+- Returns: An integer.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.ReadExisting`
+
+```csharp
+public string ReadExisting()
+```
+Reads the existing.
+
+- Returns: A string.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.ReadLine`
+
+```csharp
+public string ReadLine()
+```
+Reads the line.
+
+- Returns: A string.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.ReadLineAsync`
+
+```csharp
+public System.Threading.Tasks.Task<string> ReadLineAsync()
+```
+Reads the line asynchronous.
+
+- Returns: A Task of string.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.ReadLineAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<string> ReadLineAsync(System.Threading.CancellationToken cancellationToken)
+```
+Reads the line asynchronous with cancellation and respecting ReadTimeout (> 0) as a timeout.
+
+- Parameter `cancellationToken`: Cancellation token to cancel waiting.
+- Returns: A Task of string.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.ReadTo(System.String)`
+
+```csharp
+public string ReadTo(string value)
+```
+Reads to.
+
+- Parameter `value`: The value.
+- Returns: A string.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.ReadToAsync(System.String)`
+
+```csharp
+public System.Threading.Tasks.Task<string> ReadToAsync(string value)
+```
+Reads a string up to the specified value asynchronously.
+
+- Parameter `value`: The value to read up to.
+- Returns: The contents of the input buffer up to the specified value.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.ReadToAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<string> ReadToAsync(string value, System.Threading.CancellationToken cancellationToken)
+```
+Reads a string up to the specified value asynchronously.
+
+- Parameter `value`: The value to read up to.
+- Parameter `cancellationToken`: Cancellation token to cancel waiting.
+- Returns: The contents of the input buffer up to the specified value.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.StartDataReception`
+
+```csharp
+public System.IDisposable StartDataReception()
+```
+Starts continuous data reception that feeds both DataReceived and DataReceivedBytes observables. Call this after Open() to enable reactive data streaming.
+
+- Returns: A disposable that stops the data reception when disposed.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.StartDataReception(System.Int32)`
+
+```csharp
+public System.IDisposable StartDataReception(int pollingIntervalMs)
+```
+Starts continuous data reception that feeds both DataReceived and DataReceivedBytes observables. Call this after Open() to enable reactive data streaming.
+
+- Parameter `pollingIntervalMs`: Polling interval in milliseconds (default: 10ms).
+- Returns: A disposable that stops the data reception when disposed.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.Write(System.Byte[])`
+
+```csharp
+public void Write(byte[] byteArray)
+```
+Writes the specified byte array.
+
+- Parameter `byteArray`: The byte array.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.Write(System.Char[])`
+
+```csharp
+public void Write(char[] charArray)
+```
+Writes the specified character array.
+
+- Parameter `charArray`: The character array.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.Write(System.Char[],System.Int32,System.Int32)`
+
+```csharp
+public void Write(char[] charArray, int offset, int count)
+```
+Writes the specified character array.
+
+- Parameter `charArray`: The character array.
+- Parameter `offset`: The offset.
+- Parameter `count`: The count.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.Write(System.ReadOnlyMemory`1{System.Byte})`
+
+```csharp
+public void Write(System.ReadOnlyMemory<byte> data)
+```
+Executes the `Write` operation.
+
+- Parameter `data`: The `data` value.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.Write(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public void Write(System.ReadOnlySpan<byte> data)
+```
+Executes the `Write` operation.
+
+- Parameter `data`: The `data` value.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.Write(System.ReadOnlySpan`1{System.Char})`
+
+```csharp
+public void Write(System.ReadOnlySpan<char> data)
+```
+Executes the `Write` operation.
+
+- Parameter `data`: The `data` value.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.Write(System.String)`
+
+```csharp
+public void Write(string text)
+```
+Writes the specified text.
+
+- Parameter `text`: The text.
+
+###### `M:IoT.DriverCore.Serial.ISerialPortRx.WriteLine(System.String)`
+
+```csharp
+public void WriteLine(string text)
+```
+Writes the line.
+
+- Parameter `text`: The text.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.BaudRate`
+
+```csharp
+public int BaudRate { get; set; }
+```
+Gets or sets the baud rate.
+
+- Value: The baud rate.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.BreakState`
+
+```csharp
+public bool BreakState { get; set; }
+```
+Gets or sets a value indicating whether break state.
+
+- Value: The break state.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.BytesToRead`
+
+```csharp
+public int BytesToRead { get; }
+```
+Gets the number of bytes of data in the receive buffer.
+
+- Value: The bytes to read.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.BytesToWrite`
+
+```csharp
+public int BytesToWrite { get; }
+```
+Gets the number of bytes of data in the send buffer.
+
+- Value: The bytes to write.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.CDHolding`
+
+```csharp
+public bool CDHolding { get; }
+```
+Gets a value indicating whether the Carrier Detect (CD) signal is on.
+
+- Value: The CD holding.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.CtsHolding`
+
+```csharp
+public bool CtsHolding { get; }
+```
+Gets a value indicating whether the Clear-to-Send (CTS) signal is on.
+
+- Value: The CTS holding.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.DataBits`
+
+```csharp
+public int DataBits { get; set; }
+```
+Gets or sets the data bits.
+
+- Value: The data bits.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.DataReceived`
+
+```csharp
+public System.IObservable<char> DataReceived { get; }
+```
+Gets the data received as characters.
+
+- Value: The data received.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.DataReceivedBytes`
+
+```csharp
+public System.IObservable<byte> DataReceivedBytes { get; }
+```
+Gets the raw bytes received from the serial port.
+
+- Value: The raw bytes received.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.DiscardNull`
+
+```csharp
+public bool DiscardNull { get; set; }
+```
+Gets or sets a value indicating whether null bytes are ignored when transmitted between the port and the receive buffer.
+
+- Value: The discard null.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.DsrHolding`
+
+```csharp
+public bool DsrHolding { get; }
+```
+Gets a value indicating whether the Data Set Ready (DSR) signal is on.
+
+- Value: The DSR holding.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.DtrEnable`
+
+```csharp
+public bool DtrEnable { get; set; }
+```
+Gets or sets whether the Data Terminal Ready (DTR) signal is enabled.
+
+- Value: The DTR enable.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.EnableAutoDataReceive`
+
+```csharp
+public bool EnableAutoDataReceive { get; set; }
+```
+Gets or sets a value indicating whether to automatically consume received data and feed it to the DataReceived and DataReceivedBytes observables. Set to false if you want to use synchronous Read methods instead. Must be set before calling Open().
+
+- Value: True to enable automatic data reception (default), false to use sync reads.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.Encoding`
+
+```csharp
+public System.Text.Encoding Encoding { get; set; }
+```
+Gets or sets the encoding.
+
+- Value: The encoding.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.ErrorReceived`
+
+```csharp
+public System.IObservable<System.Exception> ErrorReceived { get; }
+```
+Gets the error received.
+
+- Value: The error received.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.Handshake`
+
+```csharp
+public System.IO.Ports.Handshake Handshake { get; set; }
+```
+Gets or sets the handshake.
+
+- Value: The handshake.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.IsDisposed`
+
+```csharp
+public bool IsDisposed { get; }
+```
+Gets a value indicating whether this instance is disposed.
+
+- Value: true if this instance is disposed; otherwise, false .
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.IsOpen`
+
+```csharp
+public bool IsOpen { get; }
+```
+Gets a value indicating whether gets the is open.
+
+- Value: The is open.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.IsOpenObservable`
+
+```csharp
+public System.IObservable<bool> IsOpenObservable { get; }
+```
+Gets the is open observable.
+
+- Value: The is open observable.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.Lines`
+
+```csharp
+public System.IObservable<string> Lines { get; }
+```
+Gets a lazily-created observable sequence of complete lines split by the NewLine sequence.
+
+- Value: The `Lines` value.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.NewLine`
+
+```csharp
+public string NewLine { get; set; }
+```
+Gets or sets the new line.
+
+- Value: The new line.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.Parity`
+
+```csharp
+public System.IO.Ports.Parity Parity { get; set; }
+```
+Gets or sets the parity.
+
+- Value: The parity.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.ParityReplace`
+
+```csharp
+public byte ParityReplace { get; set; }
+```
+Gets or sets the parity replace.
+
+- Value: The parity replace.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.PortName`
+
+```csharp
+public string PortName { get; set; }
+```
+Gets or sets the port.
+
+- Value: The port.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.ReadBufferSize`
+
+```csharp
+public int ReadBufferSize { get; set; }
+```
+Gets or sets the size of the read buffer.
+
+- Value: The size of the read buffer.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.ReceivedBytesThreshold`
+
+```csharp
+public int ReceivedBytesThreshold { get; set; }
+```
+Gets or sets the byte threshold that raises DataReceived.
+
+- Value: The received bytes threshold.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.RtsEnable`
+
+```csharp
+public bool RtsEnable { get; set; }
+```
+Gets or sets whether the Request to Send (RTS) signal is enabled.
+
+- Value: The RTS enable.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.StopBits`
+
+```csharp
+public System.IO.Ports.StopBits StopBits { get; set; }
+```
+Gets or sets the stop bits.
+
+- Value: The stop bits.
+
+###### `P:IoT.DriverCore.Serial.ISerialPortRx.WriteBufferSize`
+
+```csharp
+public int WriteBufferSize { get; set; }
+```
+Gets or sets the size of the write buffer.
+
+- Value: The size of the write buffer.
+
+#### `T:IoT.DriverCore.Serial.InMemoryPortRxPair`
+
+```csharp
+public class IoT.DriverCore.Serial.InMemoryPortRxPair
+```
+Owns two deterministic, connected `T:IoT.DriverCore.Serial.SerialPortRx` instances that exercise the normal serial wrapper without requiring physical or virtual serial hardware.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.Serial.InMemoryPortRxPair.#ctor`
+
+```csharp
+public IoT.DriverCore.Serial.InMemoryPortRxPair()
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.InMemoryPortRxPair` class.
+
+###### `M:IoT.DriverCore.Serial.InMemoryPortRxPair.#ctor(System.String,System.String)`
+
+```csharp
+public IoT.DriverCore.Serial.InMemoryPortRxPair(string firstPortName, string secondPortName)
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.InMemoryPortRxPair` class.
+
+- Parameter `firstPortName`: The diagnostic name of the first endpoint.
+- Parameter `secondPortName`: The diagnostic name of the second endpoint.
+
+###### `M:IoT.DriverCore.Serial.InMemoryPortRxPair.Dispose`
+
+```csharp
+public void Dispose()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+###### `M:IoT.DriverCore.Serial.InMemoryPortRxPair.InjectFirstError(System.Exception)`
+
+```csharp
+public void InjectFirstError(System.Exception exception)
+```
+Injects a deterministic connection error into the first endpoint.
+
+- Parameter `exception`: The error to publish.
+
+###### `M:IoT.DriverCore.Serial.InMemoryPortRxPair.InjectSecondError(System.Exception)`
+
+```csharp
+public void InjectSecondError(System.Exception exception)
+```
+Injects a deterministic connection error into the second endpoint.
+
+- Parameter `exception`: The error to publish.
+
+###### `P:IoT.DriverCore.Serial.InMemoryPortRxPair.First`
+
+```csharp
+public IoT.DriverCore.Serial.SerialPortRx First { get; }
+```
+Gets the first connected serial endpoint.
+
+- Value: The `First` value.
+
+###### `P:IoT.DriverCore.Serial.InMemoryPortRxPair.Second`
+
+```csharp
+public IoT.DriverCore.Serial.SerialPortRx Second { get; }
+```
+Gets the second connected serial endpoint.
+
+- Value: The `Second` value.
+
+#### `T:IoT.DriverCore.Serial.ObservableAsync`
+
+```csharp
+public class IoT.DriverCore.Serial.ObservableAsync
+```
+Compatibility factory for async observables.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.Serial.ObservableAsync.Return``1(``0)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<T> Return<T>(T value)
+```
+Creates an async observable that emits a single value.
+
+- Parameter `value`: The value to emit.
+- Returns: An async observable that emits `value` .
+
+#### `T:IoT.DriverCore.Serial.ObservableAsyncBridgeExtensions`
+
+```csharp
+public class IoT.DriverCore.Serial.ObservableAsyncBridgeExtensions
+```
+Compatibility bridge between classic observables and ReactiveUI.Primitives async observables.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.Serial.ObservableAsyncBridgeExtensions.ToAsyncObservable``1(System.IObservable`1{``0})`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<T> ToAsyncObservable<T>(System.IObservable<T> source)
+```
+Executes the `ToAsyncObservable` operation.
+
+- Parameter `source`: The `source` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<T>` result.
+
+###### `M:IoT.DriverCore.Serial.ObservableAsyncBridgeExtensions.ToObservable``1(ReactiveUI.Primitives.Async.IObservableAsync`1{``0})`
+
+```csharp
+public static System.IObservable<T> ToObservable<T>(ReactiveUI.Primitives.Async.IObservableAsync<T> source)
+```
+Executes the `ToObservable` operation.
+
+- Parameter `source`: The `source` value.
+- Returns: A `System.IObservable<T>` result.
+
+#### `T:IoT.DriverCore.Serial.PendingRequest`
+
+```csharp
+public class IoT.DriverCore.Serial.PendingRequest
+```
+Represents a pending command request awaiting a serial response.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.Serial.PendingRequest.#ctor(System.String,System.Action`1{System.String},System.Threading.Tasks.TaskCompletionSource`1{System.Boolean})`
+
+```csharp
+public IoT.DriverCore.Serial.PendingRequest(string Command, System.Action<string> Apply, System.Threading.Tasks.TaskCompletionSource<bool> Completion)
+```
+Initializes a new instance of `IoT.DriverCore.Serial.PendingRequest`.
+
+- Parameter `Command`: The `Command` value.
+- Parameter `Apply`: The `Apply` value.
+- Parameter `Completion`: The `Completion` value.
+
+###### `M:IoT.DriverCore.Serial.PendingRequest.Deconstruct(System.String@,System.Action`1{System.String}@,System.Threading.Tasks.TaskCompletionSource`1{System.Boolean}@)`
+
+```csharp
+public void Deconstruct(out string Command, out System.Action<string> Apply, out System.Threading.Tasks.TaskCompletionSource<bool> Completion)
+```
+Deconstructs the value into its component values.
+
+- Parameter `Command`: The `Command` value.
+- Parameter `Apply`: The `Apply` value.
+- Parameter `Completion`: The `Completion` value.
+
+###### `M:IoT.DriverCore.Serial.PendingRequest.Equals(IoT.DriverCore.Serial.PendingRequest)`
+
+```csharp
+public bool Equals(IoT.DriverCore.Serial.PendingRequest other)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `other`: The `other` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.Serial.PendingRequest.Equals(System.Object)`
+
+```csharp
+public bool Equals(object obj)
+```
+Determines whether the supplied value is equal to the current value.
+
+- Parameter `obj`: The `obj` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.Serial.PendingRequest.GetHashCode`
+
+```csharp
+public int GetHashCode()
+```
+Returns the hash code for the current value.
+
+- Returns: A `int` result.
+
+###### `M:IoT.DriverCore.Serial.PendingRequest.ToString`
+
+```csharp
+public string ToString()
+```
+Returns a string representation of the current value.
+
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.Serial.PendingRequest.op_Equality(IoT.DriverCore.Serial.PendingRequest,IoT.DriverCore.Serial.PendingRequest)`
+
+```csharp
+public static bool op_Equality(IoT.DriverCore.Serial.PendingRequest left, IoT.DriverCore.Serial.PendingRequest right)
+```
+Determines whether the two supplied values are equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.Serial.PendingRequest.op_Inequality(IoT.DriverCore.Serial.PendingRequest,IoT.DriverCore.Serial.PendingRequest)`
+
+```csharp
+public static bool op_Inequality(IoT.DriverCore.Serial.PendingRequest left, IoT.DriverCore.Serial.PendingRequest right)
+```
+Determines whether the two supplied values are not equal.
+
+- Parameter `left`: The `left` value.
+- Parameter `right`: The `right` value.
+- Returns: A `bool` result.
+
+###### `P:IoT.DriverCore.Serial.PendingRequest.Apply`
+
+```csharp
+public System.Action<string> Apply { get; set; }
+```
+The action that applies the response payload.
+
+- Value: The `Apply` value.
+
+###### `P:IoT.DriverCore.Serial.PendingRequest.Command`
+
+```csharp
+public string Command { get; set; }
+```
+The command text sent to the serial port.
+
+- Value: The `Command` value.
+
+###### `P:IoT.DriverCore.Serial.PendingRequest.Completion`
+
+```csharp
+public System.Threading.Tasks.TaskCompletionSource<bool> Completion { get; set; }
+```
+The completion source signaled when a response arrives.
+
+- Value: The `Completion` value.
+
+#### `T:IoT.DriverCore.Serial.SerialPortRx`
+
+```csharp
+public class IoT.DriverCore.Serial.SerialPortRx
+```
+Implements a cohesive portion of the reactive serial port.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.#ctor`
+
+```csharp
+public IoT.DriverCore.Serial.SerialPortRx()
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.SerialPortRx` class.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.Serial.SerialPortRx(string port)
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.SerialPortRx` class.
+
+- Parameter `port`: The port.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.#ctor(System.String,System.Int32)`
+
+```csharp
+public IoT.DriverCore.Serial.SerialPortRx(string port, int baudRate)
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.SerialPortRx` class.
+
+- Parameter `port`: The port.
+- Parameter `baudRate`: The baud rate.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.#ctor(System.String,System.Int32,System.Int32)`
+
+```csharp
+public IoT.DriverCore.Serial.SerialPortRx(string port, int baudRate, int dataBits)
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.SerialPortRx` class.
+
+- Parameter `port`: The port.
+- Parameter `baudRate`: The baud rate.
+- Parameter `dataBits`: The data bits.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.#ctor(System.String,System.Int32,System.Int32,System.IO.Ports.Parity)`
+
+```csharp
+public IoT.DriverCore.Serial.SerialPortRx(string port, int baudRate, int dataBits, System.IO.Ports.Parity parity)
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.SerialPortRx` class.
+
+- Parameter `port`: The port.
+- Parameter `baudRate`: The baud rate.
+- Parameter `dataBits`: The data bits.
+- Parameter `parity`: The parity.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.#ctor(System.String,System.Int32,System.Int32,System.IO.Ports.Parity,System.IO.Ports.StopBits)`
+
+```csharp
+public IoT.DriverCore.Serial.SerialPortRx(string port, int baudRate, int dataBits, System.IO.Ports.Parity parity, System.IO.Ports.StopBits stopBits)
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.SerialPortRx` class.
+
+- Parameter `port`: The port.
+- Parameter `baudRate`: The baud rate.
+- Parameter `dataBits`: The data bits.
+- Parameter `parity`: The parity.
+- Parameter `stopBits`: The stop bits.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.#ctor(System.String,System.Int32,System.Int32,System.IO.Ports.Parity,System.IO.Ports.StopBits,System.IO.Ports.Handshake)`
+
+```csharp
+public IoT.DriverCore.Serial.SerialPortRx(string port, int baudRate, int dataBits, System.IO.Ports.Parity parity, System.IO.Ports.StopBits stopBits, System.IO.Ports.Handshake handshake)
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.SerialPortRx` class.
+
+- Parameter `port`: The port.
+- Parameter `baudRate`: The baud rate.
+- Parameter `dataBits`: The data bits.
+- Parameter `parity`: The parity.
+- Parameter `stopBits`: The stop bits.
+- Parameter `handshake`: The handshake.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.Close`
+
+```csharp
+public void Close()
+```
+Closes this instance.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.DiscardInBuffer`
+
+```csharp
+public void DiscardInBuffer()
+```
+Discards the in buffer.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.DiscardOutBuffer`
+
+```csharp
+public void DiscardOutBuffer()
+```
+Discards the out buffer.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.Dispose`
+
+```csharp
+public void Dispose()
+```
+Releases owned resources.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.OpenAsync`
+
+```csharp
+public System.Threading.Tasks.Task OpenAsync()
+```
+Opens this instance.
+
+- Returns: A Task.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.PortNames`
+
+```csharp
+public static System.IObservable<string[]> PortNames()
+```
+Gets the port names using the default polling interval.
+
+- Returns: Observable string.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.PortNames(System.Int32)`
+
+```csharp
+public static System.IObservable<string[]> PortNames(int pollInterval)
+```
+Gets the port names.
+
+- Parameter `pollInterval`: The poll interval.
+- Returns: Observable string.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.PortNames(System.Int32,System.Int32)`
+
+```csharp
+public static System.IObservable<string[]> PortNames(int pollInterval, int pollLimit)
+```
+Gets the port names.
+
+- Parameter `pollInterval`: The poll interval.
+- Parameter `pollLimit`: The poll limit, once number is reached observable will complete.
+- Returns: Observable string.
+- Value: The port names.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.Read(System.Byte[],System.Int32,System.Int32)`
+
+```csharp
+public int Read(byte[] buffer, int offset, int count)
+```
+Reads bytes from the SerialPort input buffer into a byte array at the specified offset.
+
+- Parameter `buffer`: The byte array to write the input to.
+- Parameter `offset`: The offset in the buffer array to begin writing.
+- Parameter `count`: The number of bytes to read.
+- Returns: The number of bytes read.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.Read(System.Char[],System.Int32,System.Int32)`
+
+```csharp
+public int Read(char[] buffer, int offset, int count)
+```
+Reads characters from the SerialPort input buffer into a character array.
+
+- Parameter `buffer`: The character array to write the input to.
+- Parameter `offset`: The offset in the buffer array to begin writing.
+- Parameter `count`: The number of characters to read.
+- Returns: The number of characters read.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.ReadAsync(System.Byte[],System.Int32,System.Int32)`
+
+```csharp
+public System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count)
+```
+Reads the specified buffer.
+
+- Parameter `buffer`: The buffer.
+- Parameter `offset`: The offset.
+- Parameter `count`: The count.
+- Returns: The number of bytes read.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.ReadByte`
+
+```csharp
+public int ReadByte()
+```
+Synchronously reads one byte from the SerialPort input buffer.
+
+- Returns: The byte, or -1 if no byte is available.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.ReadChar`
+
+```csharp
+public int ReadChar()
+```
+Synchronously reads one character from the SerialPort input buffer.
+
+- Returns: The character, or -1 if no character is available.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.ReadExisting`
+
+```csharp
+public string ReadExisting()
+```
+Reads all immediately available encoded bytes from the SerialPort stream and input buffer.
+
+- Returns: The contents of the input buffer and the stream.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.ReadLine`
+
+```csharp
+public string ReadLine()
+```
+Reads up to the NewLine value in the input buffer.
+
+- Returns: The contents of the input buffer up to the first occurrence of a NewLine value.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.ReadLineAsync`
+
+```csharp
+public System.Threading.Tasks.Task<string> ReadLineAsync()
+```
+Reads the line asynchronous.
+
+- Returns: A `T:System.Threading.Tasks.Task` representing the asynchronous operation.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.ReadLineAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<string> ReadLineAsync(System.Threading.CancellationToken cancellationToken)
+```
+Reads the line asynchronous with cancellation and respecting ReadTimeout (> 0) as a timeout.
+
+- Parameter `cancellationToken`: Cancellation token to cancel waiting.
+- Returns: A Task of string.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.ReadTo(System.String)`
+
+```csharp
+public string ReadTo(string value)
+```
+Reads a string up to the specified value in the input buffer.
+
+- Parameter `value`: The value to read up to.
+- Returns: The contents of the input buffer up to the specified value.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.ReadToAsync(System.String)`
+
+```csharp
+public System.Threading.Tasks.Task<string> ReadToAsync(string value)
+```
+Reads a string up to the specified value asynchronously.
+
+- Parameter `value`: The value to read up to.
+- Returns: The contents of the input buffer up to the specified value.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.ReadToAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<string> ReadToAsync(string value, System.Threading.CancellationToken cancellationToken)
+```
+Reads a string up to the specified value asynchronously.
+
+- Parameter `value`: The value to read up to.
+- Parameter `cancellationToken`: Cancellation token to cancel waiting.
+- Returns: The contents of the input buffer up to the specified value.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.StartDataReception`
+
+```csharp
+public System.IDisposable StartDataReception()
+```
+Starts continuous data reception that feeds both DataReceived and DataReceivedBytes observables. Call this after Open() to enable reactive data streaming.
+
+- Returns: A disposable that stops the data reception when disposed.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.StartDataReception(System.Int32)`
+
+```csharp
+public System.IDisposable StartDataReception(int pollingIntervalMs)
+```
+Starts continuous data reception that feeds both DataReceived and DataReceivedBytes observables. Call this after Open() to enable reactive data streaming.
+
+- Parameter `pollingIntervalMs`: Polling interval in milliseconds (default: 10ms).
+- Returns: A disposable that stops the data reception when disposed.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.Write(System.Byte[])`
+
+```csharp
+public void Write(byte[] byteArray)
+```
+Writes the specified byte array.
+
+- Parameter `byteArray`: The byte array.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.Write(System.Byte[],System.Int32,System.Int32)`
+
+```csharp
+public void Write(byte[] buffer, int offset, int count)
+```
+Writes the specified byte array.
+
+- Parameter `buffer`: The byte array.
+- Parameter `offset`: The offset.
+- Parameter `count`: The count.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.Write(System.Char[])`
+
+```csharp
+public void Write(char[] charArray)
+```
+Writes the specified character array.
+
+- Parameter `charArray`: The character array.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.Write(System.Char[],System.Int32,System.Int32)`
+
+```csharp
+public void Write(char[] charArray, int offset, int count)
+```
+Writes the specified character array.
+
+- Parameter `charArray`: The character array.
+- Parameter `offset`: The offset.
+- Parameter `count`: The count.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.Write(System.ReadOnlyMemory`1{System.Byte})`
+
+```csharp
+public void Write(System.ReadOnlyMemory<byte> data)
+```
+Executes the `Write` operation.
+
+- Parameter `data`: The `data` value.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.Write(System.ReadOnlySpan`1{System.Byte})`
+
+```csharp
+public void Write(System.ReadOnlySpan<byte> data)
+```
+Executes the `Write` operation.
+
+- Parameter `data`: The `data` value.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.Write(System.ReadOnlySpan`1{System.Char})`
+
+```csharp
+public void Write(System.ReadOnlySpan<char> data)
+```
+Executes the `Write` operation.
+
+- Parameter `data`: The `data` value.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.Write(System.String)`
+
+```csharp
+public void Write(string text)
+```
+Writes the specified text.
+
+- Parameter `text`: The text.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRx.WriteLine(System.String)`
+
+```csharp
+public void WriteLine(string text)
+```
+Writes the line.
+
+- Parameter `text`: The text.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.BaudRate`
+
+```csharp
+public int BaudRate { get; set; }
+```
+Gets or sets the baud rate.
+
+- Value: The baud rate.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.BreakState`
+
+```csharp
+public bool BreakState { get; set; }
+```
+Gets or sets a value indicating whether break state.
+
+- Value: The break state.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.BytesReceived`
+
+```csharp
+public System.IObservable<int> BytesReceived { get; }
+```
+Gets the data received when executing ReadAsync.
+
+- Value: The data received.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.BytesReceivedAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<int> BytesReceivedAsync { get; }
+```
+Gets the data received when executing ReadAsync via an async observable.
+
+- Value: The data received.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.BytesToRead`
+
+```csharp
+public int BytesToRead { get; }
+```
+Gets the number of bytes of data in the receive buffer.
+
+- Value: The bytes to read.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.BytesToWrite`
+
+```csharp
+public int BytesToWrite { get; }
+```
+Gets the number of bytes of data in the send buffer.
+
+- Value: The bytes to write.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.CDHolding`
+
+```csharp
+public bool CDHolding { get; }
+```
+Gets a value indicating whether the Carrier Detect (CD) signal is on.
+
+- Value: The CD holding.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.CtsHolding`
+
+```csharp
+public bool CtsHolding { get; }
+```
+Gets a value indicating whether the Clear-to-Send (CTS) signal is on.
+
+- Value: The CTS holding.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.DataBits`
+
+```csharp
+public int DataBits { get; set; }
+```
+Gets or sets the data bits.
+
+- Value: The data bits.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.DataReceived`
+
+```csharp
+public System.IObservable<char> DataReceived { get; }
+```
+Gets the data received as characters.
+
+- Value: The data received.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.DataReceivedAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<char> DataReceivedAsync { get; }
+```
+Gets the data received as characters via an async observable.
+
+- Value: The data received.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.DataReceivedBatches`
+
+```csharp
+public System.IObservable<byte[]> DataReceivedBatches { get; }
+```
+Gets raw byte batches received from the serial port.
+
+- Value: The raw byte batches received.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.DataReceivedBytes`
+
+```csharp
+public System.IObservable<byte> DataReceivedBytes { get; }
+```
+Gets the raw bytes received from the serial port.
+
+- Value: The raw bytes received.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.DataReceivedBytesAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<byte> DataReceivedBytesAsync { get; }
+```
+Gets the raw bytes received from the serial port via an async observable.
+
+- Value: The raw bytes received.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.DiscardNull`
+
+```csharp
+public bool DiscardNull { get; set; }
+```
+Gets or sets a value indicating whether null bytes are ignored when transmitted between the port and the receive buffer.
+
+- Value: The discard null.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.DsrHolding`
+
+```csharp
+public bool DsrHolding { get; }
+```
+Gets a value indicating whether the Data Set Ready (DSR) signal is on.
+
+- Value: The DSR holding.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.DtrEnable`
+
+```csharp
+public bool DtrEnable { get; set; }
+```
+Gets or sets whether the Data Terminal Ready (DTR) signal is enabled.
+
+- Value: The DTR enable.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.EnableAutoDataReceive`
+
+```csharp
+public bool EnableAutoDataReceive { get; set; }
+```
+Gets or sets a value indicating whether to automatically consume received data and feed it to the DataReceived and DataReceivedBytes observables. Set to false if you want to use synchronous Read methods instead. Must be set before calling Open().
+
+- Value: True to enable automatic data reception (default), false to use sync reads.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.Encoding`
+
+```csharp
+public System.Text.Encoding Encoding { get; set; }
+```
+Gets or sets the encoding.
+
+- Value: The encoding.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.ErrorReceived`
+
+```csharp
+public System.IObservable<System.Exception> ErrorReceived { get; }
+```
+Gets the error received.
+
+- Value: The error received.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.ErrorReceivedAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<System.Exception> ErrorReceivedAsync { get; }
+```
+Gets the error received via an async observable.
+
+- Value: The error received.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.Handshake`
+
+```csharp
+public System.IO.Ports.Handshake Handshake { get; set; }
+```
+Gets or sets the handshake.
+
+- Value: The handshake.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.InfiniteTimeout`
+
+```csharp
+public int InfiniteTimeout { get; }
+```
+Gets indicates that no timeout should occur.
+
+- Value: The `InfiniteTimeout` value.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.IsDisposed`
+
+```csharp
+public bool IsDisposed { get; }
+```
+Gets a value indicating whether this instance is disposed.
+
+- Value: true if this instance is disposed; otherwise, false .
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.IsOpen`
+
+```csharp
+public bool IsOpen { get; }
+```
+Gets a value indicating whether gets the is open.
+
+- Value: The is open.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.IsOpenObservable`
+
+```csharp
+public System.IObservable<bool> IsOpenObservable { get; }
+```
+Gets the is open observable.
+
+- Value: The is open observable.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.IsOpenObservableAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<bool> IsOpenObservableAsync { get; }
+```
+Gets the is open async observable.
+
+- Value: The is open async observable.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.Lines`
+
+```csharp
+public System.IObservable<string> Lines { get; }
+```
+Gets a lazily-created observable sequence of complete lines split by the NewLine sequence.
+
+- Value: The `Lines` value.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.LinesAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<string> LinesAsync { get; }
+```
+Gets complete lines as an async observable.
+
+- Value: The `LinesAsync` value.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.NewLine`
+
+```csharp
+public string NewLine { get; set; }
+```
+Gets or sets creates new line.
+
+- Value: The new line.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.Parity`
+
+```csharp
+public System.IO.Ports.Parity Parity { get; set; }
+```
+Gets or sets the parity.
+
+- Value: The parity.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.ParityReplace`
+
+```csharp
+public byte ParityReplace { get; set; }
+```
+Gets or sets the parity replace.
+
+- Value: The parity replace.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.PortName`
+
+```csharp
+public string PortName { get; set; }
+```
+Gets or sets the port.
+
+- Value: The port.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.ReadBufferSize`
+
+```csharp
+public int ReadBufferSize { get; set; }
+```
+Gets or sets the size of the read buffer.
+
+- Value: The size of the read buffer.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.ReadTimeout`
+
+```csharp
+public int ReadTimeout { get; set; }
+```
+Gets or sets the read timeout.
+
+- Value: The read timeout.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.ReceivedBytesThreshold`
+
+```csharp
+public int ReceivedBytesThreshold { get; set; }
+```
+Gets or sets the byte threshold that raises DataReceived.
+
+- Value: The received bytes threshold.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.RtsEnable`
+
+```csharp
+public bool RtsEnable { get; set; }
+```
+Gets or sets whether the Request to Send (RTS) signal is enabled.
+
+- Value: The RTS enable.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.StopBits`
+
+```csharp
+public System.IO.Ports.StopBits StopBits { get; set; }
+```
+Gets or sets the stop bits.
+
+- Value: The stop bits.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.WriteBufferSize`
+
+```csharp
+public int WriteBufferSize { get; set; }
+```
+Gets or sets the size of the write buffer.
+
+- Value: The size of the write buffer.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRx.WriteTimeout`
+
+```csharp
+public int WriteTimeout { get; set; }
+```
+Gets or sets the write timeout.
+
+- Value: The write timeout.
+
+#### `T:IoT.DriverCore.Serial.SerialPortRxMessageHandler`
+
+```csharp
+public class IoT.DriverCore.Serial.SerialPortRxMessageHandler
+```
+Coordinates command requests and responses over a reactive serial port.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMessageHandler.#ctor(IoT.DriverCore.Serial.ISerialPortRx,System.String[])`
+
+```csharp
+public IoT.DriverCore.Serial.SerialPortRxMessageHandler(IoT.DriverCore.Serial.ISerialPortRx port, string[] errorLine)
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.SerialPortRxMessageHandler` class.
+
+- Parameter `port`: The port.
+- Parameter `errorLine`: The error line.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMessageHandler.Dispose`
+
+```csharp
+public void Dispose()
+```
+Releases owned resources.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMessageHandler.RequestAsync(System.String)`
+
+```csharp
+public System.Threading.Tasks.Task RequestAsync(string cmd)
+```
+Requests the asynchronous.
+
+- Parameter `cmd`: The command.
+- Returns: A `T:System.Threading.Tasks.Task` representing the asynchronous operation.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMessageHandler.RequestAsync(System.String,System.Action`1{System.String})`
+
+```csharp
+public System.Threading.Tasks.Task RequestAsync(string cmd, System.Action<string> apply)
+```
+Executes the `RequestAsync` operation.
+
+- Parameter `cmd`: The `cmd` value.
+- Parameter `apply`: The `apply` value.
+- Returns: A `System.Threading.Tasks.Task` result.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMessageHandler.SendCommandAsync(System.String)`
+
+```csharp
+public System.Threading.Tasks.Task SendCommandAsync(string fullCmd)
+```
+Sends the command asynchronous.
+
+- Parameter `fullCmd`: The full command.
+- Returns: A `T:System.Threading.Tasks.Task` representing the asynchronous operation.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMessageHandler.StartPolling`
+
+```csharp
+public void StartPolling()
+```
+Starts the polling.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMessageHandler.StopPolling`
+
+```csharp
+public void StopPolling()
+```
+Stops the polling.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMessageHandler.WithPollingStoppedAsync(System.Func`1{System.Threading.Tasks.Task})`
+
+```csharp
+public System.Threading.Tasks.Task WithPollingStoppedAsync(System.Func<System.Threading.Tasks.Task> action)
+```
+Executes the `WithPollingStoppedAsync` operation.
+
+- Parameter `action`: The `action` value.
+- Returns: A `System.Threading.Tasks.Task` result.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRxMessageHandler.PollingTasks`
+
+```csharp
+public System.Func<System.Threading.Tasks.Task> PollingTasks { get; set; }
+```
+Gets or sets the polling task.
+
+- Value: The polling task.
+
+###### `P:IoT.DriverCore.Serial.SerialPortRxMessageHandler.ResponsePrefix`
+
+```csharp
+public string ResponsePrefix { get; set; }
+```
+Gets or sets an optional prefix that the device may prepend to responses (e.g., "1"). When set, echo detection and response normalization will account for it.
+
+- Value: The `ResponsePrefix` value.
+
+#### `T:IoT.DriverCore.Serial.SerialPortRxMixins`
+
+```csharp
+public class IoT.DriverCore.Serial.SerialPortRxMixins
+```
+Provides serial port reactive extension methods.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.AsAsyncObservable(System.Byte)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<char> AsAsyncObservable(byte value)
+```
+Transforms a byte into a single value async observable.
+
+- Parameter `value`: The source byte.
+- Returns: An async observable char.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.AsAsyncObservable(System.Int16)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<char> AsAsyncObservable(short value)
+```
+Transforms a short into a single value async observable.
+
+- Parameter `value`: The source short.
+- Returns: An async observable char.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.AsAsyncObservable(System.Int32)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<char> AsAsyncObservable(int value)
+```
+Transforms an int into a single value async observable.
+
+- Parameter `value`: The source integer.
+- Returns: An async observable char.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.AsObservable(System.Byte)`
+
+```csharp
+public static System.IObservable<char> AsObservable(byte value)
+```
+Transforms a byte into a single value observable.
+
+- Parameter `value`: The source byte.
+- Returns: An observable char.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.AsObservable(System.Int16)`
+
+```csharp
+public static System.IObservable<char> AsObservable(short value)
+```
+Transforms a short into a single value observable.
+
+- Parameter `value`: The source short.
+- Returns: An observable char.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.AsObservable(System.Int32)`
+
+```csharp
+public static System.IObservable<char> AsObservable(int value)
+```
+Transforms an int into a single value observable.
+
+- Parameter `value`: The source integer.
+- Returns: An observable char.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.BufferUntil(ReactiveUI.Primitives.Async.IObservableAsync`1{System.Char},ReactiveUI.Primitives.Async.IObservableAsync`1{System.Char},ReactiveUI.Primitives.Async.IObservableAsync`1{System.Char},ReactiveUI.Primitives.Async.IObservableAsync`1{System.String},System.Int32)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<string> BufferUntil(ReactiveUI.Primitives.Async.IObservableAsync<char> source, ReactiveUI.Primitives.Async.IObservableAsync<char> startsWith, ReactiveUI.Primitives.Async.IObservableAsync<char> endsWith, ReactiveUI.Primitives.Async.IObservableAsync<string> defaultValue, int timeOut)
+```
+Executes the `BufferUntil` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startsWith`: The `startsWith` value.
+- Parameter `endsWith`: The `endsWith` value.
+- Parameter `defaultValue`: The `defaultValue` value.
+- Parameter `timeOut`: The `timeOut` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<string>` result.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.BufferUntil(ReactiveUI.Primitives.Async.IObservableAsync`1{System.Char},ReactiveUI.Primitives.Async.IObservableAsync`1{System.Char},ReactiveUI.Primitives.Async.IObservableAsync`1{System.Char},ReactiveUI.Primitives.Async.IObservableAsync`1{System.String},System.Int32,ReactiveUI.Primitives.Concurrency.ISequencer)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<string> BufferUntil(ReactiveUI.Primitives.Async.IObservableAsync<char> source, ReactiveUI.Primitives.Async.IObservableAsync<char> startsWith, ReactiveUI.Primitives.Async.IObservableAsync<char> endsWith, ReactiveUI.Primitives.Async.IObservableAsync<string> defaultValue, int timeOut, ReactiveUI.Primitives.Concurrency.ISequencer scheduler)
+```
+Executes the `BufferUntil` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startsWith`: The `startsWith` value.
+- Parameter `endsWith`: The `endsWith` value.
+- Parameter `defaultValue`: The `defaultValue` value.
+- Parameter `timeOut`: The `timeOut` value.
+- Parameter `scheduler`: The `scheduler` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<string>` result.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.BufferUntil(ReactiveUI.Primitives.Async.IObservableAsync`1{System.Char},ReactiveUI.Primitives.Async.IObservableAsync`1{System.Char},ReactiveUI.Primitives.Async.IObservableAsync`1{System.Char},System.Int32)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<string> BufferUntil(ReactiveUI.Primitives.Async.IObservableAsync<char> source, ReactiveUI.Primitives.Async.IObservableAsync<char> startsWith, ReactiveUI.Primitives.Async.IObservableAsync<char> endsWith, int timeOut)
+```
+Executes the `BufferUntil` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startsWith`: The `startsWith` value.
+- Parameter `endsWith`: The `endsWith` value.
+- Parameter `timeOut`: The `timeOut` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<string>` result.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.BufferUntil(ReactiveUI.Primitives.Async.IObservableAsync`1{System.Char},ReactiveUI.Primitives.Async.IObservableAsync`1{System.Char},ReactiveUI.Primitives.Async.IObservableAsync`1{System.Char},System.Int32,ReactiveUI.Primitives.Concurrency.ISequencer)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<string> BufferUntil(ReactiveUI.Primitives.Async.IObservableAsync<char> source, ReactiveUI.Primitives.Async.IObservableAsync<char> startsWith, ReactiveUI.Primitives.Async.IObservableAsync<char> endsWith, int timeOut, ReactiveUI.Primitives.Concurrency.ISequencer scheduler)
+```
+Executes the `BufferUntil` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startsWith`: The `startsWith` value.
+- Parameter `endsWith`: The `endsWith` value.
+- Parameter `timeOut`: The `timeOut` value.
+- Parameter `scheduler`: The `scheduler` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<string>` result.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.BufferUntil(System.IObservable`1{System.Char},System.IObservable`1{System.Char},System.IObservable`1{System.Char},System.IObservable`1{System.String},System.Int32)`
+
+```csharp
+public static System.IObservable<string> BufferUntil(System.IObservable<char> source, System.IObservable<char> startsWith, System.IObservable<char> endsWith, System.IObservable<string> defaultValue, int timeOut)
+```
+Executes the `BufferUntil` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startsWith`: The `startsWith` value.
+- Parameter `endsWith`: The `endsWith` value.
+- Parameter `defaultValue`: The `defaultValue` value.
+- Parameter `timeOut`: The `timeOut` value.
+- Returns: A `System.IObservable<string>` result.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.BufferUntil(System.IObservable`1{System.Char},System.IObservable`1{System.Char},System.IObservable`1{System.Char},System.IObservable`1{System.String},System.Int32,ReactiveUI.Primitives.Concurrency.ISequencer)`
+
+```csharp
+public static System.IObservable<string> BufferUntil(System.IObservable<char> source, System.IObservable<char> startsWith, System.IObservable<char> endsWith, System.IObservable<string> defaultValue, int timeOut, ReactiveUI.Primitives.Concurrency.ISequencer scheduler)
+```
+Executes the `BufferUntil` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startsWith`: The `startsWith` value.
+- Parameter `endsWith`: The `endsWith` value.
+- Parameter `defaultValue`: The `defaultValue` value.
+- Parameter `timeOut`: The `timeOut` value.
+- Parameter `scheduler`: The `scheduler` value.
+- Returns: A `System.IObservable<string>` result.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.BufferUntil(System.IObservable`1{System.Char},System.IObservable`1{System.Char},System.IObservable`1{System.Char},System.Int32)`
+
+```csharp
+public static System.IObservable<string> BufferUntil(System.IObservable<char> source, System.IObservable<char> startsWith, System.IObservable<char> endsWith, int timeOut)
+```
+Executes the `BufferUntil` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startsWith`: The `startsWith` value.
+- Parameter `endsWith`: The `endsWith` value.
+- Parameter `timeOut`: The `timeOut` value.
+- Returns: A `System.IObservable<string>` result.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.BufferUntil(System.IObservable`1{System.Char},System.IObservable`1{System.Char},System.IObservable`1{System.Char},System.Int32,ReactiveUI.Primitives.Concurrency.ISequencer)`
+
+```csharp
+public static System.IObservable<string> BufferUntil(System.IObservable<char> source, System.IObservable<char> startsWith, System.IObservable<char> endsWith, int timeOut, ReactiveUI.Primitives.Concurrency.ISequencer scheduler)
+```
+Executes the `BufferUntil` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `startsWith`: The `startsWith` value.
+- Parameter `endsWith`: The `endsWith` value.
+- Parameter `timeOut`: The `timeOut` value.
+- Parameter `scheduler`: The `scheduler` value.
+- Returns: A `System.IObservable<string>` result.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.BytesReceivedAsyncObservable(IoT.DriverCore.Serial.IPortRx)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<int> BytesReceivedAsyncObservable(IoT.DriverCore.Serial.IPortRx port)
+```
+Gets the data received after opening a receive port as an async observable.
+
+- Parameter `port`: The source port.
+- Returns: An async observable of received byte values.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.DataReceivedAsyncObservable(IoT.DriverCore.Serial.ISerialPortRx)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<char> DataReceivedAsyncObservable(IoT.DriverCore.Serial.ISerialPortRx serialPort)
+```
+Gets serial characters as an async observable.
+
+- Parameter `serialPort`: The source serial port.
+- Returns: An async observable of received characters.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.DataReceivedBytesAsyncObservable(IoT.DriverCore.Serial.ISerialPortRx)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<byte> DataReceivedBytesAsyncObservable(IoT.DriverCore.Serial.ISerialPortRx serialPort)
+```
+Gets serial bytes as an async observable.
+
+- Parameter `serialPort`: The source serial port.
+- Returns: An async observable of received bytes.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.DataReceivedObserver(System.IO.Ports.SerialPort)`
+
+```csharp
+public static System.IObservable<ReactiveUI.Primitives.Core.EventPattern<System.IO.Ports.SerialDataReceivedEventArgs>> DataReceivedObserver(System.IO.Ports.SerialPort serialPort)
+```
+Monitors the received observer.
+
+- Parameter `serialPort`: The source serial port.
+- Returns: Observable value.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.ErrorReceivedAsyncObservable(IoT.DriverCore.Serial.ISerialPortRx)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<System.Exception> ErrorReceivedAsyncObservable(IoT.DriverCore.Serial.ISerialPortRx serialPort)
+```
+Gets serial errors as an async observable.
+
+- Parameter `serialPort`: The source serial port.
+- Returns: An async observable of errors.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.ErrorReceivedObserver(System.IO.Ports.SerialPort)`
+
+```csharp
+public static System.IObservable<ReactiveUI.Primitives.Core.EventPattern<System.IO.Ports.SerialErrorReceivedEventArgs>> ErrorReceivedObserver(System.IO.Ports.SerialPort serialPort)
+```
+Monitors the Errors observer.
+
+- Parameter `serialPort`: The source serial port.
+- Returns: Observable value.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.IsOpenAsyncObservable(IoT.DriverCore.Serial.ISerialPortRx)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<bool> IsOpenAsyncObservable(IoT.DriverCore.Serial.ISerialPortRx serialPort)
+```
+Gets serial open-state changes as an async observable.
+
+- Parameter `serialPort`: The source serial port.
+- Returns: An async observable of open-state changes.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.LinesAsyncObservable(IoT.DriverCore.Serial.ISerialPortRx)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<string> LinesAsyncObservable(IoT.DriverCore.Serial.ISerialPortRx serialPort)
+```
+Gets serial lines as an async observable.
+
+- Parameter `serialPort`: The source serial port.
+- Returns: An async observable of received lines.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.PortNamesAsyncObservable`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<string[]> PortNamesAsyncObservable()
+```
+Emits the list of available port names whenever it changes as an async observable.
+
+- Returns: An async observable of port name arrays.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.PortNamesAsyncObservable(System.Int32)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<string[]> PortNamesAsyncObservable(int pollInterval)
+```
+Emits the list of available port names whenever it changes as an async observable.
+
+- Parameter `pollInterval`: The poll interval.
+- Returns: An async observable of port name arrays.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.PortNamesAsyncObservable(System.Int32,System.Int32)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<string[]> PortNamesAsyncObservable(int pollInterval, int pollLimit)
+```
+Emits the list of available port names whenever it changes as an async observable.
+
+- Parameter `pollInterval`: The poll interval.
+- Parameter `pollLimit`: The poll limit.
+- Returns: An async observable of port name arrays.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.WhileIsOpen(IoT.DriverCore.Serial.SerialPortRx,System.TimeSpan)`
+
+```csharp
+public static System.IObservable<bool> WhileIsOpen(IoT.DriverCore.Serial.SerialPortRx serialPort, System.TimeSpan timespan)
+```
+Executes while port is open at the given TimeSpan.
+
+- Parameter `serialPort`: The source serial port.
+- Parameter `timespan`: The timespan at which to notify.
+- Returns: Observable value.
+
+###### `M:IoT.DriverCore.Serial.SerialPortRxMixins.WhileIsOpenAsyncObservable(IoT.DriverCore.Serial.SerialPortRx,System.TimeSpan)`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<bool> WhileIsOpenAsyncObservable(IoT.DriverCore.Serial.SerialPortRx serialPort, System.TimeSpan timespan)
+```
+Executes while port is open at the given TimeSpan via an async observable.
+
+- Parameter `serialPort`: The source serial port.
+- Parameter `timespan`: The timespan at which to notify.
+- Returns: Async observable value.
+
+#### `T:IoT.DriverCore.Serial.SourceGeneration.SerialPortReactiveValueConverter`
+
+```csharp
+public class IoT.DriverCore.Serial.SourceGeneration.SerialPortReactiveValueConverter
+```
+Converts generated serial stream values into strongly typed reactive properties.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.Serial.SourceGeneration.SerialPortReactiveValueConverter.TryConvertMatch``1(System.Object,System.String,System.String,System.Int32,System.Boolean,``0@)`
+
+```csharp
+public static bool TryConvertMatch<T>(object value, string pattern, string groupName, int groupNumber, bool ignoreCase, out T result)
+```
+Tries to match and convert a serial stream value.
+
+- Parameter `value`: The raw stream value.
+- Parameter `pattern`: The optional regular expression pattern.
+- Parameter `groupName`: The optional named group to convert.
+- Parameter `groupNumber`: The fallback group number to convert.
+- Parameter `ignoreCase`: A value indicating whether the match ignores case.
+- Parameter `result`: The converted value.
+- Returns: true when a value was matched and converted; otherwise, false .
+
+#### `T:IoT.DriverCore.Serial.TcpClientRx`
+
+```csharp
+public class IoT.DriverCore.Serial.TcpClientRx
+```
+Provides a reactive wrapper around `T:System.Net.Sockets.TcpClient` .
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.Serial.TcpClientRx.#ctor`
+
+```csharp
+public IoT.DriverCore.Serial.TcpClientRx()
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.TcpClientRx` class.
+
+###### `M:IoT.DriverCore.Serial.TcpClientRx.#ctor(System.Net.IPEndPoint)`
+
+```csharp
+public IoT.DriverCore.Serial.TcpClientRx(System.Net.IPEndPoint localEP)
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.TcpClientRx` class.
+
+- Parameter `localEP`: The local ep.
+
+###### `M:IoT.DriverCore.Serial.TcpClientRx.#ctor(System.Net.Sockets.AddressFamily)`
+
+```csharp
+public IoT.DriverCore.Serial.TcpClientRx(System.Net.Sockets.AddressFamily family)
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.TcpClientRx` class.
+
+- Parameter `family`: The family.
+
+###### `M:IoT.DriverCore.Serial.TcpClientRx.#ctor(System.Net.Sockets.TcpClient)`
+
+```csharp
+public IoT.DriverCore.Serial.TcpClientRx(System.Net.Sockets.TcpClient tcpClient)
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.TcpClientRx` class.
+
+- Parameter `tcpClient`: The TCP client.
+
+###### `M:IoT.DriverCore.Serial.TcpClientRx.#ctor(System.String,System.Int32)`
+
+```csharp
+public IoT.DriverCore.Serial.TcpClientRx(string hostname, int port)
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.TcpClientRx` class.
+
+- Parameter `hostname`: The hostname.
+- Parameter `port`: The port.
+
+###### `M:IoT.DriverCore.Serial.TcpClientRx.Close`
+
+```csharp
+public void Close()
+```
+Closes this instance.
+
+###### `M:IoT.DriverCore.Serial.TcpClientRx.Connect(System.Net.IPAddress,System.Int32)`
+
+```csharp
+public void Connect(System.Net.IPAddress address, int port)
+```
+Connects the specified address.
+
+- Parameter `address`: The address.
+- Parameter `port`: The port.
+
+###### `M:IoT.DriverCore.Serial.TcpClientRx.Connect(System.Net.IPAddress[],System.Int32)`
+
+```csharp
+public void Connect(System.Net.IPAddress[] addresses, int port)
+```
+Connects the specified IP addresses.
+
+- Parameter `addresses`: The IP addresses.
+- Parameter `port`: The port.
+
+###### `M:IoT.DriverCore.Serial.TcpClientRx.Connect(System.Net.IPEndPoint)`
+
+```csharp
+public void Connect(System.Net.IPEndPoint remoteEP)
+```
+Connects the specified remote ep.
+
+- Parameter `remoteEP`: The remote ep.
+
+###### `M:IoT.DriverCore.Serial.TcpClientRx.Connect(System.String,System.Int32)`
+
+```csharp
+public void Connect(string hostname, int port)
+```
+Connects the specified hostname.
+
+- Parameter `hostname`: The hostname.
+- Parameter `port`: The port.
+
+###### `M:IoT.DriverCore.Serial.TcpClientRx.DiscardInBuffer`
+
+```csharp
+public void DiscardInBuffer()
+```
+Discards the in buffer.
+
+###### `M:IoT.DriverCore.Serial.TcpClientRx.Dispose`
+
+```csharp
+public void Dispose()
+```
+Releases owned resources.
+
+###### `M:IoT.DriverCore.Serial.TcpClientRx.OpenAsync`
+
+```csharp
+public System.Threading.Tasks.Task OpenAsync()
+```
+Opens this instance.
+
+- Returns: A Task.
+
+###### `M:IoT.DriverCore.Serial.TcpClientRx.ReadAsync(System.Byte[],System.Int32,System.Int32)`
+
+```csharp
+public System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count)
+```
+Reads the specified buffer.
+
+- Parameter `buffer`: The buffer.
+- Parameter `offset`: The offset.
+- Parameter `count`: The count.
+- Returns: A int.
+
+###### `M:IoT.DriverCore.Serial.TcpClientRx.Write(System.Byte[],System.Int32,System.Int32)`
+
+```csharp
+public void Write(byte[] buffer, int offset, int count)
+```
+Writes the specified buffer.
+
+- Parameter `buffer`: The buffer.
+- Parameter `offset`: The offset.
+- Parameter `count`: The count.
+
+###### `P:IoT.DriverCore.Serial.TcpClientRx.BytesReceived`
+
+```csharp
+public System.IObservable<int> BytesReceived { get; }
+```
+Gets the data received From ReadAsync.
+
+- Value: The data received.
+
+###### `P:IoT.DriverCore.Serial.TcpClientRx.BytesReceivedAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<int> BytesReceivedAsync { get; }
+```
+Gets the data received from ReadAsync as an async observable.
+
+- Value: The data received.
+
+###### `P:IoT.DriverCore.Serial.TcpClientRx.Client`
+
+```csharp
+public System.Net.Sockets.Socket Client { get; }
+```
+Gets the underlying System.Net.Sockets.Socket.
+
+- Value: The underlying network System.Net.Sockets.Socket.
+
+###### `P:IoT.DriverCore.Serial.TcpClientRx.DataReceived`
+
+```csharp
+public System.IObservable<int> DataReceived { get; }
+```
+Gets the data received after calling Open.
+
+- Value: The data received.
+
+###### `P:IoT.DriverCore.Serial.TcpClientRx.DataReceivedAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<int> DataReceivedAsync { get; }
+```
+Gets the data received after calling Open as an async observable.
+
+- Value: The data received.
+
+###### `P:IoT.DriverCore.Serial.TcpClientRx.DataReceivedBatches`
+
+```csharp
+public System.IObservable<byte[]> DataReceivedBatches { get; }
+```
+Gets stream chunks (byte arrays) produced by the internal read loop.
+
+- Value: The `DataReceivedBatches` value.
+
+###### `P:IoT.DriverCore.Serial.TcpClientRx.DataReceivedBatchesAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<byte[]> DataReceivedBatchesAsync { get; }
+```
+Gets stream chunks produced by the internal read loop as an async observable.
+
+- Value: The `DataReceivedBatchesAsync` value.
+
+###### `P:IoT.DriverCore.Serial.TcpClientRx.InfiniteTimeout`
+
+```csharp
+public int InfiniteTimeout { get; }
+```
+Gets the infinite timeout.
+
+- Value: The infinite timeout.
+
+###### `P:IoT.DriverCore.Serial.TcpClientRx.ReadTimeout`
+
+```csharp
+public int ReadTimeout { get; set; }
+```
+Gets or sets the read timeout.
+
+- Value: The read timeout.
+
+###### `P:IoT.DriverCore.Serial.TcpClientRx.Stream`
+
+```csharp
+public System.Net.Sockets.NetworkStream Stream { get; }
+```
+Gets the System.Net.Sockets.NetworkStream used to send and receive data.
+
+- Value: The stream.
+
+###### `P:IoT.DriverCore.Serial.TcpClientRx.WriteTimeout`
+
+```csharp
+public int WriteTimeout { get; set; }
+```
+Gets or sets the write timeout.
+
+- Value: The write timeout.
+
+#### `T:IoT.DriverCore.Serial.UdpClientRx`
+
+```csharp
+public class IoT.DriverCore.Serial.UdpClientRx
+```
+Provides a reactive wrapper around `T:System.Net.Sockets.UdpClient` .
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.Serial.UdpClientRx.#ctor`
+
+```csharp
+public IoT.DriverCore.Serial.UdpClientRx()
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.UdpClientRx` class.
+
+###### `M:IoT.DriverCore.Serial.UdpClientRx.#ctor(System.Int32)`
+
+```csharp
+public IoT.DriverCore.Serial.UdpClientRx(int port)
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.UdpClientRx` class.
+
+- Parameter `port`: The port.
+
+###### `M:IoT.DriverCore.Serial.UdpClientRx.#ctor(System.Int32,System.Net.Sockets.AddressFamily)`
+
+```csharp
+public IoT.DriverCore.Serial.UdpClientRx(int port, System.Net.Sockets.AddressFamily family)
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.UdpClientRx` class.
+
+- Parameter `port`: The port.
+- Parameter `family`: The family.
+
+###### `M:IoT.DriverCore.Serial.UdpClientRx.#ctor(System.Net.IPEndPoint)`
+
+```csharp
+public IoT.DriverCore.Serial.UdpClientRx(System.Net.IPEndPoint localEP)
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.UdpClientRx` class.
+
+- Parameter `localEP`: The local ep.
+
+###### `M:IoT.DriverCore.Serial.UdpClientRx.#ctor(System.Net.Sockets.AddressFamily)`
+
+```csharp
+public IoT.DriverCore.Serial.UdpClientRx(System.Net.Sockets.AddressFamily family)
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.UdpClientRx` class.
+
+- Parameter `family`: The family.
+
+###### `M:IoT.DriverCore.Serial.UdpClientRx.#ctor(System.Net.Sockets.UdpClient)`
+
+```csharp
+public IoT.DriverCore.Serial.UdpClientRx(System.Net.Sockets.UdpClient udpClient)
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.UdpClientRx` class.
+
+- Parameter `udpClient`: The UDP client.
+
+###### `M:IoT.DriverCore.Serial.UdpClientRx.#ctor(System.String,System.Int32)`
+
+```csharp
+public IoT.DriverCore.Serial.UdpClientRx(string hostname, int port)
+```
+Initializes a new instance of the `T:IoT.DriverCore.Serial.UdpClientRx` class.
+
+- Parameter `hostname`: The hostname.
+- Parameter `port`: The port.
+
+###### `M:IoT.DriverCore.Serial.UdpClientRx.Close`
+
+```csharp
+public void Close()
+```
+Closes this instance.
+
+###### `M:IoT.DriverCore.Serial.UdpClientRx.Connect(System.Net.IPAddress,System.Int32)`
+
+```csharp
+public void Connect(System.Net.IPAddress addr, int port)
+```
+Connects the specified addr.
+
+- Parameter `addr`: The addr.
+- Parameter `port`: The port.
+
+###### `M:IoT.DriverCore.Serial.UdpClientRx.Connect(System.Net.IPEndPoint)`
+
+```csharp
+public void Connect(System.Net.IPEndPoint endPoint)
+```
+Connects the specified end point.
+
+- Parameter `endPoint`: The end point.
+
+###### `M:IoT.DriverCore.Serial.UdpClientRx.Connect(System.String,System.Int32)`
+
+```csharp
+public void Connect(string hostname, int port)
+```
+Connects the specified hostname.
+
+- Parameter `hostname`: The hostname.
+- Parameter `port`: The port.
+
+###### `M:IoT.DriverCore.Serial.UdpClientRx.DiscardInBuffer`
+
+```csharp
+public void DiscardInBuffer()
+```
+Discards the in buffer.
+
+###### `M:IoT.DriverCore.Serial.UdpClientRx.Dispose`
+
+```csharp
+public void Dispose()
+```
+Releases owned resources.
+
+###### `M:IoT.DriverCore.Serial.UdpClientRx.OpenAsync`
+
+```csharp
+public System.Threading.Tasks.Task OpenAsync()
+```
+Opens this instance.
+
+- Returns: A Task.
+
+###### `M:IoT.DriverCore.Serial.UdpClientRx.ReadAsync(System.Byte[],System.Int32,System.Int32)`
+
+```csharp
+public System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count)
+```
+Reads the specified buffer.
+
+- Parameter `buffer`: The buffer.
+- Parameter `offset`: The offset.
+- Parameter `count`: The count.
+- Returns: A int.
+
+###### `M:IoT.DriverCore.Serial.UdpClientRx.ReceiveAsync`
+
+```csharp
+public System.Threading.Tasks.Task<System.Net.Sockets.UdpReceiveResult> ReceiveAsync()
+```
+Returns a UDP datagram asynchronously that was sent by a remote host.
+
+- Returns: The task object representing the asynchronous operation.
+
+###### `M:IoT.DriverCore.Serial.UdpClientRx.SendAsync(System.Byte[],System.Int32,System.Net.IPEndPoint)`
+
+```csharp
+public System.Threading.Tasks.Task<int> SendAsync(byte[] dataGram, int bytes, System.Net.IPEndPoint endPoint)
+```
+Sends a UDP datagram asynchronously to a remote host.
+
+- Parameter `dataGram`: The data gram.
+- Parameter `bytes`: The bytes.
+- Parameter `endPoint`: The end point.
+- Returns: A Task of int.
+
+###### `M:IoT.DriverCore.Serial.UdpClientRx.Write(System.Byte[],System.Int32,System.Int32)`
+
+```csharp
+public void Write(byte[] buffer, int offset, int count)
+```
+Writes the specified buffer.
+
+- Parameter `buffer`: The buffer.
+- Parameter `offset`: The offset.
+- Parameter `count`: The count.
+
+###### `P:IoT.DriverCore.Serial.UdpClientRx.Available`
+
+```csharp
+public int Available { get; }
+```
+Gets the available.
+
+- Value: The available.
+
+###### `P:IoT.DriverCore.Serial.UdpClientRx.BytesReceived`
+
+```csharp
+public System.IObservable<int> BytesReceived { get; }
+```
+Gets the data received.
+
+- Value: The data received.
+
+###### `P:IoT.DriverCore.Serial.UdpClientRx.BytesReceivedAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<int> BytesReceivedAsync { get; }
+```
+Gets the data received from ReadAsync as an async observable.
+
+- Value: The data received.
+
+###### `P:IoT.DriverCore.Serial.UdpClientRx.Client`
+
+```csharp
+public System.Net.Sockets.Socket Client { get; set; }
+```
+Gets or sets the underlying System.Net.Sockets.Socket.
+
+- Value: The underlying network System.Net.Sockets.Socket.
+
+###### `P:IoT.DriverCore.Serial.UdpClientRx.DataReceived`
+
+```csharp
+public System.IObservable<int> DataReceived { get; }
+```
+Gets the data received.
+
+- Value: The data received.
+
+###### `P:IoT.DriverCore.Serial.UdpClientRx.DataReceivedAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<int> DataReceivedAsync { get; }
+```
+Gets the data received as an async observable.
+
+- Value: The data received.
+
+###### `P:IoT.DriverCore.Serial.UdpClientRx.DataReceivedBatches`
+
+```csharp
+public System.IObservable<byte[]> DataReceivedBatches { get; }
+```
+Gets stream chunks (byte arrays) for each received UDP datagram.
+
+- Value: The `DataReceivedBatches` value.
+
+###### `P:IoT.DriverCore.Serial.UdpClientRx.DataReceivedBatchesAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<byte[]> DataReceivedBatchesAsync { get; }
+```
+Gets stream chunks for each received UDP datagram as an async observable.
+
+- Value: The `DataReceivedBatchesAsync` value.
+
+###### `P:IoT.DriverCore.Serial.UdpClientRx.DontFragment`
+
+```csharp
+public bool DontFragment { get; set; }
+```
+Gets or sets a value indicating whether [dont fragment].
+
+- Value: true if [dont fragment]; otherwise, false .
+
+###### `P:IoT.DriverCore.Serial.UdpClientRx.EnableBroadcast`
+
+```csharp
+public bool EnableBroadcast { get; set; }
+```
+Gets or sets a value indicating whether [enable broadcast].
+
+- Value: true if [enable broadcast]; otherwise, false .
+
+###### `P:IoT.DriverCore.Serial.UdpClientRx.ExclusiveAddressUse`
+
+```csharp
+public bool ExclusiveAddressUse { get; set; }
+```
+Gets or sets a value indicating whether [exclusive address use].
+
+- Value: true if [exclusive address use]; otherwise, false .
+
+###### `P:IoT.DriverCore.Serial.UdpClientRx.InfiniteTimeout`
+
+```csharp
+public int InfiniteTimeout { get; }
+```
+Gets the infinite timeout.
+
+- Value: The infinite timeout.
+
+###### `P:IoT.DriverCore.Serial.UdpClientRx.MulticastLoopback`
+
+```csharp
+public bool MulticastLoopback { get; set; }
+```
+Gets or sets a value indicating whether [multicast loopback].
+
+- Value: true if [multicast loopback]; otherwise, false .
+
+###### `P:IoT.DriverCore.Serial.UdpClientRx.ReadTimeout`
+
+```csharp
+public int ReadTimeout { get; set; }
+```
+Gets or sets the read timeout.
+
+- Value: The read timeout.
+
+###### `P:IoT.DriverCore.Serial.UdpClientRx.Ttl`
+
+```csharp
+public short Ttl { get; set; }
+```
+Gets or sets the TTL.
+
+- Value: The TTL.
+
+###### `P:IoT.DriverCore.Serial.UdpClientRx.WriteTimeout`
+
+```csharp
+public int WriteTimeout { get; set; }
+```
+Gets or sets the write timeout.
+
+- Value: The write timeout.
+
+<!-- END GENERATED PUBLIC API -->

--- a/packagereadme/TwinCATRx/README.md
+++ b/packagereadme/TwinCATRx/README.md
@@ -1,314 +1,3771 @@
-﻿![License](https://img.shields.io/github/license/ChrisPulman/TwinCATRx.svg) [![Build](https://github.com/ChrisPulman/TwinCATRx/actions/workflows/BuildOnly.yml/badge.svg)](https://github.com/ChrisPulman/TwinCATRx/actions/workflows/BuildOnly.yml) ![Nuget](https://img.shields.io/nuget/dt/CP.TwinCATRx?color=pink&style=plastic) [![NuGet](https://img.shields.io/nuget/v/CP.TwinCATRx.svg?style=plastic)](https://www.nuget.org/packages/CP.TwinCATRx)
-
----
-
 # TwinCATRx
 
-A reactive, cross-platform wrapper for Beckhoff TwinCAT ADS built on ReactiveUI.Primitives. It lets you observe PLC variables as IObservable<T>, expose async observable streams, write values, and work with structured tags using a HashTable-like API.
+## Overview
 
-### Packages
+`CP.TwinCATRx` provides reactive Beckhoff TwinCAT ADS access: configuration-driven notifications, one-shot reads and writes, typed observation extensions, structured values, and an in-memory ADS client for deterministic tests.
 
-- CP.TwinCATRx: main reactive client and extension APIs.
-- CP.TwinCATRx.Core: shared helpers (settings, code generation, reactive extensions, ADS observables).
-- CP.TwinCATRx.Reactive: System.Reactive-compatible client built with ReactiveUI.Primitives.Reactive.
-- CP.TwinCATRx.Core.Reactive: System.Reactive-compatible shared helpers built with ReactiveUI.Primitives.Reactive.
+## Safety
 
-### Supported frameworks
-- .NET Framework 4.6.2
-- .NET Framework 4.7.2
-- .NET Framework 4.8
-- .NET Framework 4.8.1
-- .NET 8
-- .NET 9
-- .NET 10
-- .NET 11
-- Windows-specific features (service monitoring) are enabled for net8.0-windows10.0.19041.0, net9.0-windows10.0.19041.0, net10.0-windows10.0.19041.0, and net11.0-windows10.0.19041.0.
-- ReactiveUI.Primitives async observable APIs are available across the supported target frameworks.
+ADS writes change PLC state. Use a non-production target for development, separate engineering and production networks, restrict routes and credentials, validate every value and array length, and retain controller-side interlocks. Never use a reactive stream as the sole safety mechanism.
 
-### Install
+## Package matrix
+
+| Package | Default namespace | Targets | Purpose |
+|---|---|---|---|
+| `CP.TwinCATRx` | `IoT.DriverCore.TwinCATRx` | core targets plus Windows targets | ADS client, observables, structures, generator |
+| `CP.TwinCATRx.Reactive` | `IoT.DriverCore.TwinCATRx.Reactive` | matching package targets | System.Reactive-compatible surface where supplied |
+| `CP.TwinCATRx.Core` | `IoT.DriverCore.TwinCATRx.Core` | net462, net472, net48, net481, net8.0-net11.0 | Shared settings, ADS abstractions, conversion, retry, and dynamic-code helpers |
+| `CP.TwinCATRx.Core.Reactive` | `IoT.DriverCore.TwinCATRx.Core.Reactive` | matching core targets | System.Reactive-compatible core helper surface |
+| `TwinCATRx.Generators` | source attributes are in `IoT.DriverCore.TwinCATRx` | analyzer targets supplied by the compiler | Standalone optional reactive-stream analyzer, useful when it is version-pinned separately from the runtime. |
+
+The package references `HashTableRx`, `ReactiveUI.Primitives`, and `ReactiveUI.Primitives.Async`. The `TwinCATRx.Core` dependency supplies `Settings`, `ISettings`, ADS abstractions, and configuration extensions. Dynamic ADS type generation is annotated for trimming/AOT analysis; source-generated stream models avoid application-level runtime reflection.
+
+## Install
 
 ```bash
-# Main package
 dotnet add package CP.TwinCATRx
-# Optional low-level helpers (usually not required directly)
-dotnet add package CP.TwinCATRx.Core
+# Optional: CP.TwinCATRx already embeds this analyzer.
+dotnet add package TwinCATRx.Generators
 ```
 
-For System.Reactive interoperability, use the matching Reactive variants together:
-
-```bash
-dotnet add package CP.TwinCATRx.Reactive
-dotnet add package CP.TwinCATRx.Core.Reactive
-```
-
-The Reactive packages use the `CP.TwinCatRx.Reactive` and `CP.TwinCatRx.Core.Reactive` namespaces. Namespace aliases allow both package families to coexist in one application without importing conflicting Rx operators globally.
-
-## 🚀 Quick Start
+## Quick start
 
 ```csharp
-using CP.TwinCatRx;
-using CP.TwinCatRx.Core;
-using ReactiveUI.Primitives.Extensions;
+using IoT.DriverCore.TwinCATRx;
+using IoT.DriverCore.TwinCATRx.Core;
 
-// Create client and settings
-var client = new RxTcAdsClient();
-var settings = new Settings { AdsAddress = "5.35.59.10.1.1", Port = 801, SettingsId = "Default" };
-
-// Register tags to observe (notifications) and write
-settings.AddNotification(".Tag1");         // structure
-settings.AddNotification(".AString", arraySize: 80); // string length required for string
+using var client = new RxTcAdsClient();
+var settings = new Settings { AdsAddress = "5.35.59.10.1.1", Port = 851, SettingsId = "Default" };
 settings.AddNotification(".AInt");
-settings.AddWriteVariable(".ArrInt", 11);  // arrays require a length
+settings.AddWriteVariable(".AInt");
+
+using var values = client.Observe<short>(".AInt", value => Convert.ToInt16(value))
+    .Subscribe(value => Console.WriteLine($"AInt = {value}"));
+using var failures = client.ErrorReceived.Subscribe(Console.Error.WriteLine);
 
 client.Connect(settings);
-
-// Wait for PLC to be ready
-client.InitializeComplete.SubscribeTo(_ =>
-{
-    // One-shot reads of simple types
-    client.Read(".AString");
-    client.Read(".AInt");
-
-    // Write a value
-    client.Write(".AInt", 42);
-});
-
-// Observe tag changes as streams
-client.Observe<string>(".AString").SubscribeTo(v => Console.WriteLine($"AString: {v}"));
-client.Observe<short>(".AInt").SubscribeTo(v => Console.WriteLine($"AInt: {v}"));
-
-// Observe arrays (triggered by reads)
-client.Observe<short[]>(".ArrInt").SubscribeTo(arr => Console.WriteLine($"ArrInt[{arr.Length}]: {string.Join(",", arr)}"));
+client.Read(".AInt");
+client.Write(".AInt", (short)42);
 ```
 
-### Async observables
+`InitializeComplete` is the readiness signal for a completed connection/setup. `DataReceived` emits `(Variable, Data, Id)` updates; use the `id` overloads of `Read`, `Write`, and `Observe` to correlate one-shot activity.
 
-TwinCATRx exposes ReactiveUI.Primitives `IObservableAsync<T>` streams alongside the classic `IObservable<T>` streams.
+## Configuration
+
+Set `Settings.AdsAddress`, `Port`, and `SettingsId`, then register every notification with `AddNotification` and every writable variable with `AddWriteVariable`. The configuration overloads accept a cycle time and an array/string size. Supply a positive explicit size for ADS strings and arrays when the protocol cannot infer it.
+
+Use `Connect(ISettings)`, then `Disconnect()` before disposing. Dynamic structure materialization in `Connect` is marked `RequiresDynamicCode` and `RequiresUnreferencedCode`; publish trimmed/AOT applications only after validating their exact ADS structures.
+
+## Detailed features
+
+### Connection lifecycle, events, errors, and disposal
+
+`IRxTcAdsClient` is the common contract implemented by `RxTcAdsClient` for ADS and `InMemoryAdsClient` for tests. Construct/configure the client, subscribe to its streams, call `Connect(ISettings)`, wait for `InitializeComplete`, then read/write or observe. `Disconnect()` releases ADS handles while allowing a later `Connect`; `Dispose()` is terminal. `Connected`, `Settings`, `IsPaused`, `IsPausedObservable`, `IsDisposed`, `ReadWriteHandleInfo`, and `WriteHandleInfo` expose session state. There is no cancellation token on the synchronous ADS operations: cancel work by disposing the subscription/client or by composing an async observable with its cancellation-aware subscription.
+
+`ErrorReceived` is the fault stream: subscribe before `Connect`, report the exception with the variable/correlation context held by your application, and do not assume an exception has stopped other notifications. `Code` exposes generated/dynamic type code where applicable, `OnWrite` emits written variable names, and `DataReceived` emits `(Variable, Data, Id)` for notification and correlated read results. Each has an `IObservableAsync<T>` counterpart where declared (`...Async`), suitable for the ReactiveUI.Primitives async observer model.
+
 ```csharp
-using ReactiveUI.Primitives.Async;
+using IoT.DriverCore.TwinCATRx;
+using IoT.DriverCore.TwinCATRx.Core;
 
-IObservableAsync<short> asyncAInt = client.ObserveAsync<short>(".AInt");
+using var client = new RxTcAdsClient();
+using var errors = client.ErrorReceived.Subscribe(ex => AuditFailure(ex));
+using var ready = client.InitializeComplete.Subscribe(_ => Console.WriteLine("ADS handles ready"));
+using var written = client.OnWrite.Subscribe(name => Console.WriteLine($"Wrote {name}"));
 
-client.DataReceivedAsync
-    .Where(x => x.Variable == ".AInt")
-    .SubscribeAsync(async (value, cancellationToken) =>
-    {
-        await Console.Out.WriteLineAsync($"AInt: {value.Data}");
-    });
+var settings = new Settings { AdsAddress = "5.35.59.10.1.1", Port = 851, SettingsId = "LineA" };
+settings.AddNotification(".Main.Temperature", cycleTime: 250);
+settings.AddWriteVariable(".Main.Setpoint");
+client.Connect(settings);
+// Dispose subscriptions first, then Disconnect/Dispose when the application stops.
 ```
 
-## 📖 API Reference
+### Settings, ADS addressing, notifications, and handles
 
-IRxTcAdsClient API
-- Code: IObservable<string[]> of generated code artifacts (internal diagnostics).
-- InitializeComplete: IObservable<Unit> signaled when connected and initialized.
-- InitializeCompleteAsync: IObservableAsync<Unit> on .NET 8+.
-- DataReceived: IObservable<(string Variable, object? Data, string? Id)> of raw variable updates.
-- DataReceivedAsync: IObservableAsync<(string Variable, object? Data, string? Id)> on .NET 8+.
-- ErrorReceived: IObservable<Exception> of client errors.
-- ErrorReceivedAsync: IObservableAsync<Exception> on .NET 8+.
-- OnWrite: IObservable<string?> of write results (e.g., "Success" or error text).
-- OnWriteAsync: IObservableAsync<string?> on .NET 8+.
-- ReadWriteHandleInfo: IDictionary<string, uint?> of handles for notification variables.
-- WriteHandleInfo: IDictionary<string, (uint? Handle, int ArrayLength)> of handles for write variables.
-- Settings: ISettings? used during Connect.
-- IsPaused: bool indicating WriteValuesAsync throttling state.
-- IsPausedObservable: IObservable<bool> of pause/resume state.
-- IsPausedObservableAsync: IObservableAsync<bool> on .NET 8+.
-- Connect(ISettings settings): connect and initialize.
-- Disconnect(): stop the client.
-- Read(string variable, int? arrayLength = null, string? id = null): one-shot read for simple or array variables.
-- Write(string variable, object value, string? id = null): write a value to a variable.
-- Pause(TimeSpan time): temporarily pause WriteValuesAsync scheduling.
+`Settings` implements `ISettings`: set `AdsAddress` to the route/net-id accepted by TwinCAT, set the ADS `Port` (commonly 851 for a PLC runtime but use the configured target), and give the configuration a stable `SettingsId`. Its `Notifications` are `INotification`/`Notification` records (`Variable`, `UpdateRate`, `ArraySize`); write registrations are `IWriteVariable`/`WriteVariable` (`Variable`, `ArraySize`). The `TwinCatRxExtensions.AddNotification` overloads accept a name alone, name/cycle, or name/cycle/array size. `AddWriteVariable` accepts a name alone or name/array size. Register all desired handles before `Connect`; adding to `Settings` afterwards does not retrofit an existing session.
 
-## Examples
+Use the exact PLC symbol spelling, including the leading-dot convention used by your project. For fixed-length `STRING`, arrays, or an `ANYTYPE` shape the runtime cannot infer, use the explicit size. A non-positive or incorrect size produces a handle/read conversion failure or truncated data; it is not a network retry condition.
 
-### Observe variable updates
-```csharp
-client.Observe<bool>(".ABool").SubscribeTo(v => Console.WriteLine($"ABool: {v}"));
-client.Observe<int>(".ADInt").SubscribeTo(v => Console.WriteLine($"ADInt: {v}"));
-
-// With correlation id
-client.Observe<int>(".AInt", id: "R1").SubscribeTo(v => Console.WriteLine($"AInt[R1]: {v}"));
-```
-
-### Read and write values
-```csharp
-// Simple types
-client.Read(".ALReal");
-client.Write(".ABool", true);
-
-// Arrays
-// For arrays registered via AddWriteVariable(".ArrInt", 11) you can read with the configured length
-client.Read(".ArrInt");
-// Or supply a length for arrays not registered as write variables
-client.Read(".ArrInt", arrayLength: 11);
-```
-
-### Structured tags with HashTableRx
-
-TwinCatRxExtensions provides helpers to work with structured PLC tags using CP.Collections.HashTableRx.
-```csharp
-// Create a live structure wrapper for a tag (structure or UDT)
-var tag1 = client.CreateStruct(".Tag1");
-
-// Wait until the first payload is received
-await tag1!.StructureReady();
-
-// Stream inner fields
-tag1.Observe<bool>("ABool").SubscribeTo(v => Console.WriteLine($"Tag1.ABool: {v}"));
-tag1.Observe<short>("AInt").SubscribeTo(v => Console.WriteLine($"Tag1.AInt: {v}"));
-
-// Clone, set values, and write back atomically
-var ok = tag1.WriteValues(ht =>
-{
-    var current = ht.Value<short>("AInt");
-    ht.Value("AInt", (short)(current + 10));
-    ht.Value("AString", $"Int Value {current + 10}");
-});
-
-// Async write with a pause window
-var okAsync = await tag1.WriteValuesAsync(ht =>
-{
-    ht.Value("AInt", 100);
-    ht.Value("AString", "Updated");
-}, TimeSpan.FromMilliseconds(300));
-```
-
-### TwinCatRxExtensions (main) reference
-
-- Observe<T>(this IRxTcAdsClient, string variable)
-- Observe<T>(this IRxTcAdsClient, string variable, string id)
-- ObserveAsync<T>(this IRxTcAdsClient, string variable)
-- ObserveAsync<T>(this IRxTcAdsClient, string variable, string id)
-- CreateStruct(this IRxTcAdsClient, string variable): HashTableRx
-- WriteValues(this HashTableRx, Action<HashTableRx>): bool
-- WriteValuesAsync(this HashTableRx, Action<HashTableRx>, TimeSpan): Task<bool>
-- StructureReady(this HashTableRx): IObservable<HashTableRx>
-- CreateClone(this HashTableRx): HashTableRx
-
-### Settings and configuration
 ```csharp
 var settings = new Settings
 {
-    AdsAddress = "5.35.59.10.1.1",  // or leave null/empty to use local port-only Connect
-    Port = 801,
-    SettingsId = "Default"
+    AdsAddress = "5.35.59.10.1.1",
+    Port = 851,
+    SettingsId = "PackagingCell"
 };
-
-// Notifications (observed tags)
-settings.AddNotification(".Tag1");        // structure
-settings.AddNotification(".AString", arraySize: 80); // strings require a size
-settings.AddNotification(".AInt");
-
-// Write variables (readable and writable)
-settings.AddWriteVariable(".ArrInt", 11); // arrays require a length
+settings.AddNotification(".Main.State", 100);
+settings.AddNotification(".Main.BatchName", 500, arraySize: 80);
+settings.AddWriteVariable(".Main.RequestedSpeed");
+settings.AddWriteVariable(".Main.Recipe", arraySize: 80);
 ```
 
-## Core helpers (CP.TwinCATRx.Core)
+### One-shot reads, correlated requests, writes, and pause windows
 
-### Reactive retry helpers
+`Read(variable)`, `Read(variable, id)`, `Read(variable, arrayLength)`, and `Read(variable, arrayLength, id)` issue a one-shot read and publish its result through `DataReceived`. Use an `id` when several reads of the same variable can overlap; use `arrayLength` for an array/string request whose size is not registered. `Write(variable, value)` and `Write(variable, value, id)` issue a write and publish the variable through `OnWrite`; check `ErrorReceived` for asynchronous ADS failures. Calls are void because their useful completion signals are these streams.
+
+`Pause(TimeSpan)` sets the pause state for paced write workflows; observe `IsPausedObservable` rather than guessing timing. It coordinates client work but does not create PLC-side transaction semantics. Use a PLC handshake/sequence value when multiple writes must be observed atomically by the control program.
+
 ```csharp
-using CP.TwinCatRx.Core;
+using var reply = client.DataReceived
+    .Where(x => x.Variable == ".Main.State" && x.Id == "state-42")
+    .Take(1)
+    .Subscribe(x => Console.WriteLine(Convert.ToInt16(x.Data)));
 
-// Retry forever
-source.OnErrorRetry();
-
-// Retry with handler
-source.OnErrorRetry<SomeType, TimeoutException>(ex => Log(ex));
-
-// Retry with delay and count
-source.OnErrorRetry<SomeType, Exception>(ex => Log(ex), retryCount: 5, delay: TimeSpan.FromSeconds(1));
+client.Read(".Main.State", "state-42");
+client.Pause(TimeSpan.FromMilliseconds(100));
+client.Write(".Main.RequestedSpeed", (short)1200, "speed-42");
 ```
 
-### ADS observables
+### Typed observable and asynchronous-observable APIs
+
+`TwinCatRxExtensions.Observe<T>` is the usual typed adapter over `DataReceived`. Supply a variable and converter; its overload with an `id` lets one stream accept a particular correlated read/notification identity. It registers no magic conversion: the converter owns the cast/scale and should validate arrays/structures. `ObserveAsyncObservable<T>` provides the same value stream as `IObservableAsync<T>`; use it when downstream consumers implement `IObserverAsync<T>` or require cancellation-aware `SubscribeAsync` disposal.
+
 ```csharp
-using CP.TwinCatRx.Core;
-using TwinCAT.Ads;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Async;
 
-var ads = new AdsClient();
-ads.Connect(801);
+using var temperature = client.Observe<float>(".Main.Temperature", value => Convert.ToSingle(value))
+    .DistinctUntilChanged()
+    .Subscribe(RenderTemperature);
 
-// State changed events
-ads.AdsStateChangedObserver().SubscribeTo(e => Console.WriteLine($"ADS state changed: {e.State}"));
+var asynchronous = client.ObserveAsyncObservable<short>(
+    ".Main.State", "state-42", value => Convert.ToInt16(value));
+await using var subscription = await asynchronous.SubscribeAsync(
+    new ConsoleAsyncObserver<short>(Console.WriteLine), CancellationToken.None);
 
-// Polling observer for StateInfo
-ads.AdsStateObserver().SubscribeTo(si => Console.WriteLine($"ADS: {si.AdsState}"));
+sealed class ConsoleAsyncObserver<T>(Action<T> onNext) : IObserverAsync<T>
+{
+    public ValueTask DisposeAsync() => default;
+    public ValueTask OnCompletedAsync(Result result) => default;
+    public ValueTask OnErrorResumeAsync(Exception error, CancellationToken cancellationToken) =>
+        ValueTask.FromException(error);
+    public ValueTask OnNextAsync(T value, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        onNext(value);
+        return default;
+    }
+}
 ```
 
-## Advanced (dynamic code generation)
-TwinCATRx can generate types for complex structures at runtime to simplify marshaling. This is handled internally, but you can hook into emitted content via IRxTcAdsClient.Code. Dynamic emit/reflective APIs carry AOT/trimming caveats and are annotated accordingly.
+`ObservableBridgeExtensions.ToAsyncObservable` adapts any ordinary `IObservable<T>` and `SubscribeTo` wires an `IObservableAsync<T>` into a standard observer. The concrete bridge adapters are implementation details; use the public extension methods and dispose the returned `IDisposable` or `IAsyncDisposable`, otherwise ADS notifications and UI handlers remain alive.
 
-### Source-generated reactive streams
+### Structured variables and coordinated member writes
 
-TwinCATRx includes a Roslyn source generator for typed PLC view models. Annotate a partial class with one or more `TwinCatReactiveStream` attributes and the generator creates:
-- A latest-value property.
-- A matching `IObservable<T?>`.
-- A `BindTwinCatRx(IRxTcAdsClient)` method that subscribes to the relevant PLC variable and updates both.
+`CreateStruct(variable)` creates a `TwinCatStructureTable` backed by `HashTableRx` for a structured ADS symbol. It subscribes to updates and exposes the mapped fields; `StructureReady()` signals when the first usable structure has been materialized. `CreateClone()` returns a snapshot suitable for editing off-stream. `WriteValues(table => ...)` applies an edit against a clone and writes it; `WriteValuesAsync(..., pace)` performs the same action coordinated with `Pause`. These helpers suit engineering/configuration screens; for trimming/AOT-sensitive or high-throughput workloads, prefer a source-generated typed stream model.
 
 ```csharp
-using CP.TwinCatRx;
+var table = client.CreateStruct(".Main.Recipe");
+if (table is null) throw new InvalidOperationException("Symbol is not a structure.");
+using (table)
+using (table.StructureReady().Take(1).Subscribe(_ => Console.WriteLine("Recipe available")))
+{
+    var editable = table.CreateClone();
+    editable.Value("TargetWeight", 12.5f);
+    if (!table.WriteValues(copy => copy.Value("TargetWeight", 12.5f)))
+        Console.Error.WriteLine("Write was not accepted");
 
-[TwinCatReactiveStream(".AInt", typeof(short), PropertyName = "AInt", ObservableName = "AIntChanged")]
-[TwinCatReactiveStream(".AString", typeof(string), PropertyName = "AString")]
-public partial class PlcState
+    bool completed = await table.WriteValuesAsync(
+        copy => copy.Value("Enabled", true), TimeSpan.FromMilliseconds(150));
+}
+```
+
+### Logical tags, catalogs, persistence, and bulk workflows
+
+`TwinCatLogicalTagClient` is the common logical-tag facade over an `IRxTcAdsClient`. Construct it with the native client and optionally an `ILogicalTagCatalog`, `LogicalTagSqliteStore`, and `TimeProvider`. Its `Catalog` holds the mappings. `CreateTag`, `RegisterTag`, and `RemoveTag` manage the in-memory map; `ReadAsync`/`WriteAsync`, `ReadManyAsync`/`WriteManyAsync`, `Observe`/`ObserveMany`, and `ObserveAsync`/`ObserveManyAsync` operate by logical name. Results are `TagOperationResult<LogicalTagValue>`: inspect their success/error data rather than assuming every request was accepted.
+
+The persistence members `InitializeStoreAsync`, `LoadTagsAsync`, `GetTagAsync`, `ListTagsAsync`, `UpsertTagAsync`, `EditTagAsync`, `DeleteTagAsync`, group CRUD, `ImportCsvAsync`, and `ExportCsvAsync` support commissioning data. All have cancellation-bearing overloads where I/O occurs. Import into a staged catalog/store, validate address/type information against the PLC, then replace the active set - avoid modifying a live safety mapping from an unreviewed CSV.
+
+```csharp
+using IoT.DriverCore.Core;
+
+using var catalog = new LogicalTagCatalog();
+var store = new LogicalTagSqliteStore("Data Source=logical-tags.db");
+using var tags = new TwinCatLogicalTagClient(client, catalog, store);
+await tags.InitializeStoreAsync(CancellationToken.None);
+tags.RegisterTag(tags.CreateTag("Line.Speed", ".Main.ActualSpeed", "Int16"));
+
+var read = await tags.ReadAsync("Line.Speed", CancellationToken.None);
+if (read.Succeeded) Console.WriteLine(read.Value.Value);
+
+var writes = await tags.WriteManyAsync(
+    [new LogicalTagValue(
+        "Line.Speed", (short)900, TimeProvider.System.GetUtcNow(), "Good")],
+    CancellationToken.None);
+using var changes = tags.Observe("Line.Speed").Subscribe(value => RenderSpeed((short)value.Value!));
+```
+
+### In-memory ADS client and deterministic tests
+
+`InMemoryAdsClient` implements `IRxTcAdsClient` without a TwinCAT runtime. Register scalar or typed symbols through `RegisterSymbol`/`RegisterStructure`, configure/connect it exactly as the production client, and exercise `Read`, `Write`, `ReadMany`, `WriteMany`, `PublishNotifications`, `Pause`, `Reconnect`, `SetValue`, `TryGetValue`, and `RemoveSymbol`. `QueueFault(InMemoryAdsOperation, Exception)` injects an expected failure. `ConnectionState`/`ConnectionStates`, `Symbols`, and `OperationMetrics` (`InMemoryAdsOperationMetrics`) make tests assertable without timing against a real ADS route. `ResetOperationMetrics` clears counters between scenarios.
+
+```csharp
+using var fake = new InMemoryAdsClient();
+fake.RegisterSymbol(".Main.Counter", 0);
+fake.Connect(new Settings { SettingsId = "test", Port = 851 });
+fake.QueueFault(InMemoryAdsOperation.Write, new InMemoryAdsException("planned"));
+using var failed = fake.ErrorReceived.Take(1).Subscribe(_ => Console.WriteLine("fault observed"));
+fake.Write(".Main.Counter", 1);            // exercises the failure route
+fake.SetValue(".Main.Counter", 2);
+fake.PublishNotifications();
+Console.WriteLine(fake.OperationMetrics.WriteCount);
+```
+
+### Source-generated reactive stream and connection models
+
+`TwinCatReactiveStreamGenerator` is embedded in `CP.TwinCATRx`; `TwinCATRx.Generators` is the standalone optional analyzer package for projects that intentionally pin it separately. Do not reference both analyzer versions in one project. Apply `TwinCatReactiveStreamAttribute(variable, dataType)` to a partial class for the legacy stream surface, or apply `TwinCatPlcConnectionAttribute(adsAddress, port)` to a partial connection class and decorate members with `DirectNotificationAttribute`, `StructuredNotificationAttribute`, and/or `WriteOnlyAttribute`.
+
+`DirectNotificationAttribute` accepts `Address`, optional `CycleTime`, `ArraySize`, `Id`, `ObservableName`, `CanWrite`, and `WriteAddress`. `StructuredNotificationAttribute` supplies an address and optional member address plus the same notification/write options. `WriteOnlyAttribute` supplies `Address`, `ArraySize`, and `Id`. The generator emits strongly typed properties, observable members, read/write helpers, settings registrations and connection lifecycle wiring; inspect compiler diagnostics/`obj` generated source when a partial declaration does not produce the expected member.
+
+```csharp
+using IoT.DriverCore.TwinCATRx;
+
+[TwinCatPlcConnection("5.35.59.10.1.1", 851, SettingsId = "LineA")]
+public sealed partial class LineConnection
+{
+    [DirectNotification(".Main.Temperature", CycleTime = 250, CanWrite = false)]
+    public float Temperature { get; private set; }
+
+    [WriteOnly(".Main.Setpoint")]
+    public float Setpoint { get; private set; }
+}
+// Generated members own typed observation/settings; the partial source remains the schema.
+```
+
+The legacy stream attribute is useful for a small, focused model rather than a full connection declaration. It generates a nullable typed property, classic/async observable properties, logical-tag read/write helpers, and `BindTwinCatRx(IRxTcAdsClient)`. The analyzer is supplied by `CP.TwinCATRx` or, when version-pinned deliberately, `TwinCATRx.Generators`; never both versions.
+
+```csharp
+using IoT.DriverCore.TwinCATRx;
+using IoT.DriverCore.TwinCATRx.Core;
+using ReactiveUI.Primitives;
+
+[TwinCatReactiveStream(
+    ".Main.Counter", typeof(short), PropertyName = "Counter", ObservableName = "CounterValues")]
+public sealed partial class LegacyCounterStream
 {
 }
 
-var state = new PlcState();
-using var binding = state.BindTwinCatRx(client);
+using var client = new InMemoryAdsClient();
+client.RegisterSymbol(".Main.Counter", (short)41);
+client.Connect(new Settings { SettingsId = "legacy-demo", Port = 851 });
 
-state.AIntChanged.SubscribeTo(value => Console.WriteLine(value));
-Console.WriteLine(state.AInt);
+var model = new LegacyCounterStream();
+using var values = model.CounterValues.Subscribe(value => Console.WriteLine(value));
+using var binding = model.BindTwinCatRx(client);
+client.Read(".Main.Counter"); // updates Counter and CounterValues through the generated binding
 ```
 
-Use the optional `Id` named argument when a generated stream should bind to a correlated read result.
+### Core helpers, dynamic code generation, and service monitoring
 
-### Windows-only: service monitoring
-Available on Windows-targeted TFMs.
+`CP.TwinCATRx.Core` contains `CodeGenerator`/`ICodeGenerator`, `CSharpLanguage`/`ILanguageService`, `INodeEmulator`, `DirectoryInfoExtensions`, `Notification`, `WriteVariable`, and the `SimpleTypeException`/`UnsuportedTypeException` error types. `CodeGenerator` uses a symbol graph to produce/compile dynamic type support. These are advanced integration APIs and carry dynamic-code/trimming annotations: validate the actual published artifact, preserve required members or choose source generation for NativeAOT/trimmed applications.
+
+`TwinCatRxExtensions.AdsStateChangedObserver` and `AdsStateObserver` expose ADS state changes. Its `OnErrorRetry` overload family retries an observable with optional exception type, retry count/delay, and error callback; use bounded retry with telemetry, not an infinite blind loop around a safety operation. `AssemblyLoad` and `GetType` support plug-in/type loading. `ObservableServiceController`, `IObservableServiceController`, and `ServiceStatus` are Windows service-monitoring APIs; use them only on supported Windows targets and dispose their polling subscription.
+
 ```csharp
-using CP.TwinCatRx;
+using IoT.DriverCore.TwinCATRx.Core;
+using ReactiveUI.Primitives;
+using TwinCAT.Ads;
 
-ObservableServiceController.GetServices()
-    .Where(s => s.DisplayName is "TwinCAT System Service" or "TwinCAT3 System Service")
-    .SubscribeTo(s =>
-    {
-        Console.WriteLine($"{s.DisplayName}: {s.Status}");
-        s.StatusObserver.SubscribeTo(st => Console.WriteLine($"Status: {st}"));
-        if (s.Status != ServiceControllerStatus.Running) s.Start();
-    });
+using var ads = new AdsClient();
+using var adsState = TwinCatRxExtensions.OnErrorRetry<StateInfo, Exception>(
+    TwinCatRxExtensions.AdsStateObserver(ads),
+        error => Console.Error.WriteLine(error.Message),
+        retryCount: 3,
+        delay: TimeSpan.FromSeconds(1))
+    .Subscribe(state => Console.WriteLine(state.AdsState));
+
+using var service = new ObservableServiceController(
+    new System.ServiceProcess.ServiceController("TcSysSrv"));
+using var status = service.StatusObserver.Subscribe(s => Console.WriteLine(s));
 ```
 
-### Error handling
+The core APIs are independently usable, but dynamic-code methods are deliberately explicit about their deployment cost. The following source-verified recipe gives an ADS-state observer a bounded retry policy, emits a small support assembly, and emits source from a symbol tree discovered from the configured route. Run the dynamic part only in a non-trimmed, trusted engineering tool; it is not required for normal `RxTcAdsClient` use.
+
 ```csharp
-client.ErrorReceived.SubscribeTo(ex => Console.WriteLine($"Error: {ex}"));
-client.OnWrite.SubscribeTo(msg => Console.WriteLine($"Write: {msg}"));
+using IoT.DriverCore.TwinCATRx.Core;
+using TwinCAT.Ads;
+
+static IDisposable WatchAdsState(AdsClient ads) =>
+    TwinCatRxExtensions.OnErrorRetry<StateInfo, Exception>(
+        TwinCatRxExtensions.AdsStateObserver(ads),
+            error => Console.Error.WriteLine(error.Message),
+            retryCount: 3,
+            delay: TimeSpan.FromSeconds(1))
+        .Subscribe(state => Console.WriteLine(state.AdsState));
+
+using var generator = new CodeGenerator(Console.Error.WriteLine);
+var roots = generator.LoadSymbols("5.35.59.10.1.1", 851);
+var root = roots.FirstOrDefault();
+if (root is not null)
+{
+    var source = generator.CreateCSharpCodeString(root, isTwinCat3: true, "LineA.Generated");
+    bool emitted = CSharpLanguage.CreateAssembly(source, "LineA.Generated.dll");
+    Console.WriteLine($"Generated: {emitted}");
+}
+
+var generatedFiles = new DirectoryInfo(".").GetFilesWhere("*.cs", file => file.Length > 0);
 ```
 
-### Performance and AOT notes
-- Case-insensitive maps are used to avoid repeated string allocations.
-- Reads use O(1) reverse handle lookups.
-- Library is trimmable; dynamic features are annotated for AOT.
-- Source-generated streams avoid runtime reflection for application-level stream wiring and are preferred for typed UI/view-model bindings.
+### Two combined production workflows
 
-### Tests
-Tests run on TUnit with Microsoft.Testing.Platform across .NET Framework 4.8, .NET 9 Windows, and .NET 11 Windows:
-```bash
-dotnet test --solution src/TwinCATRx.slnx --configuration Release
+**Workflow 1 - typed live dashboard with a commanded setpoint.** Build `Settings` with notifications and write handles, subscribe to `ErrorReceived`, `InitializeComplete`, a typed `Observe<float>` stream and `OnWrite`, then `Connect`. Render only values from the stream; correlate a one-shot confirmation read with an id after the user requests a setpoint. Call `Pause` before the write if the UI must visibly rate-limit it; rely on a PLC acknowledgement tag, not the local pause, before declaring the change complete. Dispose streams then client on shutdown.
+
+```csharp
+using var live = new RxTcAdsClient();
+var dashboard = new Settings { AdsAddress = "5.35.59.10.1.1", Port = 851, SettingsId = "Dashboard" };
+dashboard.AddNotification(".Main.ActualSpeed", 200);
+dashboard.AddWriteVariable(".Main.RequestedSpeed");
+using var errors = live.ErrorReceived.Subscribe(ex => ReportAdsFailure(ex));
+using var values = live.Observe<float>(".Main.ActualSpeed", Convert.ToSingle)
+    .Subscribe(speed => RenderSpeed(speed));
+using var confirm = live.DataReceived.Where(x => x.Id == "speed-confirm").Take(1)
+    .Subscribe(x => ConfirmSpeed(Convert.ToSingle(x.Data)));
+live.Connect(dashboard);
+
+if (await OperatorInterlockAllowsAsync())
+{
+    live.Pause(TimeSpan.FromMilliseconds(100));
+    live.Write(".Main.RequestedSpeed", 900f, "speed-command");
+    live.Read(".Main.ActualSpeed", "speed-confirm");
+}
+live.Disconnect();
 ```
 
-### Limitations
-- Arrays of string are not supported at this time (including arrays of string inside structures).
+**Workflow 2 - commissioning and regression test.** Define logical tags in CSV, import them into a `TwinCatLogicalTagClient` over `InMemoryAdsClient`, register the corresponding fake symbols, run `ReadManyAsync`/`WriteManyAsync`, inject a queued `InMemoryAdsException` to test error handling, then point the unchanged logical-tag configuration at `RxTcAdsClient` in an isolated TwinCAT environment. For stable application schemas, replace runtime structure reflection with the generator attributes and test the generated connection class against `InMemoryAdsClient`.
 
+```csharp
+using var test = new InMemoryAdsClient();
+test.RegisterSymbol(".Main.ActualSpeed", (short)500);
+test.RegisterSymbol(".Main.RequestedSpeed", (short)0);
+var configuration = new Settings { SettingsId = "commissioning", Port = 851 };
+configuration.AddNotification(".Main.ActualSpeed");
+configuration.AddWriteVariable(".Main.RequestedSpeed");
+test.Connect(configuration);
+using var observed = test.Observe<short>(".Main.ActualSpeed", Convert.ToInt16)
+    .Subscribe(value => Console.WriteLine($"Observed {value}"));
+test.ReadMany(new[] { ".Main.ActualSpeed", ".Main.RequestedSpeed" }, "baseline");
+test.WriteMany(new[] { new KeyValuePair<string, object>(".Main.RequestedSpeed", (short)700) }, "setpoint");
+test.QueueFault(InMemoryAdsOperation.Write, new InMemoryAdsException("Expected commissioning failure"));
+using var fault = test.ErrorReceived.Take(1).Subscribe(ex => AssertExpectedFailure(ex));
+test.Write(".Main.RequestedSpeed", (short)701, "expected-fault");
+test.PublishNotifications();
+test.Disconnect();
+```
 
-## 📄 License
+### Correlated reads and async streams
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+```csharp
+using var client = new InMemoryAdsClient();
+client.RegisterSymbol(".AInt", (short)5);
+client.Connect(new Settings { Port = 851, SettingsId = "Test" });
 
-## 🤝 Contributing
+using var result = client.Observe<short>(".AInt", "request-7", value => Convert.ToInt16(value))
+    .Subscribe(value => Console.WriteLine(value));
+client.Read(".AInt", "request-7");
 
-Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
+var asyncData = client.DataReceivedAsync;
+```
 
----
+`IRxTcAdsClient` has async-native forms for initialization, data, errors, writes, and pause state. `TwinCatRxExtensions.ObserveAsyncObservable<T>` converts either typed observation overload to `IObservableAsync<T>`.
 
-**TwinCATRx** - Empowering Industrial Automation with Reactive Technology ⚡🏭
+### Structures and paced writes
+
+```csharp
+var structure = client.CreateStruct(".Machine");
+if (structure is not null)
+{
+    using var ready = structure.StructureReady().Subscribe(_ => Console.WriteLine("Structure ready"));
+    bool written = structure.WriteValues(table => table.Value("Enabled", true));
+    bool paced = await structure.WriteValuesAsync(
+        table => table.Value("Enabled", false), TimeSpan.FromMilliseconds(200));
+}
+```
+
+`CreateStruct` listens for the named variable and maps its received structure into `HashTableRx`. `WriteValues` and `WriteValuesAsync` clone before applying edits; the async variant coordinates the client's pause window. These helpers may use reflection for structures, so heed their trimming annotations.
+
+### Test without an ADS runtime
+
+```csharp
+using var testClient = new InMemoryAdsClient();
+testClient.RegisterSymbol(".Counter", 0);
+testClient.Connect(new Settings { Port = 851, SettingsId = "Test" });
+testClient.Write(".Counter", 1);
+testClient.Read(".Counter");
+```
+
+`InMemoryAdsClient` also supports symbol removal/updates, publication, queued operation faults, operation metrics, reconnect, and bulk read/write helpers for deterministic tests.
+
+## Complete public API reference
+
+The following is the public surface by member family. Overloads with `id` add correlation; overloads with `arrayLength` provide a required ADS size; `...Async` observable properties use the ReactiveUI.Primitives async-observable contract, rather than converting an ADS call into `Task`.
+
+| Area | Types and complete member families | Purpose, result, and lifetime |
+| --- | --- | --- |
+| ADS contract | `IRxTcAdsClient`: `Code`, `InitializeComplete`/`InitializeCompleteAsync`, `DataReceived`/`DataReceivedAsync`, `ErrorReceived`/`ErrorReceivedAsync`, `OnWrite`/`OnWriteAsync`, `ReadWriteHandleInfo`, `WriteHandleInfo`, `Settings`, `IsPaused`, `IsPausedObservable`/`IsPausedObservableAsync`, `IsDisposed`; `Connect`, `Disconnect`, `Pause`, `Read(variable)`, `Read(variable,id)`, `Read(variable,arrayLength)`, `Read(variable,arrayLength,id)`, `Write(variable,value)`, `Write(variable,value,id)`, `Dispose`. | This is the operational API. Stream subscriptions are individually disposable; client disposal releases handles and completes the owned infrastructure. |
+| Production client | `RxTcAdsClient` constructors (default and `TimeProvider`) plus the complete `IRxTcAdsClient` contract. | `RxTcAdsClient` is the normal implementation. Platform/runtime adapters are intentionally internal composition details. |
+| Standard and async observables | Main `TwinCatRxExtensions`: `Observe<T>` (variable/converter and variable/id/converter), `ObserveAsyncObservable<T>` matching both overloads, `CreateStruct`, `StructureReady`, `CreateClone`, `WriteValues`, `WriteValuesAsync`. `ObservableBridgeExtensions.ToAsyncObservable` and all public `SubscribeTo` overloads. | `Observe*` returns a stream that must be disposed. Structure helpers clone before modifying. Bridge methods adapt subscriptions; prefer their extensions to direct adapter construction. |
+| In-memory test ADS | `InMemoryAdsClient` constructors and full `IRxTcAdsClient` surface, plus `ConnectionState`, `ConnectionStates`, `OperationMetrics`, `Symbols`, `Reconnect`, `PublishNotifications`, `QueueFault`, `ReadMany`, `WriteMany`, `RegisterSymbol` overloads, `RegisterStructure<T>` overloads, `RemoveSymbol`, `SetValue`, `TryGetValue<T>`, `ResetOperationMetrics`. `InMemoryAdsSymbol`, `InMemoryAdsOperation`, `InMemoryAdsOperationMetrics`, `InMemoryAdsException`, `InMemoryAdsConnectionState`. | Use only for deterministic tests/simulators. Calls are synchronous but publish the same events as the production contract; queue a fault before the operation whose failure path is being tested. |
+| Logical tags | `TwinCatLogicalTagClient` constructors for native client, catalog/store and optional `TimeProvider`; `Catalog`, `CreateTag` overloads, `RegisterTag`, `RemoveTag`, `ReadAsync`, `ReadManyAsync`, `WriteAsync`, `WriteManyAsync`, `Observe`, `ObserveMany`, `ObserveAsync`, `ObserveManyAsync`, `Dispose`. Persistence: `ImportCsvAsync` overloads, `ExportCsvAsync` overloads, `InitializeStoreAsync`, `LoadTagsAsync` overloads, `GetTagAsync`, `ListTagsAsync`, `UpsertTagAsync`, `EditTagAsync`, `DeleteTagAsync`, `GetGroupAsync`, `ListGroupsAsync`, `UpsertGroupAsync`, `DeleteGroupAsync`. | Read/write methods return logical-tag operation results; observation returns normal or async streams. Store methods use cancellation-bearing I/O overloads and are not a substitute for validating PLC mappings. |
+| Service monitoring | `IObservableServiceController`, `ObservableServiceController` constructors accepting `ServiceController` and interval, `IsDisposed`, `CanStop`, `DisplayName`, `ServiceName`, `Status`, `StatusObserver`, static `GetServices`, `Restart`, `Start`, `Stop`, `Dispose`, and `ServiceStatus`. | Windows-only operational integration. `StatusObserver` must be disposed with the controller; start/stop/restart can alter host services and require authorization. |
+| Core configuration | `ISettings`/`Settings` (`AdsAddress`, `Port`, `Notifications`, `WriteVariables`, `SettingsId`); `INotification`/`Notification` (`Variable`, `UpdateRate`, `ArraySize`); `IWriteVariable`/`WriteVariable` (`Variable`, `ArraySize`). Core `TwinCatRxExtensions.AddNotification` three overloads and `AddWriteVariable` two overloads. | These values are consumed during `Connect`. Make a fresh settings instance for a different endpoint or shape rather than mutate a live connected configuration. |
+| Core retry, state and loading | Core `TwinCatRxExtensions.AdsStateChangedObserver`, `AdsStateObserver`, all `OnErrorRetry` overloads (basic; typed error callback; callback plus delay; callback plus retry count; callback plus retry count/delay/sequencer), `AssemblyLoad`, `GetType`. | State observers are streams. Retry extension overloads return a new sequence; use a finite count/delay/callback for production recovery and observe terminal errors. |
+| Dynamic code generation | `ICodeGenerator`, `CodeGenerator` constructors/properties, static `CodeGenerator.PLCToCSharpTypeConverter`, `CreateCSharpCode` overloads, `CreateCSharpCodeString` overloads, `CreateDll` overloads, `LoadSymbols` overloads, `ReadSymbol`, `SearchSymbols`, and `Dispose`; `ILanguageService`/`CSharpLanguage` (`CreateAssembly`, `ParseText`, `CreateLibraryCompilation`); `INodeEmulator`; `DirectoryInfoExtensions.GetFilesWhere` overloads; `SimpleTypeException`, `UnsuportedTypeException`. | Advanced reflection/dynamic-compilation integration. Generated DLL/source file operations return success flags and can throw IO/compiler errors; guard them and validate trim/AOT deployment. |
+| Structures | `CreateStruct` returns the public `HashTableRx` abstraction from its extension API. | It materializes ADS structure values; dispose the returned table to release its source subscription. |
+| Analyzer | `TwinCatReactiveStreamGenerator`. | It emits the compile-time schema attributes `TwinCatReactiveStreamAttribute`, `TwinCatPlcConnectionAttribute`, `DirectNotificationAttribute`, `StructuredNotificationAttribute`, and `WriteOnlyAttribute` into the consuming compilation; they are not public runtime package types. `CP.TwinCATRx` embeds the analyzer; `TwinCATRx.Generators` supplies the same analyzer as a standalone optional package. |
+
+## Operational guidance
+
+Register notifications before connecting, retain subscriptions for the whole operational session, and treat `ErrorReceived` and `OnWrite` as first-class telemetry. Use correlation identifiers for concurrent reads. Avoid high-rate notifications unless the PLC, ADS route, and consumer can keep up. Dispose structures and clients; do not silently recover from a safety-relevant write failure.
+
+## Troubleshooting
+
+- **Connect fails:** verify TwinCAT is in Run mode, the ADS route/address and port are correct, and the host can reach ADS.
+- **No value arrives:** register a notification before `Connect`, wait for `InitializeComplete`, then check the exact variable spelling and route.
+- **Strings/arrays are truncated or fail:** provide the required positive array/string length during registration or read.
+- **Structure code fails under trimming/AOT:** preserve required members or use source-generated application stream wiring; validate the published artifact.
+- **Write cadence is wrong:** use `Pause`/`WriteValuesAsync` deliberately and observe `IsPausedObservable` rather than adding uncoordinated delays.
+
+## AI skill
+
+Use the packaged [`twincat-rx` skill](../../skills/twincat-rx/SKILL.md) for concise source-grounded workflow guidance and use this README as the detailed reference.
+
+MIT licensed. See the repository `LICENSE`.
+
+<!-- BEGIN GENERATED PUBLIC API -->
+
+## Exhaustive public API reference
+
+This catalogue is generated from the packaged runtime assemblies and their XML documentation. It includes exported public types and their declared public members; inherited members and non-public implementation details are intentionally omitted.
+
+### `TwinCATRx`
+
+Exported public types: 14; declared public members: 220.
+
+#### `T:IoT.DriverCore.TwinCATRx.IObservableServiceController`
+
+```csharp
+public interface IoT.DriverCore.TwinCATRx.IObservableServiceController
+```
+Interface for Observable Service Controller.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.IObservableServiceController.Restart`
+
+```csharp
+public void Restart()
+```
+Restarts this instance.
+
+###### `M:IoT.DriverCore.TwinCATRx.IObservableServiceController.Start`
+
+```csharp
+public void Start()
+```
+Starts this instance.
+
+###### `M:IoT.DriverCore.TwinCATRx.IObservableServiceController.Stop`
+
+```csharp
+public void Stop()
+```
+Stops this instance.
+
+###### `P:IoT.DriverCore.TwinCATRx.IObservableServiceController.CanStop`
+
+```csharp
+public bool CanStop { get; }
+```
+Gets a value indicating whether this instance can stop.
+
+- Value: true if this instance can stop; otherwise, false .
+
+###### `P:IoT.DriverCore.TwinCATRx.IObservableServiceController.DisplayName`
+
+```csharp
+public string DisplayName { get; }
+```
+Gets the display name.
+
+- Value: The display name.
+
+###### `P:IoT.DriverCore.TwinCATRx.IObservableServiceController.ServiceName`
+
+```csharp
+public string ServiceName { get; }
+```
+Gets the name of the service.
+
+- Value: The name of the service.
+
+###### `P:IoT.DriverCore.TwinCATRx.IObservableServiceController.Status`
+
+```csharp
+public System.ServiceProcess.ServiceControllerStatus Status { get; }
+```
+Gets the status.
+
+- Value: The status.
+
+###### `P:IoT.DriverCore.TwinCATRx.IObservableServiceController.StatusObserver`
+
+```csharp
+public System.IObservable<System.ServiceProcess.ServiceControllerStatus> StatusObserver { get; }
+```
+Gets the status observer.
+
+- Value: The status observer.
+
+#### `T:IoT.DriverCore.TwinCATRx.IRxTcAdsClient`
+
+```csharp
+public interface IoT.DriverCore.TwinCATRx.IRxTcAdsClient
+```
+Interface for Rx Tc Ads Client.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.Connect(IoT.DriverCore.TwinCATRx.Core.ISettings)`
+
+```csharp
+public void Connect(IoT.DriverCore.TwinCATRx.Core.ISettings settings)
+```
+Connects the specified settings.
+
+- Parameter `settings`: The settings.
+
+###### `M:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.Disconnect`
+
+```csharp
+public void Disconnect()
+```
+Disconnects this instance.
+
+###### `M:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.Pause(System.TimeSpan)`
+
+```csharp
+public void Pause(System.TimeSpan time)
+```
+Pauses the specified time.
+
+- Parameter `time`: The time.
+
+###### `M:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.Read(System.String)`
+
+```csharp
+public void Read(string variable)
+```
+Reads the specified data.
+
+- Parameter `variable`: The data.
+
+###### `M:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.Read(System.String,System.Nullable`1{System.Int32})`
+
+```csharp
+public void Read(string variable, System.Nullable<int> arrayLength)
+```
+Executes the `Read` operation.
+
+- Parameter `variable`: The `variable` value.
+- Parameter `arrayLength`: The `arrayLength` value.
+
+###### `M:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.Read(System.String,System.Nullable`1{System.Int32},System.String)`
+
+```csharp
+public void Read(string variable, System.Nullable<int> arrayLength, string id)
+```
+Executes the `Read` operation.
+
+- Parameter `variable`: The `variable` value.
+- Parameter `arrayLength`: The `arrayLength` value.
+- Parameter `id`: The `id` value.
+
+###### `M:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.Read(System.String,System.String)`
+
+```csharp
+public void Read(string variable, string id)
+```
+Reads the specified data with a correlation identifier.
+
+- Parameter `variable`: The data.
+- Parameter `id`: The identifier.
+
+###### `M:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.Write(System.String,System.Object)`
+
+```csharp
+public void Write(string variable, object value)
+```
+Writes the specified value.
+
+- Parameter `variable`: The variable.
+- Parameter `value`: The value.
+
+###### `M:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.Write(System.String,System.Object,System.String)`
+
+```csharp
+public void Write(string variable, object value, string id)
+```
+Writes the specified value with a correlation identifier.
+
+- Parameter `variable`: The variable.
+- Parameter `value`: The value.
+- Parameter `id`: The identifier.
+
+###### `P:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.Code`
+
+```csharp
+public System.IObservable<string[]> Code { get; }
+```
+Gets the code.
+
+- Value: The code.
+
+###### `P:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.DataReceived`
+
+```csharp
+public System.IObservable<System.ValueTuple<string, object, string>> DataReceived { get; }
+```
+Gets the data received.
+
+- Value: The data received.
+
+###### `P:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.DataReceivedAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<string, object, string>> DataReceivedAsync { get; }
+```
+Gets the async data received stream.
+
+- Value: The `DataReceivedAsync` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.ErrorReceived`
+
+```csharp
+public System.IObservable<System.Exception> ErrorReceived { get; }
+```
+Gets the error received.
+
+- Value: The error received.
+
+###### `P:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.ErrorReceivedAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<System.Exception> ErrorReceivedAsync { get; }
+```
+Gets the async error received stream.
+
+- Value: The `ErrorReceivedAsync` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.InitializeComplete`
+
+```csharp
+public System.IObservable<ReactiveUI.Primitives.RxVoid> InitializeComplete { get; }
+```
+Gets the initialize complete. PLC is ready to read and write.
+
+- Value: The initialize complete.
+
+###### `P:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.InitializeCompleteAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid> InitializeCompleteAsync { get; }
+```
+Gets the async initialize complete stream.
+
+- Value: The `InitializeCompleteAsync` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.IsDisposed`
+
+```csharp
+public bool IsDisposed { get; }
+```
+Gets a value indicating whether the instance is disposed.
+
+- Value: The `IsDisposed` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.IsPaused`
+
+```csharp
+public bool IsPaused { get; }
+```
+Gets a value indicating whether this instance is paused within WriteValuesAsync.
+
+- Value: true if this instance is paused; otherwise, false .
+
+###### `P:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.IsPausedObservable`
+
+```csharp
+public System.IObservable<bool> IsPausedObservable { get; }
+```
+Gets the is paused observable.
+
+- Value: The is paused observable.
+
+###### `P:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.IsPausedObservableAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<bool> IsPausedObservableAsync { get; }
+```
+Gets the async paused state stream.
+
+- Value: The `IsPausedObservableAsync` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.OnWrite`
+
+```csharp
+public System.IObservable<string> OnWrite { get; }
+```
+Gets the on write.
+
+- Value: The on write.
+
+###### `P:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.OnWriteAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<string> OnWriteAsync { get; }
+```
+Gets the async write result stream.
+
+- Value: The `OnWriteAsync` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.ReadWriteHandleInfo`
+
+```csharp
+public System.Collections.Generic.IDictionary<string, System.Nullable<uint>> ReadWriteHandleInfo { get; }
+```
+Gets the read write handle information.
+
+- Value: The read write handle information.
+
+###### `P:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.Settings`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.Core.ISettings Settings { get; }
+```
+Gets the settings.
+
+- Value: The settings.
+
+###### `P:IoT.DriverCore.TwinCATRx.IRxTcAdsClient.WriteHandleInfo`
+
+```csharp
+public System.Collections.Generic.IDictionary<string, System.ValueTuple<System.Nullable<uint>, int>> WriteHandleInfo { get; }
+```
+Gets the write handle information.
+
+- Value: The write handle information.
+
+#### `T:IoT.DriverCore.TwinCATRx.InMemoryAdsClient`
+
+```csharp
+public class IoT.DriverCore.TwinCATRx.InMemoryAdsClient
+```
+Provides a deterministic, production-usable ADS simulator for applications that need to run without a TwinCAT runtime or physical PLC.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.#ctor`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.InMemoryAdsClient()
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.InMemoryAdsClient` class.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.Connect(IoT.DriverCore.TwinCATRx.Core.ISettings)`
+
+```csharp
+public void Connect(IoT.DriverCore.TwinCATRx.Core.ISettings settings)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `settings`: The `settings` value.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.Disconnect`
+
+```csharp
+public void Disconnect()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.Dispose`
+
+```csharp
+public void Dispose()
+```
+Inherits XML documentation from its implemented or overridden member.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.Pause(System.TimeSpan)`
+
+```csharp
+public void Pause(System.TimeSpan time)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `time`: The `time` value.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.PublishNotifications`
+
+```csharp
+public void PublishNotifications()
+```
+Publishes every configured notification using the latest in-memory symbol values.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.QueueFault(IoT.DriverCore.TwinCATRx.InMemoryAdsOperation,System.Exception)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.InMemoryAdsClient QueueFault(IoT.DriverCore.TwinCATRx.InMemoryAdsOperation operation, System.Exception error)
+```
+Queues a failure for the next matching operation.
+
+- Parameter `operation`: The operation that will consume the failure.
+- Parameter `error`: The error to publish.
+- Returns: This simulator for fluent setup.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.Read(System.String)`
+
+```csharp
+public void Read(string variable)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `variable`: The `variable` value.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.Read(System.String,System.Nullable`1{System.Int32})`
+
+```csharp
+public void Read(string variable, System.Nullable<int> arrayLength)
+```
+Executes the `Read` operation.
+
+- Parameter `variable`: The `variable` value.
+- Parameter `arrayLength`: The `arrayLength` value.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.Read(System.String,System.Nullable`1{System.Int32},System.String)`
+
+```csharp
+public void Read(string variable, System.Nullable<int> arrayLength, string id)
+```
+Executes the `Read` operation.
+
+- Parameter `variable`: The `variable` value.
+- Parameter `arrayLength`: The `arrayLength` value.
+- Parameter `id`: The `id` value.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.Read(System.String,System.String)`
+
+```csharp
+public void Read(string variable, string id)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `variable`: The `variable` value.
+- Parameter `id`: The `id` value.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.ReadMany(System.Collections.Generic.IEnumerable`1{System.String})`
+
+```csharp
+public void ReadMany(System.Collections.Generic.IEnumerable<string> variables)
+```
+Executes the `ReadMany` operation.
+
+- Parameter `variables`: The `variables` value.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.ReadMany(System.Collections.Generic.IEnumerable`1{System.String},System.String)`
+
+```csharp
+public void ReadMany(System.Collections.Generic.IEnumerable<string> variables, string correlationPrefix)
+```
+Executes the `ReadMany` operation.
+
+- Parameter `variables`: The `variables` value.
+- Parameter `correlationPrefix`: The `correlationPrefix` value.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.Reconnect`
+
+```csharp
+public void Reconnect()
+```
+Reconnects with the latest settings while preserving registered symbols and queued faults.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.RegisterStructure``1(System.String,``0)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.InMemoryAdsClient RegisterStructure<T>(string name, T value)
+```
+Registers or replaces an in-memory structure symbol.
+
+- Parameter `name`: The root symbol name.
+- Parameter `value`: The structure value.
+- Returns: This simulator for fluent setup.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.RegisterStructure``1(System.String,``0,System.Boolean,System.Boolean)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.InMemoryAdsClient RegisterStructure<T>(string name, T value, bool isReadable, bool isWritable)
+```
+Registers or replaces an in-memory structure symbol with full access metadata.
+
+- Parameter `name`: The root symbol name.
+- Parameter `value`: The structure value.
+- Parameter `isReadable`: Whether reads are permitted.
+- Parameter `isWritable`: Whether writes are permitted.
+- Returns: This simulator for fluent setup.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.RegisterSymbol(System.String,System.Object)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.InMemoryAdsClient RegisterSymbol(string name, object value)
+```
+Registers or replaces an in-memory ADS symbol.
+
+- Parameter `name`: The symbol name.
+- Parameter `value`: The initial value.
+- Returns: This simulator for fluent setup.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.RegisterSymbol(System.String,System.Object,System.Type)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.InMemoryAdsClient RegisterSymbol(string name, object value, System.Type dataType)
+```
+Registers or replaces an in-memory ADS symbol with an explicit declared type.
+
+- Parameter `name`: The symbol name.
+- Parameter `value`: The initial value.
+- Parameter `dataType`: The declared type.
+- Returns: This simulator for fluent setup.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.RegisterSymbol(System.String,System.Object,System.Type,System.Int32,System.Boolean,System.Boolean)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.InMemoryAdsClient RegisterSymbol(string name, object value, System.Type dataType, int arrayLength, bool isReadable, bool isWritable)
+```
+Registers or replaces an in-memory ADS symbol with full access metadata.
+
+- Parameter `name`: The symbol name.
+- Parameter `value`: The initial value.
+- Parameter `dataType`: The declared type.
+- Parameter `arrayLength`: The array or string length, or -1 for a scalar.
+- Parameter `isReadable`: Whether reads are permitted.
+- Parameter `isWritable`: Whether writes are permitted.
+- Returns: This simulator for fluent setup.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.RemoveSymbol(System.String)`
+
+```csharp
+public bool RemoveSymbol(string name)
+```
+Removes a registered symbol and any configured handles for it.
+
+- Parameter `name`: The symbol name.
+- Returns: Whether a symbol was removed.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.ResetOperationMetrics`
+
+```csharp
+public void ResetOperationMetrics()
+```
+Resets deterministic native ADS operation counts without changing simulator state.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.SetValue(System.String,System.Object)`
+
+```csharp
+public void SetValue(string variable, object value)
+```
+Updates a symbol as if its value changed in the simulated PLC.
+
+- Parameter `variable`: The variable to update.
+- Parameter `value`: The new value.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.TryGetValue``1(System.String,``0@)`
+
+```csharp
+public bool TryGetValue<T>(string variable, out T value)
+```
+Tries to retrieve and convert a registered symbol value.
+
+- Parameter `variable`: The symbol name.
+- Parameter `value`: The converted value when successful.
+- Returns: Whether the symbol exists and its value is compatible.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.Write(System.String,System.Object)`
+
+```csharp
+public void Write(string variable, object value)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `variable`: The `variable` value.
+- Parameter `value`: The `value` value.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.Write(System.String,System.Object,System.String)`
+
+```csharp
+public void Write(string variable, object value, string id)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `variable`: The `variable` value.
+- Parameter `value`: The `value` value.
+- Parameter `id`: The `id` value.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.WriteMany(System.Collections.Generic.IEnumerable`1{System.Collections.Generic.KeyValuePair`2{System.String,System.Object}})`
+
+```csharp
+public void WriteMany(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>> values)
+```
+Executes the `WriteMany` operation.
+
+- Parameter `values`: The `values` value.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.WriteMany(System.Collections.Generic.IEnumerable`1{System.Collections.Generic.KeyValuePair`2{System.String,System.Object}},System.String)`
+
+```csharp
+public void WriteMany(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>> values, string correlationPrefix)
+```
+Executes the `WriteMany` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `correlationPrefix`: The `correlationPrefix` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.Code`
+
+```csharp
+public System.IObservable<string[]> Code { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `Code` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.Connected`
+
+```csharp
+public bool Connected { get; }
+```
+Gets a value indicating whether the simulator is connected.
+
+- Value: The `Connected` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.ConnectionState`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.InMemoryAdsConnectionState ConnectionState { get; }
+```
+Gets the current simulator connection state.
+
+- Value: The `ConnectionState` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.ConnectionStates`
+
+```csharp
+public System.IObservable<IoT.DriverCore.TwinCATRx.InMemoryAdsConnectionState> ConnectionStates { get; }
+```
+Gets the observable connection state stream.
+
+- Value: The `ConnectionStates` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.DataReceived`
+
+```csharp
+public System.IObservable<System.ValueTuple<string, object, string>> DataReceived { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `DataReceived` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.DataReceivedAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<string, object, string>> DataReceivedAsync { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `DataReceivedAsync` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.ErrorReceived`
+
+```csharp
+public System.IObservable<System.Exception> ErrorReceived { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `ErrorReceived` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.ErrorReceivedAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<System.Exception> ErrorReceivedAsync { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `ErrorReceivedAsync` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.InitializeComplete`
+
+```csharp
+public System.IObservable<ReactiveUI.Primitives.RxVoid> InitializeComplete { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `InitializeComplete` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.InitializeCompleteAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid> InitializeCompleteAsync { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `InitializeCompleteAsync` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.IsDisposed`
+
+```csharp
+public bool IsDisposed { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `IsDisposed` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.IsPaused`
+
+```csharp
+public bool IsPaused { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `IsPaused` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.IsPausedObservable`
+
+```csharp
+public System.IObservable<bool> IsPausedObservable { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `IsPausedObservable` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.IsPausedObservableAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<bool> IsPausedObservableAsync { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `IsPausedObservableAsync` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.OnWrite`
+
+```csharp
+public System.IObservable<string> OnWrite { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `OnWrite` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.OnWriteAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<string> OnWriteAsync { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `OnWriteAsync` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.OperationMetrics`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.InMemoryAdsOperationMetrics OperationMetrics { get; }
+```
+Gets a deterministic snapshot of native ADS operation counts.
+
+- Value: The `OperationMetrics` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.ReadWriteHandleInfo`
+
+```csharp
+public System.Collections.Generic.IDictionary<string, System.Nullable<uint>> ReadWriteHandleInfo { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `ReadWriteHandleInfo` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.Settings`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.Core.ISettings Settings { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `Settings` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.Symbols`
+
+```csharp
+public System.Collections.Generic.IReadOnlyCollection<IoT.DriverCore.TwinCATRx.InMemoryAdsSymbol> Symbols { get; }
+```
+Gets a snapshot of all registered symbols.
+
+- Value: The `Symbols` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsClient.WriteHandleInfo`
+
+```csharp
+public System.Collections.Generic.IDictionary<string, System.ValueTuple<System.Nullable<uint>, int>> WriteHandleInfo { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `WriteHandleInfo` value.
+
+#### `T:IoT.DriverCore.TwinCATRx.InMemoryAdsConnectionState`
+
+```csharp
+public enum IoT.DriverCore.TwinCATRx.InMemoryAdsConnectionState
+```
+Describes the lifecycle state of an `T:IoT.DriverCore.TwinCATRx.InMemoryAdsClient` .
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.TwinCATRx.InMemoryAdsConnectionState.Connected`
+
+```csharp
+public static const IoT.DriverCore.TwinCATRx.InMemoryAdsConnectionState Connected
+```
+The simulator is ready to service reads, writes, and notifications.
+
+###### `F:IoT.DriverCore.TwinCATRx.InMemoryAdsConnectionState.Connecting`
+
+```csharp
+public static const IoT.DriverCore.TwinCATRx.InMemoryAdsConnectionState Connecting
+```
+The simulator is validating settings and creating handles.
+
+###### `F:IoT.DriverCore.TwinCATRx.InMemoryAdsConnectionState.Disconnected`
+
+```csharp
+public static const IoT.DriverCore.TwinCATRx.InMemoryAdsConnectionState Disconnected
+```
+The simulator is disconnected and can be connected.
+
+###### `F:IoT.DriverCore.TwinCATRx.InMemoryAdsConnectionState.Disposed`
+
+```csharp
+public static const IoT.DriverCore.TwinCATRx.InMemoryAdsConnectionState Disposed
+```
+The simulator and its observable streams have been disposed.
+
+###### `F:IoT.DriverCore.TwinCATRx.InMemoryAdsConnectionState.Faulted`
+
+```csharp
+public static const IoT.DriverCore.TwinCATRx.InMemoryAdsConnectionState Faulted
+```
+The latest connection attempt or simulated operation failed.
+
+#### `T:IoT.DriverCore.TwinCATRx.InMemoryAdsException`
+
+```csharp
+public class IoT.DriverCore.TwinCATRx.InMemoryAdsException
+```
+Represents a deterministic in-memory ADS operation failure.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsException.#ctor`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.InMemoryAdsException()
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.InMemoryAdsException` class.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsException.#ctor(IoT.DriverCore.TwinCATRx.InMemoryAdsOperation,System.String)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.InMemoryAdsException(IoT.DriverCore.TwinCATRx.InMemoryAdsOperation operation, string message)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.InMemoryAdsException` class.
+
+- Parameter `operation`: The failed operation.
+- Parameter `message`: The failure message.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsException.#ctor(IoT.DriverCore.TwinCATRx.InMemoryAdsOperation,System.String,System.String)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.InMemoryAdsException(IoT.DriverCore.TwinCATRx.InMemoryAdsOperation operation, string message, string variable)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.InMemoryAdsException` class.
+
+- Parameter `operation`: The failed operation.
+- Parameter `message`: The failure message.
+- Parameter `variable`: The optional ADS variable involved in the failure.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsException.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.InMemoryAdsException(string message)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.InMemoryAdsException` class.
+
+- Parameter `message`: The failure message.
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsException.#ctor(System.String,System.Exception)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.InMemoryAdsException(string message, System.Exception innerException)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.InMemoryAdsException` class.
+
+- Parameter `message`: The failure message.
+- Parameter `innerException`: The failure that caused this exception.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsException.Operation`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.InMemoryAdsOperation Operation { get; }
+```
+Gets the failed operation.
+
+- Value: The `Operation` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsException.Variable`
+
+```csharp
+public string Variable { get; }
+```
+Gets the optional ADS variable involved in the failure.
+
+- Value: The `Variable` value.
+
+#### `T:IoT.DriverCore.TwinCATRx.InMemoryAdsOperation`
+
+```csharp
+public enum IoT.DriverCore.TwinCATRx.InMemoryAdsOperation
+```
+Identifies an operation that can receive a deterministic simulator fault.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.TwinCATRx.InMemoryAdsOperation.Connect`
+
+```csharp
+public static const IoT.DriverCore.TwinCATRx.InMemoryAdsOperation Connect
+```
+A connection or reconnection operation.
+
+###### `F:IoT.DriverCore.TwinCATRx.InMemoryAdsOperation.Notification`
+
+```csharp
+public static const IoT.DriverCore.TwinCATRx.InMemoryAdsOperation Notification
+```
+A configured notification publication.
+
+###### `F:IoT.DriverCore.TwinCATRx.InMemoryAdsOperation.Read`
+
+```csharp
+public static const IoT.DriverCore.TwinCATRx.InMemoryAdsOperation Read
+```
+A symbol read operation.
+
+###### `F:IoT.DriverCore.TwinCATRx.InMemoryAdsOperation.Write`
+
+```csharp
+public static const IoT.DriverCore.TwinCATRx.InMemoryAdsOperation Write
+```
+A symbol write operation.
+
+#### `T:IoT.DriverCore.TwinCATRx.InMemoryAdsOperationMetrics`
+
+```csharp
+public class IoT.DriverCore.TwinCATRx.InMemoryAdsOperationMetrics
+```
+Provides a deterministic snapshot of native ADS operations issued to an in-memory client.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsOperationMetrics.#ctor(System.Int64,System.Int64,System.Int64)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.InMemoryAdsOperationMetrics(long readOperations, long writeOperations, long notificationPublications)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.InMemoryAdsOperationMetrics` class.
+
+- Parameter `readOperations`: The number of native read attempts.
+- Parameter `writeOperations`: The number of native write attempts.
+- Parameter `notificationPublications`: The number of notification publication attempts.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsOperationMetrics.NotificationPublications`
+
+```csharp
+public long NotificationPublications { get; }
+```
+Gets the number of notification publication attempts.
+
+- Value: The `NotificationPublications` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsOperationMetrics.ReadOperations`
+
+```csharp
+public long ReadOperations { get; }
+```
+Gets the number of native read attempts.
+
+- Value: The `ReadOperations` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsOperationMetrics.WriteOperations`
+
+```csharp
+public long WriteOperations { get; }
+```
+Gets the number of native write attempts.
+
+- Value: The `WriteOperations` value.
+
+#### `T:IoT.DriverCore.TwinCATRx.InMemoryAdsSymbol`
+
+```csharp
+public class IoT.DriverCore.TwinCATRx.InMemoryAdsSymbol
+```
+Describes one symbol hosted by an `T:IoT.DriverCore.TwinCATRx.InMemoryAdsClient` .
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.InMemoryAdsSymbol.#ctor(System.String,System.Object,System.Type,System.Int32,System.Boolean,System.Boolean)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.InMemoryAdsSymbol(string name, object value, System.Type dataType, int arrayLength, bool isReadable, bool isWritable)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.InMemoryAdsSymbol` class.
+
+- Parameter `name`: The case-insensitive ADS variable name.
+- Parameter `value`: The initial symbol value.
+- Parameter `dataType`: The declared value type.
+- Parameter `arrayLength`: The declared array or string length, or -1 for a scalar.
+- Parameter `isReadable`: Whether ADS reads are permitted.
+- Parameter `isWritable`: Whether ADS writes are permitted.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsSymbol.ArrayLength`
+
+```csharp
+public int ArrayLength { get; }
+```
+Gets the declared array or string length, or -1 for a scalar.
+
+- Value: The `ArrayLength` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsSymbol.DataType`
+
+```csharp
+public System.Type DataType { get; }
+```
+Gets the declared value type.
+
+- Value: The `DataType` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsSymbol.IsReadable`
+
+```csharp
+public bool IsReadable { get; }
+```
+Gets a value indicating whether ADS reads are permitted.
+
+- Value: The `IsReadable` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsSymbol.IsWritable`
+
+```csharp
+public bool IsWritable { get; }
+```
+Gets a value indicating whether ADS writes are permitted.
+
+- Value: The `IsWritable` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsSymbol.Name`
+
+```csharp
+public string Name { get; }
+```
+Gets the case-insensitive ADS variable name.
+
+- Value: The `Name` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.InMemoryAdsSymbol.Value`
+
+```csharp
+public object Value { get; }
+```
+Gets the current symbol value.
+
+- Value: The `Value` value.
+
+#### `T:IoT.DriverCore.TwinCATRx.ObservableBridgeExtensions`
+
+```csharp
+public class IoT.DriverCore.TwinCATRx.ObservableBridgeExtensions
+```
+Observable bridge helpers.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.ObservableBridgeExtensions.SubscribeTo``1(System.IObservable`1{``0})`
+
+```csharp
+public static System.IDisposable SubscribeTo<T>(System.IObservable<T> source)
+```
+Executes the `SubscribeTo` operation.
+
+- Parameter `source`: The `source` value.
+- Returns: A `System.IDisposable` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.ObservableBridgeExtensions.SubscribeTo``1(System.IObservable`1{``0},System.Action`1{``0})`
+
+```csharp
+public static System.IDisposable SubscribeTo<T>(System.IObservable<T> source, System.Action<T> onNext)
+```
+Executes the `SubscribeTo` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `onNext`: The `onNext` value.
+- Returns: A `System.IDisposable` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.ObservableBridgeExtensions.SubscribeTo``1(System.IObservable`1{``0},System.Action`1{``0},System.Action`1{System.Exception},System.Action)`
+
+```csharp
+public static System.IDisposable SubscribeTo<T>(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted)
+```
+Executes the `SubscribeTo` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `onNext`: The `onNext` value.
+- Parameter `onError`: The `onError` value.
+- Parameter `onCompleted`: The `onCompleted` value.
+- Returns: A `System.IDisposable` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.ObservableBridgeExtensions.ToAsyncObservable``1(System.IObservable`1{``0})`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<T> ToAsyncObservable<T>(System.IObservable<T> source)
+```
+Executes the `ToAsyncObservable` operation.
+
+- Parameter `source`: The `source` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<T>` result.
+
+#### `T:IoT.DriverCore.TwinCATRx.ObservableServiceController`
+
+```csharp
+public class IoT.DriverCore.TwinCATRx.ObservableServiceController
+```
+Observable Service Controller.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.ObservableServiceController.#ctor(System.ServiceProcess.ServiceController)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.ObservableServiceController(System.ServiceProcess.ServiceController service)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.ObservableServiceController` class.
+
+- Parameter `service`: The service.
+
+###### `M:IoT.DriverCore.TwinCATRx.ObservableServiceController.#ctor(System.ServiceProcess.ServiceController,System.TimeSpan)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.ObservableServiceController(System.ServiceProcess.ServiceController service, System.TimeSpan interval)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.ObservableServiceController` class.
+
+- Parameter `service`: The service.
+- Parameter `interval`: The interval.
+
+###### `M:IoT.DriverCore.TwinCATRx.ObservableServiceController.Dispose`
+
+```csharp
+public void Dispose()
+```
+Releases managed and unmanaged resources.
+
+###### `M:IoT.DriverCore.TwinCATRx.ObservableServiceController.GetServices`
+
+```csharp
+public static System.IObservable<IoT.DriverCore.TwinCATRx.ObservableServiceController> GetServices()
+```
+Gets the services.
+
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.ObservableServiceController.Restart`
+
+```csharp
+public void Restart()
+```
+Restarts this instance.
+
+###### `M:IoT.DriverCore.TwinCATRx.ObservableServiceController.Start`
+
+```csharp
+public void Start()
+```
+Starts this instance.
+
+###### `M:IoT.DriverCore.TwinCATRx.ObservableServiceController.Stop`
+
+```csharp
+public void Stop()
+```
+Stops this instance.
+
+###### `P:IoT.DriverCore.TwinCATRx.ObservableServiceController.CanStop`
+
+```csharp
+public bool CanStop { get; }
+```
+Gets a value indicating whether this instance can stop.
+
+- Value: true if this instance can stop; otherwise, false .
+
+###### `P:IoT.DriverCore.TwinCATRx.ObservableServiceController.DisplayName`
+
+```csharp
+public string DisplayName { get; }
+```
+Gets the display name.
+
+- Value: The display name.
+
+###### `P:IoT.DriverCore.TwinCATRx.ObservableServiceController.IsDisposed`
+
+```csharp
+public bool IsDisposed { get; }
+```
+Gets a value indicating whether the is disposed.
+
+- Value: The `IsDisposed` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.ObservableServiceController.ServiceName`
+
+```csharp
+public string ServiceName { get; }
+```
+Gets the name of the service.
+
+- Value: The name of the service.
+
+###### `P:IoT.DriverCore.TwinCATRx.ObservableServiceController.Status`
+
+```csharp
+public System.ServiceProcess.ServiceControllerStatus Status { get; }
+```
+Gets the status.
+
+- Value: The status.
+
+###### `P:IoT.DriverCore.TwinCATRx.ObservableServiceController.StatusObserver`
+
+```csharp
+public System.IObservable<System.ServiceProcess.ServiceControllerStatus> StatusObserver { get; }
+```
+Gets the status.
+
+- Value: The status.
+
+#### `T:IoT.DriverCore.TwinCATRx.RxTcAdsClient`
+
+```csharp
+public class IoT.DriverCore.TwinCATRx.RxTcAdsClient
+```
+Observable TwinCAT ADS Client.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.RxTcAdsClient.#ctor`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.RxTcAdsClient()
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.RxTcAdsClient` class.
+
+###### `M:IoT.DriverCore.TwinCATRx.RxTcAdsClient.#ctor(System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.RxTcAdsClient(System.TimeProvider timeProvider)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.RxTcAdsClient` class.
+
+- Parameter `timeProvider`: The time provider.
+
+###### `M:IoT.DriverCore.TwinCATRx.RxTcAdsClient.Connect(IoT.DriverCore.TwinCATRx.Core.ISettings)`
+
+```csharp
+public void Connect(IoT.DriverCore.TwinCATRx.Core.ISettings settings)
+```
+Connects the specified settings.
+
+- Parameter `settings`: The settings.
+
+###### `M:IoT.DriverCore.TwinCATRx.RxTcAdsClient.Disconnect`
+
+```csharp
+public void Disconnect()
+```
+Disconnects this instance.
+
+###### `M:IoT.DriverCore.TwinCATRx.RxTcAdsClient.Dispose`
+
+```csharp
+public void Dispose()
+```
+Releases unmanaged and - optionally - managed resources.
+
+###### `M:IoT.DriverCore.TwinCATRx.RxTcAdsClient.Pause(System.TimeSpan)`
+
+```csharp
+public void Pause(System.TimeSpan time)
+```
+Pauses the specified time.
+
+- Parameter `time`: The time.
+
+###### `M:IoT.DriverCore.TwinCATRx.RxTcAdsClient.Read(System.String)`
+
+```csharp
+public void Read(string variable)
+```
+Reads the specified variable.
+
+- Parameter `variable`: The data.
+
+###### `M:IoT.DriverCore.TwinCATRx.RxTcAdsClient.Read(System.String,System.Nullable`1{System.Int32})`
+
+```csharp
+public void Read(string variable, System.Nullable<int> arrayLength)
+```
+Executes the `Read` operation.
+
+- Parameter `variable`: The `variable` value.
+- Parameter `arrayLength`: The `arrayLength` value.
+
+###### `M:IoT.DriverCore.TwinCATRx.RxTcAdsClient.Read(System.String,System.Nullable`1{System.Int32},System.String)`
+
+```csharp
+public void Read(string variable, System.Nullable<int> arrayLength, string id)
+```
+Executes the `Read` operation.
+
+- Parameter `variable`: The `variable` value.
+- Parameter `arrayLength`: The `arrayLength` value.
+- Parameter `id`: The `id` value.
+
+###### `M:IoT.DriverCore.TwinCATRx.RxTcAdsClient.Read(System.String,System.String)`
+
+```csharp
+public void Read(string variable, string id)
+```
+Reads a variable with a correlation identifier.
+
+- Parameter `variable`: The variable.
+- Parameter `id`: The correlation identifier.
+
+###### `M:IoT.DriverCore.TwinCATRx.RxTcAdsClient.Write(System.String,System.Object)`
+
+```csharp
+public void Write(string variable, object value)
+```
+Writes the specified variable.
+
+- Parameter `variable`: The variable.
+- Parameter `value`: The value.
+
+###### `M:IoT.DriverCore.TwinCATRx.RxTcAdsClient.Write(System.String,System.Object,System.String)`
+
+```csharp
+public void Write(string variable, object value, string id)
+```
+Writes a variable with a correlation identifier.
+
+- Parameter `variable`: The variable.
+- Parameter `value`: The value.
+- Parameter `id`: The correlation identifier.
+
+###### `P:IoT.DriverCore.TwinCATRx.RxTcAdsClient.Code`
+
+```csharp
+public System.IObservable<string[]> Code { get; }
+```
+Gets codes this instance.
+
+- Returns: A Value.
+- Value: The `Code` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.RxTcAdsClient.Connected`
+
+```csharp
+public bool Connected { get; }
+```
+Gets a value indicating whether this `T:IoT.DriverCore.TwinCATRx.RxTcAdsClient` is connected.
+
+- Value: true if connected; otherwise, false .
+
+###### `P:IoT.DriverCore.TwinCATRx.RxTcAdsClient.DataReceived`
+
+```csharp
+public System.IObservable<System.ValueTuple<string, object, string>> DataReceived { get; }
+```
+Gets the data received.
+
+- Value: The data received.
+
+###### `P:IoT.DriverCore.TwinCATRx.RxTcAdsClient.DataReceivedAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<System.ValueTuple<string, object, string>> DataReceivedAsync { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `DataReceivedAsync` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.RxTcAdsClient.ErrorReceived`
+
+```csharp
+public System.IObservable<System.Exception> ErrorReceived { get; }
+```
+Gets error received.
+
+- Returns: A Value.
+- Value: The `ErrorReceived` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.RxTcAdsClient.ErrorReceivedAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<System.Exception> ErrorReceivedAsync { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `ErrorReceivedAsync` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.RxTcAdsClient.InitializeComplete`
+
+```csharp
+public System.IObservable<ReactiveUI.Primitives.RxVoid> InitializeComplete { get; }
+```
+Gets the initialize complete. PLC is ready to read and write.
+
+- Value: The initialize complete.
+
+###### `P:IoT.DriverCore.TwinCATRx.RxTcAdsClient.InitializeCompleteAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid> InitializeCompleteAsync { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `InitializeCompleteAsync` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.RxTcAdsClient.IsDisposed`
+
+```csharp
+public bool IsDisposed { get; }
+```
+Gets a value indicating whether gets a value that indicates whether the object is disposed.
+
+- Value: The `IsDisposed` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.RxTcAdsClient.IsPaused`
+
+```csharp
+public bool IsPaused { get; }
+```
+Gets a value indicating whether this instance is paused.
+
+- Value: true if this instance is paused; otherwise, false .
+
+###### `P:IoT.DriverCore.TwinCATRx.RxTcAdsClient.IsPausedObservable`
+
+```csharp
+public System.IObservable<bool> IsPausedObservable { get; }
+```
+Gets the is paused observable.
+
+- Value: The is paused observable.
+
+###### `P:IoT.DriverCore.TwinCATRx.RxTcAdsClient.IsPausedObservableAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<bool> IsPausedObservableAsync { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `IsPausedObservableAsync` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.RxTcAdsClient.OnWrite`
+
+```csharp
+public System.IObservable<string> OnWrite { get; }
+```
+Gets the on write.
+
+- Value: The on write.
+
+###### `P:IoT.DriverCore.TwinCATRx.RxTcAdsClient.OnWriteAsync`
+
+```csharp
+public ReactiveUI.Primitives.Async.IObservableAsync<string> OnWriteAsync { get; }
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Value: The `OnWriteAsync` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.RxTcAdsClient.ReadWriteHandleInfo`
+
+```csharp
+public System.Collections.Generic.IDictionary<string, System.Nullable<uint>> ReadWriteHandleInfo { get; }
+```
+Gets the read write handle information.
+
+- Value: The read write handle information.
+
+###### `P:IoT.DriverCore.TwinCATRx.RxTcAdsClient.Settings`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.Core.ISettings Settings { get; }
+```
+Gets the settings.
+
+- Value: The settings.
+
+###### `P:IoT.DriverCore.TwinCATRx.RxTcAdsClient.WriteHandleInfo`
+
+```csharp
+public System.Collections.Generic.IDictionary<string, System.ValueTuple<System.Nullable<uint>, int>> WriteHandleInfo { get; }
+```
+Gets the write handle information.
+
+- Value: The write handle information.
+
+#### `T:IoT.DriverCore.TwinCATRx.ServiceStatus`
+
+```csharp
+public enum IoT.DriverCore.TwinCATRx.ServiceStatus
+```
+Service Status.
+
+##### Declared public members
+
+###### `F:IoT.DriverCore.TwinCATRx.ServiceStatus.Faulted`
+
+```csharp
+public static const IoT.DriverCore.TwinCATRx.ServiceStatus Faulted
+```
+The faulted.
+
+###### `F:IoT.DriverCore.TwinCATRx.ServiceStatus.Paused`
+
+```csharp
+public static const IoT.DriverCore.TwinCATRx.ServiceStatus Paused
+```
+The paused.
+
+###### `F:IoT.DriverCore.TwinCATRx.ServiceStatus.Running`
+
+```csharp
+public static const IoT.DriverCore.TwinCATRx.ServiceStatus Running
+```
+The running.
+
+###### `F:IoT.DriverCore.TwinCATRx.ServiceStatus.Starting`
+
+```csharp
+public static const IoT.DriverCore.TwinCATRx.ServiceStatus Starting
+```
+The starting.
+
+###### `F:IoT.DriverCore.TwinCATRx.ServiceStatus.StatusChanging`
+
+```csharp
+public static const IoT.DriverCore.TwinCATRx.ServiceStatus StatusChanging
+```
+The status changing.
+
+###### `F:IoT.DriverCore.TwinCATRx.ServiceStatus.Stopped`
+
+```csharp
+public static const IoT.DriverCore.TwinCATRx.ServiceStatus Stopped
+```
+The stopped.
+
+###### `F:IoT.DriverCore.TwinCATRx.ServiceStatus.Stopping`
+
+```csharp
+public static const IoT.DriverCore.TwinCATRx.ServiceStatus Stopping
+```
+The stopping.
+
+###### `F:IoT.DriverCore.TwinCATRx.ServiceStatus.Unknown`
+
+```csharp
+public static const IoT.DriverCore.TwinCATRx.ServiceStatus Unknown
+```
+The unknown.
+
+#### `T:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient`
+
+```csharp
+public class IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient
+```
+Maps logical CP.IoT tags onto an event-driven TwinCAT ADS client.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.#ctor(IoT.DriverCore.TwinCATRx.IRxTcAdsClient)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient(IoT.DriverCore.TwinCATRx.IRxTcAdsClient nativeClient)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient` class.
+
+- Parameter `nativeClient`: The composed ADS client.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.#ctor(IoT.DriverCore.TwinCATRx.IRxTcAdsClient,IoT.DriverCore.Core.ILogicalTagCatalog)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient(IoT.DriverCore.TwinCATRx.IRxTcAdsClient nativeClient, IoT.DriverCore.Core.ILogicalTagCatalog catalog)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient` class.
+
+- Parameter `nativeClient`: The composed ADS client.
+- Parameter `catalog`: The caller-owned catalog.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.#ctor(IoT.DriverCore.TwinCATRx.IRxTcAdsClient,IoT.DriverCore.Core.ILogicalTagCatalog,IoT.DriverCore.Core.LogicalTagSqliteStore)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient(IoT.DriverCore.TwinCATRx.IRxTcAdsClient nativeClient, IoT.DriverCore.Core.ILogicalTagCatalog catalog, IoT.DriverCore.Core.LogicalTagSqliteStore store)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient` class.
+
+- Parameter `nativeClient`: The composed ADS client.
+- Parameter `catalog`: The caller-owned catalog.
+- Parameter `store`: The SQLite store.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.#ctor(IoT.DriverCore.TwinCATRx.IRxTcAdsClient,IoT.DriverCore.Core.ILogicalTagCatalog,IoT.DriverCore.Core.LogicalTagSqliteStore,System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient(IoT.DriverCore.TwinCATRx.IRxTcAdsClient nativeClient, IoT.DriverCore.Core.ILogicalTagCatalog catalog, IoT.DriverCore.Core.LogicalTagSqliteStore store, System.TimeProvider timeProvider)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient` class.
+
+- Parameter `nativeClient`: The composed ADS client.
+- Parameter `catalog`: The caller-owned catalog.
+- Parameter `store`: The SQLite store.
+- Parameter `timeProvider`: The time provider.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.#ctor(IoT.DriverCore.TwinCATRx.IRxTcAdsClient,IoT.DriverCore.Core.ILogicalTagCatalog,System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient(IoT.DriverCore.TwinCATRx.IRxTcAdsClient nativeClient, IoT.DriverCore.Core.ILogicalTagCatalog catalog, System.TimeProvider timeProvider)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient` class.
+
+- Parameter `nativeClient`: The composed ADS client.
+- Parameter `catalog`: The caller-owned catalog.
+- Parameter `timeProvider`: The time provider.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.#ctor(IoT.DriverCore.TwinCATRx.IRxTcAdsClient,IoT.DriverCore.Core.LogicalTagSqliteStore)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient(IoT.DriverCore.TwinCATRx.IRxTcAdsClient nativeClient, IoT.DriverCore.Core.LogicalTagSqliteStore store)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient` class.
+
+- Parameter `nativeClient`: The composed ADS client.
+- Parameter `store`: The SQLite store.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.#ctor(IoT.DriverCore.TwinCATRx.IRxTcAdsClient,IoT.DriverCore.Core.LogicalTagSqliteStore,System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient(IoT.DriverCore.TwinCATRx.IRxTcAdsClient nativeClient, IoT.DriverCore.Core.LogicalTagSqliteStore store, System.TimeProvider timeProvider)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient` class.
+
+- Parameter `nativeClient`: The composed ADS client.
+- Parameter `store`: The SQLite store.
+- Parameter `timeProvider`: The time provider.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.#ctor(IoT.DriverCore.TwinCATRx.IRxTcAdsClient,System.TimeProvider)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient(IoT.DriverCore.TwinCATRx.IRxTcAdsClient nativeClient, System.TimeProvider timeProvider)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient` class.
+
+- Parameter `nativeClient`: The composed ADS client.
+- Parameter `timeProvider`: The time provider.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.CreateTag(IoT.DriverCore.Core.LogicalTag)`
+
+```csharp
+public IoT.DriverCore.Core.LogicalTag CreateTag(IoT.DriverCore.Core.LogicalTag tag)
+```
+Creates a tag from a complete shared tag definition and registers it.
+
+- Parameter `tag`: The complete shared tag definition.
+- Returns: The registered tag.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.CreateTag(System.String,System.String,System.String)`
+
+```csharp
+public IoT.DriverCore.Core.LogicalTag CreateTag(string name, string address, string dataType)
+```
+Creates and registers a logical TwinCAT tag.
+
+- Parameter `name`: The logical name.
+- Parameter `address`: The ADS address.
+- Parameter `dataType`: The logical data type.
+- Returns: The registered tag.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.DeleteGroupAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> DeleteGroupAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `name`: The `name` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<bool>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.DeleteTagAsync(System.String)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> DeleteTagAsync(string name)
+```
+Deletes a tag from SQLite and the live registry.
+
+- Parameter `name`: The logical tag name.
+- Returns: Whether an existing tag was deleted.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.DeleteTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> DeleteTagAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Deletes a tag from SQLite and the live registry.
+
+- Parameter `name`: The logical tag name.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: Whether an existing tag was deleted.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.Dispose`
+
+```csharp
+public void Dispose()
+```
+Releases registry-owned resources without disposing the composed ADS client.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.EditTagAsync(IoT.DriverCore.Core.LogicalTag)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> EditTagAsync(IoT.DriverCore.Core.LogicalTag tag)
+```
+Edits an existing SQLite tag and refreshes the live registry.
+
+- Parameter `tag`: The logical tag.
+- Returns: Whether an existing tag was edited.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.EditTagAsync(IoT.DriverCore.Core.LogicalTag,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<bool> EditTagAsync(IoT.DriverCore.Core.LogicalTag tag, System.Threading.CancellationToken cancellationToken)
+```
+Edits an existing SQLite tag and refreshes the live registry.
+
+- Parameter `tag`: The logical tag.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: Whether an existing tag was edited.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.ExportCsvAsync(System.IO.TextWriter)`
+
+```csharp
+public System.Threading.Tasks.Task ExportCsvAsync(System.IO.TextWriter writer)
+```
+Exports the live registry as CSV.
+
+- Parameter `writer`: The CSV writer.
+- Returns: The export operation.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.ExportCsvAsync(System.IO.TextWriter,System.Char,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task ExportCsvAsync(System.IO.TextWriter writer, char delimiter, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `writer`: The `writer` value.
+- Parameter `delimiter`: The `delimiter` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.ExportCsvAsync(System.IO.TextWriter,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task ExportCsvAsync(System.IO.TextWriter writer, System.Threading.CancellationToken cancellationToken)
+```
+Exports the live registry as CSV.
+
+- Parameter `writer`: The CSV writer.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The export operation.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.GetGroupAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.LogicalTagGroup> GetGroupAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `name`: The `name` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.Core.LogicalTagGroup>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.GetTagAsync(System.String)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.LogicalTag> GetTagAsync(string name)
+```
+Gets a persisted tag.
+
+- Parameter `name`: The logical tag name.
+- Returns: The persisted tag, or null.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.GetTagAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.LogicalTag> GetTagAsync(string name, System.Threading.CancellationToken cancellationToken)
+```
+Gets a persisted tag.
+
+- Parameter `name`: The logical tag name.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The persisted tag, or null.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.ImportCsvAsync(System.IO.TextReader)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> ImportCsvAsync(System.IO.TextReader reader)
+```
+Imports CSV definitions into the live registry.
+
+- Parameter `reader`: The CSV reader.
+- Returns: The imported tags.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.ImportCsvAsync(System.IO.TextReader,System.Boolean)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> ImportCsvAsync(System.IO.TextReader reader, bool replaceExisting)
+```
+Imports CSV definitions into the live registry.
+
+- Parameter `reader`: The CSV reader.
+- Parameter `replaceExisting`: Whether imported tags replace matching live tags.
+- Returns: The imported tags.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.ImportCsvAsync(System.IO.TextReader,System.Boolean,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> ImportCsvAsync(System.IO.TextReader reader, bool replaceExisting, System.Threading.CancellationToken cancellationToken)
+```
+Imports CSV definitions into the live registry.
+
+- Parameter `reader`: The CSV reader.
+- Parameter `replaceExisting`: Whether imported tags replace matching live tags.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The imported tags.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.ImportCsvAsync(System.IO.TextReader,System.Char,System.Boolean,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> ImportCsvAsync(System.IO.TextReader reader, char delimiter, bool replaceExisting, System.Threading.CancellationToken cancellationToken)
+```
+Imports CSV definitions into the live registry.
+
+- Parameter `reader`: The CSV reader.
+- Parameter `delimiter`: The CSV delimiter.
+- Parameter `replaceExisting`: Whether imported tags replace matching live tags.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The imported tags.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.ImportCsvAsync(System.IO.TextReader,System.Char,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> ImportCsvAsync(System.IO.TextReader reader, char delimiter, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `reader`: The `reader` value.
+- Parameter `delimiter`: The `delimiter` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.InitializeStoreAsync`
+
+```csharp
+public System.Threading.Tasks.Task InitializeStoreAsync()
+```
+Initializes the configured SQLite store.
+
+- Returns: The initialization operation.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.InitializeStoreAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task InitializeStoreAsync(System.Threading.CancellationToken cancellationToken)
+```
+Initializes the configured SQLite store.
+
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The initialization operation.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.ListGroupsAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTagGroup>> ListGroupsAsync(System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTagGroup>>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.ListTagsAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> ListTagsAsync(System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.LoadTagsAsync`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> LoadTagsAsync()
+```
+Dynamically loads persisted tags into the live registry.
+
+- Returns: The loaded tags.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.LoadTagsAsync(System.Boolean)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> LoadTagsAsync(bool replaceExisting)
+```
+Dynamically loads persisted tags into the live registry.
+
+- Parameter `replaceExisting`: Whether persisted tags replace matching live tags.
+- Returns: The loaded tags.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.LoadTagsAsync(System.Boolean,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> LoadTagsAsync(bool replaceExisting, System.Threading.CancellationToken cancellationToken)
+```
+Dynamically loads persisted tags into the live registry.
+
+- Parameter `replaceExisting`: Whether persisted tags replace matching live tags.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The loaded tags.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.LoadTagsAsync(System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>> LoadTagsAsync(System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.LogicalTag>>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.Observe(System.String)`
+
+```csharp
+public System.IObservable<IoT.DriverCore.Core.LogicalTagValue> Observe(string tagName)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Returns: A `System.IObservable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.ObserveAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue> ObserveAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.ObserveMany(System.Collections.Generic.IReadOnlyCollection`1{System.String})`
+
+```csharp
+public System.IObservable<IoT.DriverCore.Core.LogicalTagValue> ObserveMany(System.Collections.Generic.IReadOnlyCollection<string> tagNames)
+```
+Executes the `ObserveMany` operation.
+
+- Parameter `tagNames`: The `tagNames` value.
+- Returns: A `System.IObservable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.ObserveManyAsync(System.Collections.Generic.IReadOnlyCollection`1{System.String},System.Threading.CancellationToken)`
+
+```csharp
+public System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue> ObserveManyAsync(System.Collections.Generic.IReadOnlyCollection<string> tagNames, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ObserveManyAsync` operation.
+
+- Parameter `tagNames`: The `tagNames` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Collections.Generic.IAsyncEnumerable<IoT.DriverCore.Core.LogicalTagValue>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.ReadAsync(System.String,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>> ReadAsync(string tagName, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `tagName`: The `tagName` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.ReadManyAsync(System.Collections.Generic.IReadOnlyCollection`1{System.String},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>> ReadManyAsync(System.Collections.Generic.IReadOnlyCollection<string> tagNames, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `ReadManyAsync` operation.
+
+- Parameter `tagNames`: The `tagNames` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.RegisterTag(IoT.DriverCore.Core.LogicalTag)`
+
+```csharp
+public void RegisterTag(IoT.DriverCore.Core.LogicalTag tag)
+```
+Adds or replaces a logical tag in the live registry.
+
+- Parameter `tag`: The logical tag.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.RemoveTag(System.String)`
+
+```csharp
+public bool RemoveTag(string name)
+```
+Removes a logical tag from the live registry.
+
+- Parameter `name`: The logical tag name.
+- Returns: Whether the tag was removed.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.UpsertGroupAsync(IoT.DriverCore.Core.LogicalTagGroup,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task UpsertGroupAsync(IoT.DriverCore.Core.LogicalTagGroup group, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `group`: The `group` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.UpsertTagAsync(IoT.DriverCore.Core.LogicalTag)`
+
+```csharp
+public System.Threading.Tasks.Task UpsertTagAsync(IoT.DriverCore.Core.LogicalTag tag)
+```
+Upserts a tag in SQLite and the live registry.
+
+- Parameter `tag`: The logical tag.
+- Returns: The upsert operation.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.UpsertTagAsync(IoT.DriverCore.Core.LogicalTag,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task UpsertTagAsync(IoT.DriverCore.Core.LogicalTag tag, System.Threading.CancellationToken cancellationToken)
+```
+Upserts a tag in SQLite and the live registry.
+
+- Parameter `tag`: The logical tag.
+- Parameter `cancellationToken`: The cancellation token.
+- Returns: The upsert operation.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.WriteAsync(IoT.DriverCore.Core.LogicalTagValue,System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>> WriteAsync(IoT.DriverCore.Core.LogicalTagValue value, System.Threading.CancellationToken cancellationToken)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `value`: The `value` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.WriteManyAsync(System.Collections.Generic.IReadOnlyCollection`1{IoT.DriverCore.Core.LogicalTagValue},System.Threading.CancellationToken)`
+
+```csharp
+public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>> WriteManyAsync(System.Collections.Generic.IReadOnlyCollection<IoT.DriverCore.Core.LogicalTagValue> values, System.Threading.CancellationToken cancellationToken)
+```
+Executes the `WriteManyAsync` operation.
+
+- Parameter `values`: The `values` value.
+- Parameter `cancellationToken`: The `cancellationToken` value.
+- Returns: A `System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<IoT.DriverCore.Core.TagOperationResult<IoT.DriverCore.Core.LogicalTagValue>>>` result.
+
+###### `P:IoT.DriverCore.TwinCATRx.TwinCatLogicalTagClient.Catalog`
+
+```csharp
+public IoT.DriverCore.Core.ILogicalTagCatalog Catalog { get; }
+```
+Gets the logical tag catalog.
+
+- Value: The `Catalog` value.
+
+#### `T:IoT.DriverCore.TwinCATRx.TwinCatRxExtensions`
+
+```csharp
+public class IoT.DriverCore.TwinCATRx.TwinCatRxExtensions
+```
+Observable TwinCAT extensions.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatRxExtensions.CreateClone(CP.Collections.HashTableRx)`
+
+```csharp
+public static CP.Collections.HashTableRx CreateClone(CP.Collections.HashTableRx hashTable)
+```
+Clones the specified HashTableRx.
+
+- Parameter `hashTable`: The HashTableRx instance.
+- Returns: A HashTableRx.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatRxExtensions.CreateStruct(IoT.DriverCore.TwinCATRx.IRxTcAdsClient,System.String)`
+
+```csharp
+public static CP.Collections.HashTableRx CreateStruct(IoT.DriverCore.TwinCATRx.IRxTcAdsClient client, string variable)
+```
+Creates the structure.
+
+- Parameter `client`: The reactive TwinCAT client.
+- Parameter `variable`: The variable.
+- Returns: A HashTableRx with a link to the PLC.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatRxExtensions.ObserveAsyncObservable``1(IoT.DriverCore.TwinCATRx.IRxTcAdsClient,System.String,System.Func`2{System.Object,``0})`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<T> ObserveAsyncObservable<T>(IoT.DriverCore.TwinCATRx.IRxTcAdsClient client, string variable, System.Func<object, T> converter)
+```
+Executes the `ObserveAsyncObservable` operation.
+
+- Parameter `client`: The `client` value.
+- Parameter `variable`: The `variable` value.
+- Parameter `converter`: The `converter` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<T>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatRxExtensions.ObserveAsyncObservable``1(IoT.DriverCore.TwinCATRx.IRxTcAdsClient,System.String,System.String,System.Func`2{System.Object,``0})`
+
+```csharp
+public static ReactiveUI.Primitives.Async.IObservableAsync<T> ObserveAsyncObservable<T>(IoT.DriverCore.TwinCATRx.IRxTcAdsClient client, string variable, string id, System.Func<object, T> converter)
+```
+Executes the `ObserveAsyncObservable` operation.
+
+- Parameter `client`: The `client` value.
+- Parameter `variable`: The `variable` value.
+- Parameter `id`: The `id` value.
+- Parameter `converter`: The `converter` value.
+- Returns: A `ReactiveUI.Primitives.Async.IObservableAsync<T>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatRxExtensions.Observe``1(IoT.DriverCore.TwinCATRx.IRxTcAdsClient,System.String,System.Func`2{System.Object,``0})`
+
+```csharp
+public static System.IObservable<T> Observe<T>(IoT.DriverCore.TwinCATRx.IRxTcAdsClient client, string variable, System.Func<object, T> converter)
+```
+Executes the `Observe` operation.
+
+- Parameter `client`: The `client` value.
+- Parameter `variable`: The `variable` value.
+- Parameter `converter`: The `converter` value.
+- Returns: A `System.IObservable<T>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatRxExtensions.Observe``1(IoT.DriverCore.TwinCATRx.IRxTcAdsClient,System.String,System.String,System.Func`2{System.Object,``0})`
+
+```csharp
+public static System.IObservable<T> Observe<T>(IoT.DriverCore.TwinCATRx.IRxTcAdsClient client, string variable, string id, System.Func<object, T> converter)
+```
+Executes the `Observe` operation.
+
+- Parameter `client`: The `client` value.
+- Parameter `variable`: The `variable` value.
+- Parameter `id`: The `id` value.
+- Parameter `converter`: The `converter` value.
+- Returns: A `System.IObservable<T>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatRxExtensions.StructureReady(CP.Collections.HashTableRx)`
+
+```csharp
+public static System.IObservable<CP.Collections.HashTableRx> StructureReady(CP.Collections.HashTableRx hashTable)
+```
+Returns an observable that fires when the structure is ready.
+
+- Parameter `hashTable`: The HashTableRx instance.
+- Returns: An observable when values have been set.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatRxExtensions.WriteValues(CP.Collections.HashTableRx,System.Action`1{CP.Collections.HashTableRx})`
+
+```csharp
+public static bool WriteValues(CP.Collections.HashTableRx hashTable, System.Action<CP.Collections.HashTableRx> setValues)
+```
+Executes the `WriteValues` operation.
+
+- Parameter `hashTable`: The `hashTable` value.
+- Parameter `setValues`: The `setValues` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.TwinCatRxExtensions.WriteValuesAsync(CP.Collections.HashTableRx,System.Action`1{CP.Collections.HashTableRx},System.TimeSpan)`
+
+```csharp
+public static System.Threading.Tasks.Task<bool> WriteValuesAsync(CP.Collections.HashTableRx hashTable, System.Action<CP.Collections.HashTableRx> setValues, System.TimeSpan time)
+```
+Executes the `WriteValuesAsync` operation.
+
+- Parameter `hashTable`: The `hashTable` value.
+- Parameter `setValues`: The `setValues` value.
+- Parameter `time`: The `time` value.
+- Returns: A `System.Threading.Tasks.Task<bool>` result.
+
+### `TwinCATRx.Core`
+
+Exported public types: 13; declared public members: 97.
+
+#### `T:IoT.DriverCore.TwinCATRx.Core.CSharpLanguage`
+
+```csharp
+public class IoT.DriverCore.TwinCATRx.Core.CSharpLanguage
+```
+C Sharp Language.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CSharpLanguage.#ctor`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.Core.CSharpLanguage()
+```
+Initializes a new instance of `IoT.DriverCore.TwinCATRx.Core.CSharpLanguage`.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CSharpLanguage.CreateAssembly(System.String,System.String)`
+
+```csharp
+public static bool CreateAssembly(string code, string assemblyFileName)
+```
+Creates the assembly.
+
+- Parameter `code`: The code.
+- Parameter `assemblyFileName`: Name of the assembly file.
+- Returns: A bool.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CSharpLanguage.CreateLibraryCompilation(System.String,System.Boolean)`
+
+```csharp
+public Microsoft.CodeAnalysis.Compilation CreateLibraryCompilation(string assemblyName, bool enableOptimisations)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `assemblyName`: The `assemblyName` value.
+- Parameter `enableOptimisations`: The `enableOptimisations` value.
+- Returns: A `Microsoft.CodeAnalysis.Compilation` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CSharpLanguage.ParseText(System.String,Microsoft.CodeAnalysis.SourceCodeKind)`
+
+```csharp
+public Microsoft.CodeAnalysis.SyntaxTree ParseText(string code, Microsoft.CodeAnalysis.SourceCodeKind kind)
+```
+Inherits XML documentation from its implemented or overridden member.
+
+- Parameter `code`: The `code` value.
+- Parameter `kind`: The `kind` value.
+- Returns: A `Microsoft.CodeAnalysis.SyntaxTree` result.
+
+#### `T:IoT.DriverCore.TwinCATRx.Core.CodeGenerator`
+
+```csharp
+public class IoT.DriverCore.TwinCATRx.Core.CodeGenerator
+```
+Code Generator.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.#ctor`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.Core.CodeGenerator()
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.Core.CodeGenerator` class.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.#ctor(System.Action`1{System.Exception})`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.Core.CodeGenerator(System.Action<System.Exception> errorHandler)
+```
+Initializes a new instance of `IoT.DriverCore.TwinCATRx.Core.CodeGenerator`.
+
+- Parameter `errorHandler`: The `errorHandler` value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.CreateCSharpCode(IoT.DriverCore.TwinCATRx.Core.INodeEmulator)`
+
+```csharp
+public bool CreateCSharpCode(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN)
+```
+Creates a C# code file using the default TwinCAT version.
+
+- Parameter `selectedTN`: The selected node.
+- Returns: true when code was created.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.CreateCSharpCode(IoT.DriverCore.TwinCATRx.Core.INodeEmulator,System.Boolean)`
+
+```csharp
+public bool CreateCSharpCode(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN, bool isTwinCat3)
+```
+Creates a C# code file based on the selected node structure.
+
+- Parameter `selectedTN`: The selected tn.
+- Parameter `isTwinCat3`: Whether TwinCAT 3 packing should be used.
+- Returns: Result as a Boolean.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.CreateCSharpCode(IoT.DriverCore.TwinCATRx.Core.INodeEmulator,System.String)`
+
+```csharp
+public bool CreateCSharpCode(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN, string fileName)
+```
+Creates a C# code file using default generation settings.
+
+- Parameter `selectedTN`: The `selectedTN` value.
+- Parameter `fileName`: The `fileName` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.CreateCSharpCode(IoT.DriverCore.TwinCATRx.Core.INodeEmulator,System.String,System.Boolean)`
+
+```csharp
+public bool CreateCSharpCode(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN, string fileName, bool isTwinCat3)
+```
+Creates a C# code file using the default namespace.
+
+- Parameter `selectedTN`: The `selectedTN` value.
+- Parameter `fileName`: The `fileName` value.
+- Parameter `isTwinCat3`: The `isTwinCat3` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.CreateCSharpCode(IoT.DriverCore.TwinCATRx.Core.INodeEmulator,System.String,System.Boolean,System.String)`
+
+```csharp
+public bool CreateCSharpCode(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN, string fileName, bool isTwinCat3, string classNamespace)
+```
+Creates a C# code file based on the selected node structure.
+
+- Parameter `selectedTN`: The selected tn.
+- Parameter `fileName`: Name of the file.
+- Parameter `isTwinCat3`: if set to true [is twin cat3].
+- Parameter `classNamespace`: The class namespace.
+- Returns: Result as a Boolean.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.CreateCSharpCodeString(IoT.DriverCore.TwinCATRx.Core.INodeEmulator)`
+
+```csharp
+public string CreateCSharpCodeString(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN)
+```
+Creates a C# code string using default generation settings.
+
+- Parameter `selectedTN`: The selected node.
+- Returns: The generated code.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.CreateCSharpCodeString(IoT.DriverCore.TwinCATRx.Core.INodeEmulator,System.Boolean)`
+
+```csharp
+public string CreateCSharpCodeString(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN, bool isTwinCat3)
+```
+Creates a C# code string using the default namespace.
+
+- Parameter `selectedTN`: The `selectedTN` value.
+- Parameter `isTwinCat3`: The `isTwinCat3` value.
+- Returns: A `string` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.CreateCSharpCodeString(IoT.DriverCore.TwinCATRx.Core.INodeEmulator,System.Boolean,System.String)`
+
+```csharp
+public string CreateCSharpCodeString(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN, bool isTwinCat3, string classNamespace)
+```
+Creates the C# code string.
+
+- Parameter `selectedTN`: The selected tn.
+- Parameter `isTwinCat3`: if set to true [is twin cat3].
+- Parameter `classNamespace`: The class namespace.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.CreateDll(IoT.DriverCore.TwinCATRx.Core.INodeEmulator)`
+
+```csharp
+public bool CreateDll(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN)
+```
+Creates a DLL based on the selected node structure.
+
+- Parameter `selectedTN`: The selected tn.
+- Returns: Result as a Boolean.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.CreateDll(IoT.DriverCore.TwinCATRx.Core.INodeEmulator,System.Boolean)`
+
+```csharp
+public bool CreateDll(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN, bool isTwinCat3)
+```
+Creates a DLL based on the selected node structure.
+
+- Parameter `selectedTN`: The selected node.
+- Parameter `isTwinCat3`: Whether TwinCAT 3 packing should be used.
+- Returns: true when the DLL was created.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.CreateDll(IoT.DriverCore.TwinCATRx.Core.INodeEmulator,System.String)`
+
+```csharp
+public bool CreateDll(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN, string fileName)
+```
+Creates a DLL using default generation settings.
+
+- Parameter `selectedTN`: The `selectedTN` value.
+- Parameter `fileName`: The `fileName` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.CreateDll(IoT.DriverCore.TwinCATRx.Core.INodeEmulator,System.String,System.Boolean)`
+
+```csharp
+public bool CreateDll(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN, string fileName, bool isTwinCat3)
+```
+Creates a DLL using the default namespace.
+
+- Parameter `selectedTN`: The `selectedTN` value.
+- Parameter `fileName`: The `fileName` value.
+- Parameter `isTwinCat3`: The `isTwinCat3` value.
+- Returns: A `bool` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.CreateDll(IoT.DriverCore.TwinCATRx.Core.INodeEmulator,System.String,System.Boolean,System.String)`
+
+```csharp
+public bool CreateDll(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN, string fileName, bool isTwinCat3, string classNamespace)
+```
+Creates a DLL based on the selected node structure.
+
+- Parameter `selectedTN`: The selected tn.
+- Parameter `fileName`: Name of the file.
+- Parameter `isTwinCat3`: if set to true [is twincat3].
+- Parameter `classNamespace`: The class namespace.
+- Returns: Result as a Boolean.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.CreateDll(System.String,System.String)`
+
+```csharp
+public bool CreateDll(string sourceCode, string fileName)
+```
+Creates the DLL from raw source.
+
+- Parameter `sourceCode`: The C# source code.
+- Parameter `fileName`: Name of the file.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.Dispose`
+
+```csharp
+public void Dispose()
+```
+Performs application-defined tasks associated with freeing resources.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.LoadSymbols(System.Int32)`
+
+```csharp
+public System.Collections.Generic.HashSet<IoT.DriverCore.TwinCATRx.Core.INodeEmulator> LoadSymbols(int port)
+```
+Loads symbols from the specified PLC ADS port.
+
+- Parameter `port`: The port.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.LoadSymbols(System.String)`
+
+```csharp
+public System.Collections.Generic.HashSet<IoT.DriverCore.TwinCATRx.Core.INodeEmulator> LoadSymbols(string adsAddress)
+```
+Loads symbols from the specified PLC ADS address.
+
+- Parameter `adsAddress`: The ADS address.
+- Returns: HashSet(Of NodeEmulator).
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.LoadSymbols(System.String,System.Int32)`
+
+```csharp
+public System.Collections.Generic.HashSet<IoT.DriverCore.TwinCATRx.Core.INodeEmulator> LoadSymbols(string adsAddress, int port)
+```
+Loads symbols from the specified PLC ADS address and port.
+
+- Parameter `adsAddress`: The ADS address.
+- Parameter `port`: The port.
+- Returns: HashSet(Of NodeEmulator).
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.PLCToCSharpTypeConverter(System.String)`
+
+```csharp
+public static string PLCToCSharpTypeConverter(string plcType)
+```
+Converts a supported PLC scalar, string, or array type name to its CLR representation.
+
+- Parameter `plcType`: Type of the PLC.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.ReadSymbol(System.String,System.Int32,System.String,System.Type)`
+
+```csharp
+public object ReadSymbol(string adsAddress, int port, string variable, System.Type variableType)
+```
+Reads the symbol.
+
+- Parameter `adsAddress`: The ADS address.
+- Parameter `port`: The port.
+- Parameter `variable`: The variable.
+- Parameter `variableType`: Type of the variable.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.SearchSymbols(System.String)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.Core.INodeEmulator SearchSymbols(string symbolName)
+```
+Searches for the nearest matching symbol list element.
+
+- Parameter `symbolName`: Name of the symbol.
+- Returns: NodeEmulator.
+
+###### `P:IoT.DriverCore.TwinCATRx.Core.CodeGenerator.SymbolList`
+
+```csharp
+public System.Collections.Generic.HashSet<IoT.DriverCore.TwinCATRx.Core.INodeEmulator> SymbolList { get; }
+```
+Gets the symbol list.
+
+- Value: The symbol list.
+
+#### `T:IoT.DriverCore.TwinCATRx.Core.DirectoryInfoExtensions`
+
+```csharp
+public class IoT.DriverCore.TwinCATRx.Core.DirectoryInfoExtensions
+```
+Provides filtered file enumeration extensions for `T:System.IO.DirectoryInfo` .
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.DirectoryInfoExtensions.GetFilesWhere(System.IO.DirectoryInfo,System.Func`2{System.IO.FileInfo,System.Boolean})`
+
+```csharp
+public static System.IO.FileInfo[] GetFilesWhere(System.IO.DirectoryInfo directory, System.Func<System.IO.FileInfo, bool> predicate)
+```
+Executes the `GetFilesWhere` operation.
+
+- Parameter `directory`: The `directory` value.
+- Parameter `predicate`: The `predicate` value.
+- Returns: A `System.IO.FileInfo[]` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.DirectoryInfoExtensions.GetFilesWhere(System.IO.DirectoryInfo,System.String,System.Func`2{System.IO.FileInfo,System.Boolean})`
+
+```csharp
+public static System.IO.FileInfo[] GetFilesWhere(System.IO.DirectoryInfo directory, string searchPattern, System.Func<System.IO.FileInfo, bool> predicate)
+```
+Executes the `GetFilesWhere` operation.
+
+- Parameter `directory`: The `directory` value.
+- Parameter `searchPattern`: The `searchPattern` value.
+- Parameter `predicate`: The `predicate` value.
+- Returns: A `System.IO.FileInfo[]` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.DirectoryInfoExtensions.GetFilesWhere(System.IO.DirectoryInfo,System.String,System.IO.SearchOption,System.Func`2{System.IO.FileInfo,System.Boolean})`
+
+```csharp
+public static System.IO.FileInfo[] GetFilesWhere(System.IO.DirectoryInfo directory, string searchPattern, System.IO.SearchOption searchOption, System.Func<System.IO.FileInfo, bool> predicate)
+```
+Executes the `GetFilesWhere` operation.
+
+- Parameter `directory`: The `directory` value.
+- Parameter `searchPattern`: The `searchPattern` value.
+- Parameter `searchOption`: The `searchOption` value.
+- Parameter `predicate`: The `predicate` value.
+- Returns: A `System.IO.FileInfo[]` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.DirectoryInfoExtensions.GetFilesWhere(System.IO.DirectoryInfo,System.String[],System.Func`2{System.IO.FileInfo,System.Boolean})`
+
+```csharp
+public static System.IO.FileInfo[] GetFilesWhere(System.IO.DirectoryInfo directory, string[] searchPatterns, System.Func<System.IO.FileInfo, bool> predicate)
+```
+Executes the `GetFilesWhere` operation.
+
+- Parameter `directory`: The `directory` value.
+- Parameter `searchPatterns`: The `searchPatterns` value.
+- Parameter `predicate`: The `predicate` value.
+- Returns: A `System.IO.FileInfo[]` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.DirectoryInfoExtensions.GetFilesWhere(System.IO.DirectoryInfo,System.String[],System.IO.SearchOption,System.Func`2{System.IO.FileInfo,System.Boolean})`
+
+```csharp
+public static System.IO.FileInfo[] GetFilesWhere(System.IO.DirectoryInfo directory, string[] searchPatterns, System.IO.SearchOption searchOption, System.Func<System.IO.FileInfo, bool> predicate)
+```
+Executes the `GetFilesWhere` operation.
+
+- Parameter `directory`: The `directory` value.
+- Parameter `searchPatterns`: The `searchPatterns` value.
+- Parameter `searchOption`: The `searchOption` value.
+- Parameter `predicate`: The `predicate` value.
+- Returns: A `System.IO.FileInfo[]` result.
+
+#### `T:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator`
+
+```csharp
+public interface IoT.DriverCore.TwinCATRx.Core.ICodeGenerator
+```
+Interface for Code Generator.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator.CreateCSharpCode(IoT.DriverCore.TwinCATRx.Core.INodeEmulator)`
+
+```csharp
+public bool CreateCSharpCode(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN)
+```
+Creates the c sharp code.
+
+- Parameter `selectedTN`: The selected tn.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator.CreateCSharpCode(IoT.DriverCore.TwinCATRx.Core.INodeEmulator,System.Boolean)`
+
+```csharp
+public bool CreateCSharpCode(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN, bool isTwinCat3)
+```
+Creates the c sharp code.
+
+- Parameter `selectedTN`: The selected tn.
+- Parameter `isTwinCat3`: Whether TwinCAT 3 conventions are used.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator.CreateCSharpCode(IoT.DriverCore.TwinCATRx.Core.INodeEmulator,System.String)`
+
+```csharp
+public bool CreateCSharpCode(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN, string fileName)
+```
+Creates the c sharp code.
+
+- Parameter `selectedTN`: The selected tn.
+- Parameter `fileName`: Name of the file.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator.CreateCSharpCode(IoT.DriverCore.TwinCATRx.Core.INodeEmulator,System.String,System.Boolean)`
+
+```csharp
+public bool CreateCSharpCode(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN, string fileName, bool isTwinCat3)
+```
+Creates the c sharp code.
+
+- Parameter `selectedTN`: The selected tn.
+- Parameter `fileName`: Name of the file.
+- Parameter `isTwinCat3`: if set to true [is twin cat3].
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator.CreateCSharpCode(IoT.DriverCore.TwinCATRx.Core.INodeEmulator,System.String,System.Boolean,System.String)`
+
+```csharp
+public bool CreateCSharpCode(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN, string fileName, bool isTwinCat3, string classNamespace)
+```
+Creates the c sharp code.
+
+- Parameter `selectedTN`: The selected tn.
+- Parameter `fileName`: Name of the file.
+- Parameter `isTwinCat3`: Whether TwinCAT 3 conventions are used.
+- Parameter `classNamespace`: The namespace for generated types.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator.CreateCSharpCodeString(IoT.DriverCore.TwinCATRx.Core.INodeEmulator)`
+
+```csharp
+public string CreateCSharpCodeString(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN)
+```
+Creates the c sharp code string.
+
+- Parameter `selectedTN`: The selected tn.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator.CreateCSharpCodeString(IoT.DriverCore.TwinCATRx.Core.INodeEmulator,System.Boolean)`
+
+```csharp
+public string CreateCSharpCodeString(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN, bool isTwinCat3)
+```
+Creates the c sharp code string.
+
+- Parameter `selectedTN`: The selected tn.
+- Parameter `isTwinCat3`: if set to true [is twin cat3].
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator.CreateCSharpCodeString(IoT.DriverCore.TwinCATRx.Core.INodeEmulator,System.Boolean,System.String)`
+
+```csharp
+public string CreateCSharpCodeString(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN, bool isTwinCat3, string classNamespace)
+```
+Creates the c sharp code string.
+
+- Parameter `selectedTN`: The selected tn.
+- Parameter `isTwinCat3`: Whether TwinCAT 3 conventions are used.
+- Parameter `classNamespace`: The namespace for generated types.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator.CreateDll(IoT.DriverCore.TwinCATRx.Core.INodeEmulator)`
+
+```csharp
+public bool CreateDll(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN)
+```
+Creates the DLL.
+
+- Parameter `selectedTN`: The selected tn.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator.CreateDll(IoT.DriverCore.TwinCATRx.Core.INodeEmulator,System.Boolean)`
+
+```csharp
+public bool CreateDll(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN, bool isTwinCat3)
+```
+Creates the DLL.
+
+- Parameter `selectedTN`: The selected tn.
+- Parameter `isTwinCat3`: Whether TwinCAT 3 conventions are used.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator.CreateDll(IoT.DriverCore.TwinCATRx.Core.INodeEmulator,System.String)`
+
+```csharp
+public bool CreateDll(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN, string fileName)
+```
+Creates the DLL.
+
+- Parameter `selectedTN`: The selected tn.
+- Parameter `fileName`: Name of the file.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator.CreateDll(IoT.DriverCore.TwinCATRx.Core.INodeEmulator,System.String,System.Boolean)`
+
+```csharp
+public bool CreateDll(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN, string fileName, bool isTwinCat3)
+```
+Creates the DLL.
+
+- Parameter `selectedTN`: The selected tn.
+- Parameter `fileName`: Name of the file.
+- Parameter `isTwinCat3`: if set to true [is twin cat3].
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator.CreateDll(IoT.DriverCore.TwinCATRx.Core.INodeEmulator,System.String,System.Boolean,System.String)`
+
+```csharp
+public bool CreateDll(IoT.DriverCore.TwinCATRx.Core.INodeEmulator selectedTN, string fileName, bool isTwinCat3, string classNamespace)
+```
+Creates the DLL.
+
+- Parameter `selectedTN`: The selected tn.
+- Parameter `fileName`: Name of the file.
+- Parameter `isTwinCat3`: Whether TwinCAT 3 conventions are used.
+- Parameter `classNamespace`: The namespace for generated types.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator.CreateDll(System.String,System.String)`
+
+```csharp
+public bool CreateDll(string sourceCode, string fileName)
+```
+Creates the DLL.
+
+- Parameter `sourceCode`: The C# source code.
+- Parameter `fileName`: Name of the file.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator.LoadSymbols(System.Int32)`
+
+```csharp
+public System.Collections.Generic.HashSet<IoT.DriverCore.TwinCATRx.Core.INodeEmulator> LoadSymbols(int port)
+```
+Loads the symbols.
+
+- Parameter `port`: The port.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator.LoadSymbols(System.String)`
+
+```csharp
+public System.Collections.Generic.HashSet<IoT.DriverCore.TwinCATRx.Core.INodeEmulator> LoadSymbols(string adsAddress)
+```
+Loads the symbols.
+
+- Parameter `adsAddress`: The ADS address.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator.LoadSymbols(System.String,System.Int32)`
+
+```csharp
+public System.Collections.Generic.HashSet<IoT.DriverCore.TwinCATRx.Core.INodeEmulator> LoadSymbols(string adsAddress, int port)
+```
+Loads the symbols.
+
+- Parameter `adsAddress`: The ADS address.
+- Parameter `port`: The port.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator.ReadSymbol(System.String,System.Int32,System.String,System.Type)`
+
+```csharp
+public object ReadSymbol(string adsAddress, int port, string variable, System.Type variableType)
+```
+Reads the symbol.
+
+- Parameter `adsAddress`: The ADS address.
+- Parameter `port`: The port.
+- Parameter `variable`: The variable.
+- Parameter `variableType`: Type of the variable.
+- Returns: A Value.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator.SearchSymbols(System.String)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.Core.INodeEmulator SearchSymbols(string symbolName)
+```
+Searches the symbols.
+
+- Parameter `symbolName`: Name of the symbol.
+- Returns: A Value.
+
+###### `P:IoT.DriverCore.TwinCATRx.Core.ICodeGenerator.SymbolList`
+
+```csharp
+public System.Collections.Generic.HashSet<IoT.DriverCore.TwinCATRx.Core.INodeEmulator> SymbolList { get; }
+```
+Gets the symbol list.
+
+- Value: The symbol list.
+
+#### `T:IoT.DriverCore.TwinCATRx.Core.ILanguageService`
+
+```csharp
+public interface IoT.DriverCore.TwinCATRx.Core.ILanguageService
+```
+I Language Service.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ILanguageService.CreateLibraryCompilation(System.String,System.Boolean)`
+
+```csharp
+public Microsoft.CodeAnalysis.Compilation CreateLibraryCompilation(string assemblyName, bool enableOptimisations)
+```
+Creates the library compilation.
+
+- Parameter `assemblyName`: Name of the assembly.
+- Parameter `enableOptimisations`: if set to true [enable optimisations].
+- Returns: A Compilation.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ILanguageService.ParseText(System.String,Microsoft.CodeAnalysis.SourceCodeKind)`
+
+```csharp
+public Microsoft.CodeAnalysis.SyntaxTree ParseText(string code, Microsoft.CodeAnalysis.SourceCodeKind kind)
+```
+Parses the text.
+
+- Parameter `code`: The code.
+- Parameter `kind`: The kind.
+- Returns: A SyntaxTree.
+
+#### `T:IoT.DriverCore.TwinCATRx.Core.INodeEmulator`
+
+```csharp
+public interface IoT.DriverCore.TwinCATRx.Core.INodeEmulator
+```
+Interface for Node Emulator.
+
+##### Declared public members
+
+###### `P:IoT.DriverCore.TwinCATRx.Core.INodeEmulator.Nodes`
+
+```csharp
+public System.Collections.Generic.HashSet<IoT.DriverCore.TwinCATRx.Core.INodeEmulator> Nodes { get; }
+```
+Gets the nodes.
+
+- Value: The nodes.
+
+###### `P:IoT.DriverCore.TwinCATRx.Core.INodeEmulator.Tag`
+
+```csharp
+public object Tag { get; set; }
+```
+Gets or sets the tag.
+
+- Value: The tag.
+
+###### `P:IoT.DriverCore.TwinCATRx.Core.INodeEmulator.Text`
+
+```csharp
+public string Text { get; set; }
+```
+Gets or sets the text.
+
+- Value: The text.
+
+#### `T:IoT.DriverCore.TwinCATRx.Core.INotification`
+
+```csharp
+public interface IoT.DriverCore.TwinCATRx.Core.INotification
+```
+Interface for Notification.
+
+##### Declared public members
+
+###### `P:IoT.DriverCore.TwinCATRx.Core.INotification.ArraySize`
+
+```csharp
+public int ArraySize { get; }
+```
+Gets the size of the array.
+
+- Value: The size of the array.
+
+###### `P:IoT.DriverCore.TwinCATRx.Core.INotification.UpdateRate`
+
+```csharp
+public int UpdateRate { get; }
+```
+Gets the update rate.
+
+- Value: The update rate.
+
+###### `P:IoT.DriverCore.TwinCATRx.Core.INotification.Variable`
+
+```csharp
+public string Variable { get; }
+```
+Gets the variable.
+
+- Value: The variable.
+
+#### `T:IoT.DriverCore.TwinCATRx.Core.ISettings`
+
+```csharp
+public interface IoT.DriverCore.TwinCATRx.Core.ISettings
+```
+Interface for engine settings.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.ISettings.Defaults``1(``0)`
+
+```csharp
+public T Defaults<T>(T defaultSettings)
+```
+Gets or sets Default settings.
+
+- Parameter `defaultSettings`: The settings instance that establishes the requested type.
+- Returns: Default values of type T.
+
+###### `P:IoT.DriverCore.TwinCATRx.Core.ISettings.AdsAddress`
+
+```csharp
+public string AdsAddress { get; set; }
+```
+Gets or sets the ads address.
+
+- Value: The ads address.
+
+###### `P:IoT.DriverCore.TwinCATRx.Core.ISettings.Notifications`
+
+```csharp
+public System.Collections.Generic.IList<IoT.DriverCore.TwinCATRx.Core.INotification> Notifications { get; }
+```
+Gets or sets Notifications of this Engine.
+
+- Value: The `Notifications` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.Core.ISettings.Port`
+
+```csharp
+public int Port { get; set; }
+```
+Gets or sets the port.
+
+- Value: The port.
+
+###### `P:IoT.DriverCore.TwinCATRx.Core.ISettings.SettingsId`
+
+```csharp
+public string SettingsId { get; set; }
+```
+Gets or sets System Identifier.
+
+- Value: The `SettingsId` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.Core.ISettings.WriteVariables`
+
+```csharp
+public System.Collections.Generic.IList<IoT.DriverCore.TwinCATRx.Core.IWriteVariable> WriteVariables { get; }
+```
+Gets or sets Write variables to this Engine.
+
+- Value: The `WriteVariables` value.
+
+#### `T:IoT.DriverCore.TwinCATRx.Core.IWriteVariable`
+
+```csharp
+public interface IoT.DriverCore.TwinCATRx.Core.IWriteVariable
+```
+Interface for Write Variable.
+
+##### Declared public members
+
+###### `P:IoT.DriverCore.TwinCATRx.Core.IWriteVariable.ArraySize`
+
+```csharp
+public int ArraySize { get; }
+```
+Gets the size of the array.
+
+- Value: The size of the array.
+
+###### `P:IoT.DriverCore.TwinCATRx.Core.IWriteVariable.Variable`
+
+```csharp
+public string Variable { get; }
+```
+Gets the variable.
+
+- Value: The variable.
+
+#### `T:IoT.DriverCore.TwinCATRx.Core.Settings`
+
+```csharp
+public class IoT.DriverCore.TwinCATRx.Core.Settings
+```
+Base settings for Engine Settings file.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.Settings.#ctor`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.Core.Settings()
+```
+Initializes a new instance of `IoT.DriverCore.TwinCATRx.Core.Settings`.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.Settings.Defaults``1(``0)`
+
+```csharp
+public T Defaults<T>(T defaultSettings)
+```
+Creates default settings when no persisted file exists.
+
+- Parameter `defaultSettings`: The settings instance that establishes the requested type.
+- Returns: The default settings.
+
+###### `P:IoT.DriverCore.TwinCATRx.Core.Settings.AdsAddress`
+
+```csharp
+public string AdsAddress { get; set; }
+```
+Gets or sets the Ads Address.
+
+- Value: The `AdsAddress` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.Core.Settings.Notifications`
+
+```csharp
+public System.Collections.Generic.List<IoT.DriverCore.TwinCATRx.Core.INotification> Notifications { get; set; }
+```
+Gets or sets Notifications of this Engine.
+
+- Value: The `Notifications` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.Core.Settings.Port`
+
+```csharp
+public int Port { get; set; }
+```
+Gets or sets the Port of the PLC to connect to.
+
+- Value: The `Port` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.Core.Settings.SettingsId`
+
+```csharp
+public string SettingsId { get; set; }
+```
+Gets or sets System Identifier.
+
+- Value: The `SettingsId` value.
+
+###### `P:IoT.DriverCore.TwinCATRx.Core.Settings.WriteVariables`
+
+```csharp
+public System.Collections.Generic.List<IoT.DriverCore.TwinCATRx.Core.IWriteVariable> WriteVariables { get; set; }
+```
+Gets or sets Write variables to this Engine.
+
+- Value: The `WriteVariables` value.
+
+#### `T:IoT.DriverCore.TwinCATRx.Core.SimpleTypeException`
+
+```csharp
+public class IoT.DriverCore.TwinCATRx.Core.SimpleTypeException
+```
+Exception thrown when a simple type is not supported.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.SimpleTypeException.#ctor`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.Core.SimpleTypeException()
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.Core.SimpleTypeException` class.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.SimpleTypeException.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.Core.SimpleTypeException(string message)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.Core.SimpleTypeException` class.
+
+- Parameter `message`: The message that describes the error.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.SimpleTypeException.#ctor(System.String,System.Exception)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.Core.SimpleTypeException(string message, System.Exception innerException)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.Core.SimpleTypeException` class.
+
+- Parameter `message`: The error message that explains the reason for the exception.
+- Parameter `innerException`: The exception that caused this exception, or null when no inner exception is specified.
+
+#### `T:IoT.DriverCore.TwinCATRx.Core.TwinCatRxExtensions`
+
+```csharp
+public class IoT.DriverCore.TwinCATRx.Core.TwinCatRxExtensions
+```
+Observable TwinCAT extensions.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.TwinCatRxExtensions.AddNotification(IoT.DriverCore.TwinCATRx.Core.ISettings,System.String)`
+
+```csharp
+public static void AddNotification(IoT.DriverCore.TwinCATRx.Core.ISettings settings, string variableName)
+```
+Adds a notification variable to the settings.
+
+- Parameter `settings`: The TwinCAT settings.
+- Parameter `variableName`: The PLC variable name.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.TwinCatRxExtensions.AddNotification(IoT.DriverCore.TwinCATRx.Core.ISettings,System.String,System.Int32)`
+
+```csharp
+public static void AddNotification(IoT.DriverCore.TwinCATRx.Core.ISettings settings, string variableName, int cycleTime)
+```
+Adds a notification variable to the settings.
+
+- Parameter `settings`: The TwinCAT settings.
+- Parameter `variableName`: The PLC variable name.
+- Parameter `cycleTime`: The polling cycle time.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.TwinCatRxExtensions.AddNotification(IoT.DriverCore.TwinCATRx.Core.ISettings,System.String,System.Int32,System.Int32)`
+
+```csharp
+public static void AddNotification(IoT.DriverCore.TwinCATRx.Core.ISettings settings, string variableName, int cycleTime, int arraySize)
+```
+Adds a notification variable to the settings.
+
+- Parameter `settings`: The TwinCAT settings.
+- Parameter `variableName`: The PLC variable name.
+- Parameter `cycleTime`: The polling cycle time.
+- Parameter `arraySize`: The array size.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.TwinCatRxExtensions.AddWriteVariable(IoT.DriverCore.TwinCATRx.Core.ISettings,System.String)`
+
+```csharp
+public static void AddWriteVariable(IoT.DriverCore.TwinCATRx.Core.ISettings settings, string variableName)
+```
+Adds a write variable to the settings.
+
+- Parameter `settings`: The TwinCAT settings.
+- Parameter `variableName`: The PLC variable name.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.TwinCatRxExtensions.AddWriteVariable(IoT.DriverCore.TwinCATRx.Core.ISettings,System.String,System.Int32)`
+
+```csharp
+public static void AddWriteVariable(IoT.DriverCore.TwinCATRx.Core.ISettings settings, string variableName, int arraySize)
+```
+Adds a write variable to the settings.
+
+- Parameter `settings`: The TwinCAT settings.
+- Parameter `variableName`: The PLC variable name.
+- Parameter `arraySize`: The array size.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.TwinCatRxExtensions.AdsStateChangedObserver(TwinCAT.Ads.AdsClient)`
+
+```csharp
+public static System.IObservable<TwinCAT.Ads.AdsStateChangedEventArgs> AdsStateChangedObserver(TwinCAT.Ads.AdsClient client)
+```
+Observes ADS state changed events.
+
+- Parameter `client`: The ADS client.
+- Returns: The ADS state changed observable sequence.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.TwinCatRxExtensions.AdsStateObserver(TwinCAT.Ads.AdsClient)`
+
+```csharp
+public static System.IObservable<TwinCAT.Ads.StateInfo> AdsStateObserver(TwinCAT.Ads.AdsClient client)
+```
+Polls ADS state from the client.
+
+- Parameter `client`: The ADS client.
+- Returns: The ADS state observable sequence.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.TwinCatRxExtensions.AssemblyLoad(System.String)`
+
+```csharp
+public static System.Reflection.Assembly AssemblyLoad(string dllFullName)
+```
+Loads an assembly from a DLL file path.
+
+- Parameter `dllFullName`: The full DLL path.
+- Returns: The loaded assembly.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.TwinCatRxExtensions.GetType(System.String,System.String)`
+
+```csharp
+public static System.Type GetType(string dllFullName, string engineType)
+```
+Gets a type from an assembly file.
+
+- Parameter `dllFullName`: The full DLL path.
+- Parameter `engineType`: The type name.
+- Returns: The resolved type.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.TwinCatRxExtensions.OnErrorRetry``1(System.IObservable`1{``0})`
+
+```csharp
+public static System.IObservable<TSource> OnErrorRetry<TSource>(System.IObservable<TSource> source)
+```
+Executes the `OnErrorRetry` operation.
+
+- Parameter `source`: The `source` value.
+- Returns: A `System.IObservable<TSource>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.TwinCatRxExtensions.OnErrorRetry``2(System.IObservable`1{``0},System.Action`1{``1})`
+
+```csharp
+public static System.IObservable<TSource> OnErrorRetry<TSource, TException>(System.IObservable<TSource> source, System.Action<TException> onError)
+```
+Executes the `OnErrorRetry` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `onError`: The `onError` value.
+- Returns: A `System.IObservable<TSource>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.TwinCatRxExtensions.OnErrorRetry``2(System.IObservable`1{``0},System.Action`1{``1},System.Int32)`
+
+```csharp
+public static System.IObservable<TSource> OnErrorRetry<TSource, TException>(System.IObservable<TSource> source, System.Action<TException> onError, int retryCount)
+```
+Executes the `OnErrorRetry` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `onError`: The `onError` value.
+- Parameter `retryCount`: The `retryCount` value.
+- Returns: A `System.IObservable<TSource>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.TwinCatRxExtensions.OnErrorRetry``2(System.IObservable`1{``0},System.Action`1{``1},System.Int32,System.TimeSpan)`
+
+```csharp
+public static System.IObservable<TSource> OnErrorRetry<TSource, TException>(System.IObservable<TSource> source, System.Action<TException> onError, int retryCount, System.TimeSpan delay)
+```
+Executes the `OnErrorRetry` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `onError`: The `onError` value.
+- Parameter `retryCount`: The `retryCount` value.
+- Parameter `delay`: The `delay` value.
+- Returns: A `System.IObservable<TSource>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.TwinCatRxExtensions.OnErrorRetry``2(System.IObservable`1{``0},System.Action`1{``1},System.Int32,System.TimeSpan,ReactiveUI.Primitives.Concurrency.ISequencer)`
+
+```csharp
+public static System.IObservable<TSource> OnErrorRetry<TSource, TException>(System.IObservable<TSource> source, System.Action<TException> onError, int retryCount, System.TimeSpan delay, ReactiveUI.Primitives.Concurrency.ISequencer delaySequencer)
+```
+Executes the `OnErrorRetry` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `onError`: The `onError` value.
+- Parameter `retryCount`: The `retryCount` value.
+- Parameter `delay`: The `delay` value.
+- Parameter `delaySequencer`: The `delaySequencer` value.
+- Returns: A `System.IObservable<TSource>` result.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.TwinCatRxExtensions.OnErrorRetry``2(System.IObservable`1{``0},System.Action`1{``1},System.TimeSpan)`
+
+```csharp
+public static System.IObservable<TSource> OnErrorRetry<TSource, TException>(System.IObservable<TSource> source, System.Action<TException> onError, System.TimeSpan delay)
+```
+Executes the `OnErrorRetry` operation.
+
+- Parameter `source`: The `source` value.
+- Parameter `onError`: The `onError` value.
+- Parameter `delay`: The `delay` value.
+- Returns: A `System.IObservable<TSource>` result.
+
+#### `T:IoT.DriverCore.TwinCATRx.Core.UnsuportedTypeException`
+
+```csharp
+public class IoT.DriverCore.TwinCATRx.Core.UnsuportedTypeException
+```
+Exception thrown when a simple type is not supported.
+
+##### Declared public members
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.UnsuportedTypeException.#ctor`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.Core.UnsuportedTypeException()
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.Core.UnsuportedTypeException` class.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.UnsuportedTypeException.#ctor(System.String)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.Core.UnsuportedTypeException(string message)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.Core.UnsuportedTypeException` class.
+
+- Parameter `message`: The message that describes the error.
+
+###### `M:IoT.DriverCore.TwinCATRx.Core.UnsuportedTypeException.#ctor(System.String,System.Exception)`
+
+```csharp
+public IoT.DriverCore.TwinCATRx.Core.UnsuportedTypeException(string message, System.Exception innerException)
+```
+Initializes a new instance of the `T:IoT.DriverCore.TwinCATRx.Core.UnsuportedTypeException` class.
+
+- Parameter `message`: The error message that explains the reason for the exception.
+- Parameter `innerException`: The exception that caused this exception, or null when no inner exception is specified.
+
+<!-- END GENERATED PUBLIC API -->

--- a/skills/ab-plc-rx/SKILL.md
+++ b/skills/ab-plc-rx/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: ab-plc-rx
+description: Implement, review, or troubleshoot reactive Allen-Bradley PLC access with ABPlcRx. Use for libplctag tag registration, scanning, reads, writes, observables, simulator tests, and generated PLC stream models.
+---
+
+# ABPlcRx
+
+Use `IoT.DriverCore.ABPlcRx` for the default package surface. Register each physical tag with an explicit logical variable, group, and generic type witness before reading, writing, or subscribing.
+
+Treat writes as safety-critical. Validate addressing, route, data type, bit index, and operational interlocks against a non-production controller. Use `short` plus a 0–15 bit index for SLC/PLC-5 word bits; do not apply word-bit access to a native boolean tag.
+
+Manage client and subscription lifetimes explicitly. Use `AutoWriteValue = false` with `Write` for deliberate staged writes; inspect `PlcTagResult.StatusCode`, `PlcTagStatus.DecodeError`, and `ObserveErrors` rather than ignoring failures. Prefer `ReadManyAsync`, `WriteManyAsync`, or grouped scans for multi-tag work.
+
+Use `ABPlcSimulator` to test registrations, values, reconnect behavior, and injected faults without hardware. For constructor, API, and source-generator details, read the co-packaged `../../README.md`; in a repository checkout use `packagereadme/ABPlcRx/README.md`.
+
+`ABPlcRx` and `ABPlcRx.Reactive` already embed the matching source generator. Install `ABPlcRx.Generators` only when the analyzer must be pinned or managed independently, and never load a second generator version alongside the embedded analyzer.

--- a/skills/mitsubishi-rx/SKILL.md
+++ b/skills/mitsubishi-rx/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: mitsubishi-rx
+description: Implement, review, or document Mitsubishi MC Protocol and SLMP integrations using MitsubishiRx or MitsubishiRx.Reactive. Use when configuring Mitsubishi PLC transports, direct devices, tags, polling, write pipelines, serial frames, or simulator-backed tests.
+---
+
+# MitsubishiRx
+
+Before changing an integration, read the co-packaged `../../README.md`; in a repository checkout use `packagereadme/MitsubishiRx/README.md`.
+
+- Import `IoT.DriverCore.MitsubishiRx` or the `.Reactive` namespace that matches the selected package; never mix both surfaces casually.
+- Both runtime packages carry the analyzer, but the current generator emits the base `IoT.DriverCore.MitsubishiRx` surface and requires the base `MitsubishiRx` runtime. Install `MitsubishiRx.Generators` only alongside that base runtime when the analyzer must be versioned independently; use handwritten APIs in a `.Reactive`-only project and never load duplicate analyzer versions.
+- Construct `MitsubishiRx` with `MitsubishiClientOptions`, an optional `IMitsubishiTransport`, and an optional scheduler. Check `Responce.IsSucceed` before reading `Value`.
+- Match frame, data code, transport, route, serial format, and X/Y notation to the real PLC/module configuration. Require `MitsubishiSerialOptions` for serial transport.
+- Use cancellation tokens, dispose clients/subscriptions, batch contiguous reads, and serialize or coalesce writes.
+- Treat remote control, passwords, memory, raw commands, and writes as safety-sensitive; require explicit interlocks and audit evidence.
+- Validate tag databases and preview diffs before rollout. Use `MitsubishiSimulatorTransport` / `MitsubishiSimulatorMemory` for deterministic tests.
+- For generated clients, define and validate the supported Mitsubishi attributes, build once to inspect the generated surface, then exercise generated reads, writes, and observations against a simulator before connecting to a PLC.
+- Inspect `src/MitsubishiRx` before describing an API; shared reactive source changes namespaces under `REACTIVE_SHIM`.

--- a/skills/modbus-rx/SKILL.md
+++ b/skills/modbus-rx/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: modbus-rx
+description: Implement, review, or document Modbus TCP, UDP, RTU, ASCII, server, simulation, logical-tag, or observable integrations using ModbusRx or ModbusRx.Reactive.
+---
+
+# ModbusRx
+
+Before changing an integration, read the co-packaged `../../README.md`; in a repository checkout use `packagereadme/ModbusRx/README.md`.
+
+- Import `IoT.DriverCore.ModbusRx` or its `.Reactive` counterpart to match the selected package.
+- Install `ModbusRx.Generators` alongside the selected runtime package when attribute-driven register maps are required; the runtime packages do not embed this analyzer.
+- Create masters through `ModbusIpMaster.CreateIp` or `ModbusSerialMaster.CreateRtu` / `CreateAscii`; match endpoint and serial settings to the device.
+- Use zero-based API addresses, correct unit IDs, and protocol limits: 2,000 bits, 125 read registers, 1,968 coils, 123 write registers, and 121 combined-write registers.
+- Batch contiguous ranges, dispose masters/slaves/servers and observable subscriptions, and make retryable writes idempotent.
+- Use `DataStore`, `ModbusSimulator`, or `ModbusTcpLoopbackEndpoint` for tests before a physical device. Synchronize direct `DataStore` access.
+- Treat every write as safety-sensitive; validate function, unit ID, address, value, access permissions, and interlocks.
+- Inspect `src/ModbusRx` before describing an API; the reactive package compiles shared source under a different namespace.

--- a/skills/omron-plc-rx/SKILL.md
+++ b/skills/omron-plc-rx/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: omron-plc-rx
+description: Use when implementing, reviewing, or troubleshooting Omron FINS TCP, UDP, Host Link FINS, or Toolbus serial integrations with OmronPlcRx or OmronPlcRx.Reactive.
+---
+
+# OmronPlcRx
+
+Use `IoT.DriverCore.OmronPlcRx` for the base package; use the `.Reactive` namespace only with `OmronPlcRx.Reactive`.
+
+The runtime packages already embed the matching source generator. Install `OmronPlcRx.Generators` only when the analyzer must be pinned or managed independently, and do not load a duplicate generator version.
+
+Create `OmronConnectionOptions`, construct `OmronPlcRx(options, pollInterval)`, register `PlcTag<T>`, and use the same-name, same-type `LogicalTagKey<T>` for `Observe`, `ReadValueAsync`, `WriteValueAsync`, `GetValue`, and `SetValue`.
+
+Subscribe to `Errors`. Prefer `WriteValueAsync` for commands that require an observable result; regard `SetValue` as queued background work. Validate serial settings with `OmronSerialOptions.Validate()` and use `CreateToolbus` only for Toolbus endpoints.
+
+Treat PLC writes as safety-sensitive. Verify node IDs, transport, endpoint, address, tag type, and PLC permissions before enabling writes or reducing poll intervals.
+
+For the complete public API, address/type guidance, examples, and troubleshooting, read the co-packaged `../../README.md`; in a repository checkout use `packagereadme/OmronPlcRx/README.md`.

--- a/skills/s7-plc-rx/SKILL.md
+++ b/skills/s7-plc-rx/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: s7-plc-rx
+description: Use when implementing, reviewing, or troubleshooting Siemens S7 integrations with S7PlcRx or S7PlcRx.Reactive, including typed tags, polling, bindings, batch work, and diagnostics.
+---
+
+# S7PlcRx
+
+Use `IoT.DriverCore.S7PlcRx` for the base package; use the `.Reactive` namespace only with `S7PlcRx.Reactive`.
+
+Install `S7PlcRx.Generators` alongside the selected runtime package when generated bindings are required; the runtime packages do not embed this analyzer.
+
+Create an `IRxS7` through the CPU factory or `RxS7Options` and dispose it: `using IRxS7 plc = S71500.Create(...)`. `IRxS7` inherits disposable `ReactiveUI.Primitives.Disposables.ICancelable`. Register tags with `TagOperations.AddUpdateTagItem(plc, typeof(T), name, address[, length])`, then use a matching `LogicalTagKey<T>` with `Observe<T>` and `ReadAsync<T>`; use `Value<T>` only after the tag and type have been verified.
+
+Subscribe to `IsConnected`, `LastError`, and `LastErrorCode`. Configure watchdogs only with a reviewed `DBW` address and safe interval. Confirm CPU family, rack/slot, DB/bit address syntax, PLC protection, and machine interlocks before writing.
+
+Use generator attributes only on partial binding types. Use batch, logical-tag, optimisation, and production APIs after establishing a baseline with the basic tag flow.
+
+For the complete public API, supported addressing, examples, operational guidance, and troubleshooting, read the co-packaged `../../README.md`; in a repository checkout use `packagereadme/S7PlcRx/README.md`.

--- a/skills/serial-port-rx/SKILL.md
+++ b/skills/serial-port-rx/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: serial-port-rx
+description: Implement, review, or troubleshoot reactive serial, TCP, and UDP I/O with SerialPortRx. Use for port configuration, receive ownership, message framing, connection streams, and deterministic in-memory port tests.
+---
+
+# SerialPortRx
+
+Use `IoT.DriverCore.Serial` for the default package surface. Configure serial settings before `OpenAsync`, subscribe to errors before opening, and dispose subscriptions with the port.
+
+The source generator is embedded in `SerialPortRx` and `SerialPortRx.Reactive`; there is no standalone `SerialPortRx.Generators` NuGet package to install.
+
+Choose exactly one receive owner. Leave `EnableAutoDataReceive` enabled for `DataReceived`, `DataReceivedBytes`, and `DataReceivedBatches`; set it to false before opening for manual read APIs. Do not mix automatic parsing with competing manual reads.
+
+Frame TCP and serial payloads explicitly. Treat TCP read batches as arbitrary transport chunks, use bounded `BufferUntil` or a protocol parser, and select finite timeouts for commands. Treat UDP batches as datagrams but still validate their source and content.
+
+Use `InMemoryPortRxPair` for deterministic tests. For complete contracts, network client APIs, and platform restrictions, read the co-packaged `../../README.md`; in a repository checkout use `packagereadme/SerialPortRx/README.md`.

--- a/skills/twincat-rx/SKILL.md
+++ b/skills/twincat-rx/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: twincat-rx
+description: Implement, review, or troubleshoot reactive TwinCAT ADS access with CP.TwinCATRx. Use for ADS routes, notification settings, correlated reads/writes, typed observables, structured tags, and in-memory ADS tests.
+---
+
+# TwinCATRx
+
+Use `IoT.DriverCore.TwinCATRx` and `IoT.DriverCore.TwinCATRx.Core`. Configure the ADS address, port, and settings id; register notifications and writable variables before `Connect`; wait for `InitializeComplete` before operational I/O.
+
+`CP.TwinCATRx` and `CP.TwinCATRx.Reactive` already embed the matching source generator. Install `TwinCATRx.Generators` only when the analyzer must be pinned or managed independently, and do not load a duplicate generator version.
+
+Treat PLC writes as safety-critical. Validate every variable name, value type, string/array length, route, and controller-side interlock. Observe `ErrorReceived` and `OnWrite`; use correlation ids when concurrent one-shot reads or writes need distinct results.
+
+Use typed `Observe`/`ObserveAsyncObservable` with explicit conversion. Use `CreateStruct` and `WriteValues` only after checking trimming/AOT implications; register required members when publishing trimmed applications. Use `InMemoryAdsClient` to test symbols, faults, reconnection, and metrics without an ADS runtime.
+
+For generated clients, choose `[TwinCatReactiveStream]` or `[TwinCatPlcConnection]` deliberately, declare direct, structured, and write-only members with the documented attributes, build once to inspect diagnostics and generated members, then verify reads, writes, observations, and disposal against `InMemoryAdsClient`.
+
+For the complete public API, generator attribute matrix, configuration overloads, and service-monitoring constraints, read the co-packaged `../../README.md`; in a repository checkout use `packagereadme/TwinCATRx/README.md`.

--- a/src/CP.IoT.Core/CP.IoT.Core.csproj
+++ b/src/CP.IoT.Core/CP.IoT.Core.csproj
@@ -18,5 +18,8 @@
     <None Include="..\..\README.md"
           Pack="true"
           PackagePath="README.md" />
+    <None Include="..\..\images\iot-drivercore-hero.png"
+          Pack="true"
+          PackagePath="images\iot-drivercore-hero.png" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -100,6 +100,7 @@
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'ABPlcRx' or '$(MSBuildProjectName)' == 'ABPlcRx.Reactive' or '$(MSBuildProjectName)' == 'ABPlcRx.Generators'">
     <None Include="$(MSBuildThisFileDirectory)..\images\abplclogo.png" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\packagereadme\ABPlcRx\README.md" Pack="true" PackagePath="\"/>
+    <None Include="$(MSBuildThisFileDirectory)..\skills\ab-plc-rx\SKILL.md" Pack="true" PackagePath="skills/ab-plc-rx/SKILL.md"/>
   </ItemGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'MitsubishiRx' or '$(MSBuildProjectName)' == 'MitsubishiRx.Reactive'">
@@ -110,9 +111,10 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(MSBuildProjectName)' == 'MitsubishiRx' or '$(MSBuildProjectName)' == 'MitsubishiRx.Reactive'">
+  <ItemGroup Condition="'$(MSBuildProjectName)' == 'MitsubishiRx' or '$(MSBuildProjectName)' == 'MitsubishiRx.Reactive' or '$(MSBuildProjectName)' == 'MitsubishiRx.Generators'">
     <None Include="$(MSBuildThisFileDirectory)..\images\mitplclogo.png" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\packagereadme\MitsubishiRx\README.md" Pack="true" PackagePath="\"/>
+    <None Include="$(MSBuildThisFileDirectory)..\skills\mitsubishi-rx\SKILL.md" Pack="true" PackagePath="skills/mitsubishi-rx/SKILL.md"/>
   </ItemGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'ModbusRx' or '$(MSBuildProjectName)' == 'ModbusRx.Reactive'">
@@ -126,6 +128,7 @@
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'ModbusRx' or '$(MSBuildProjectName)' == 'ModbusRx.Reactive' or '$(MSBuildProjectName)' == 'ModbusRx.Generators'">
     <None Include="$(MSBuildThisFileDirectory)..\images\ModbusRx.png" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\packagereadme\ModbusRx\README.md" Pack="true" PackagePath="\"/>
+    <None Include="$(MSBuildThisFileDirectory)..\skills\modbus-rx\SKILL.md" Pack="true" PackagePath="skills/modbus-rx/SKILL.md"/>
   </ItemGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'OmronPlcRx' or '$(MSBuildProjectName)' == 'OmronPlcRx.Reactive'">
@@ -139,6 +142,7 @@
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'OmronPlcRx' or '$(MSBuildProjectName)' == 'OmronPlcRx.Reactive' or '$(MSBuildProjectName)' == 'OmronPlcRx.Generators'">
     <None Include="$(MSBuildThisFileDirectory)..\images\OmronPLCRx-icon.png" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\packagereadme\OmronPlcRx\README.md" Pack="true" PackagePath="\"/>
+    <None Include="$(MSBuildThisFileDirectory)..\skills\omron-plc-rx\SKILL.md" Pack="true" PackagePath="skills/omron-plc-rx/SKILL.md"/>
   </ItemGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'S7PlcRx' or '$(MSBuildProjectName)' == 'S7PlcRx.Reactive'">
@@ -152,6 +156,7 @@
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'S7PlcRx' or '$(MSBuildProjectName)' == 'S7PlcRx.Reactive' or '$(MSBuildProjectName)' == 'S7PlcRx.Generators'">
     <None Include="$(MSBuildThisFileDirectory)..\images\S7PlcRx.png" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\packagereadme\S7PlcRx\README.md" Pack="true" PackagePath="\"/>
+    <None Include="$(MSBuildThisFileDirectory)..\skills\s7-plc-rx\SKILL.md" Pack="true" PackagePath="skills/s7-plc-rx/SKILL.md"/>
   </ItemGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'ABPlcRx.Generators'">
@@ -178,6 +183,13 @@
     <PackageIcon>S7PlcRx.png</PackageIcon>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(MSBuildProjectName)' == 'MitsubishiRx.Generators'">
+    <Description>Compile-time source generators for strongly typed Mitsubishi MELSEC tag clients.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageIcon>mitplclogo.png</PackageIcon>
+    <PackageTags>Mitsubishi;MELSEC;MC Protocol;SLMP;PLC;source generator;Roslyn;IoT</PackageTags>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'SerialPortRx' or '$(MSBuildProjectName)' == 'SerialPortRx.Reactive'">
     <Description>Reactive, cross-platform serial-port driver with asynchronous observable streams and source-generated helpers.</Description>
     <PackageReleaseNotes>Cross-platform serial communication for .NET 8 through .NET 11 with Windows-specific framework targets, async observables, and generated streams.</PackageReleaseNotes>
@@ -189,6 +201,7 @@
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'SerialPortRx' or '$(MSBuildProjectName)' == 'SerialPortRx.Reactive'">
     <None Include="$(MSBuildThisFileDirectory)..\images\serlogo.png" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\packagereadme\SerialPortRx\README.md" Pack="true" PackagePath="\"/>
+    <None Include="$(MSBuildThisFileDirectory)..\skills\serial-port-rx\SKILL.md" Pack="true" PackagePath="skills/serial-port-rx/SKILL.md"/>
   </ItemGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'TwinCATRx' or '$(MSBuildProjectName)' == 'TwinCATRx.Reactive' or '$(MSBuildProjectName)' == 'TwinCATRx.Core' or '$(MSBuildProjectName)' == 'TwinCATRx.Core.Reactive'">
@@ -202,11 +215,26 @@
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'TwinCATRx' or '$(MSBuildProjectName)' == 'TwinCATRx.Reactive'">
     <None Include="$(MSBuildThisFileDirectory)..\images\TwinCATRx.png" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\packagereadme\TwinCATRx\README.md" Pack="true" PackagePath="\"/>
+    <None Include="$(MSBuildThisFileDirectory)..\skills\twincat-rx\SKILL.md" Pack="true" PackagePath="skills/twincat-rx/SKILL.md"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'TwinCATRx.Core' or '$(MSBuildProjectName)' == 'TwinCATRx.Core.Reactive'">
     <None Include="$(MSBuildThisFileDirectory)..\images\TwinCATRx.png" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\packagereadme\TwinCATRx\README.md" Pack="true" PackagePath="\"/>
+    <None Include="$(MSBuildThisFileDirectory)..\skills\twincat-rx\SKILL.md" Pack="true" PackagePath="skills/twincat-rx/SKILL.md"/>
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(MSBuildProjectName)' == 'TwinCATRx.Generators'">
+    <Description>Compile-time source generators for strongly typed Beckhoff TwinCAT ADS models and reactive streams.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageIcon>TwinCATRx.png</PackageIcon>
+    <PackageTags>Beckhoff;TwinCAT;ADS;PLC;source generator;Roslyn;IoT;reactive</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(MSBuildProjectName)' == 'TwinCATRx.Generators'">
+    <None Include="$(MSBuildThisFileDirectory)..\images\TwinCATRx.png" Pack="true" PackagePath="\"/>
+    <None Include="$(MSBuildThisFileDirectory)..\packagereadme\TwinCATRx\README.md" Pack="true" PackagePath="\"/>
+    <None Include="$(MSBuildThisFileDirectory)..\skills\twincat-rx\SKILL.md" Pack="true" PackagePath="skills/twincat-rx/SKILL.md"/>
   </ItemGroup>
 
   <!-- Alias Lock to the dedicated System.Threading.Lock on .NET 9+ (faster EnterScope fast path),

--- a/src/IoT-DriverCore.slnx
+++ b/src/IoT-DriverCore.slnx
@@ -16,6 +16,8 @@
   <Folder Name="/Config/">
     <File Path="../.editorconfig" />
     <File Path="../.gitattributes" />
+    <File Path="../.github/workflows/BuildDeploy.yml" />
+    <File Path="../.github/workflows/BuildOnly.yml" />
     <File Path="../.gitignore" />
     <File Path="../global.json" />
     <File Path="../LICENSE" />

--- a/src/MitsubishiRx.Generators/MitsubishiRx.Generators.csproj
+++ b/src/MitsubishiRx.Generators/MitsubishiRx.Generators.csproj
@@ -2,7 +2,11 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <IsRoslynComponent>true</IsRoslynComponent>
     <LangVersion>latest</LangVersion>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
@@ -16,5 +20,12 @@
 
   <ItemGroup>
     <PackageReference Update="Microsoft.SourceLink.GitHub" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(TargetPath)"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
   </ItemGroup>
 </Project>

--- a/src/TwinCATRx.Generators/TwinCATRx.Generators.csproj
+++ b/src/TwinCATRx.Generators/TwinCATRx.Generators.csproj
@@ -4,14 +4,24 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <IsRoslynComponent>true</IsRoslynComponent>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(TargetPath)"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
   </ItemGroup>
 
 </Project>

--- a/tools/ApiReferenceGenerator/ApiReferenceGenerator.csproj
+++ b/tools/ApiReferenceGenerator/ApiReferenceGenerator.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>

--- a/tools/ApiReferenceGenerator/Program.cs
+++ b/tools/ApiReferenceGenerator/Program.cs
@@ -1,0 +1,782 @@
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Text;
+using System.Text.Json;
+using System.Xml.Linq;
+
+return await ApiReferenceProgram.RunAsync(args);
+
+internal static class ApiReferenceProgram
+{
+    internal const BindingFlags DeclaredPublic = BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
+
+    public static Task<int> RunAsync(string[] args)
+    {
+        try
+        {
+            var options = Options.Parse(args);
+            Generate(options);
+            return Task.FromResult(0);
+        }
+        catch (ArgumentException exception)
+        {
+            Console.Error.WriteLine(exception.Message);
+            Console.Error.WriteLine(Options.Usage);
+            return Task.FromResult(2);
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine($"API reference generation failed: {exception}");
+            return Task.FromResult(1);
+        }
+    }
+
+    private static void Generate(Options options)
+    {
+        var fullAssemblyPaths = options.Assemblies
+            .Select(Path.GetFullPath)
+            .OrderBy(static path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var xmlPaths = fullAssemblyPaths.ToDictionary(
+            static assemblyPath => assemblyPath,
+            assemblyPath => options.XmlPaths.TryGetValue(assemblyPath, out var xmlPath)
+                ? Path.GetFullPath(xmlPath)
+                : Path.ChangeExtension(assemblyPath, ".xml"),
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var assemblyPath in fullAssemblyPaths)
+        {
+            if (!File.Exists(assemblyPath))
+            {
+                throw new ArgumentException($"Assembly does not exist: {assemblyPath}");
+            }
+
+            if (!File.Exists(xmlPaths[assemblyPath]))
+            {
+                throw new ArgumentException($"XML documentation does not exist for '{assemblyPath}': {xmlPaths[assemblyPath]}");
+            }
+        }
+
+        var loadContext = new DocumentationLoadContext(fullAssemblyPaths);
+        var reports = fullAssemblyPaths
+            .Select(assemblyPath => new AssemblyReport(
+                loadContext.LoadFromAssemblyPath(assemblyPath),
+                XmlDocumentation.Load(xmlPaths[assemblyPath])))
+            .OrderBy(static report => report.Name, StringComparer.Ordinal)
+            .ToArray();
+
+        var markdown = MarkdownRenderer.Render(reports, options.ReadmePath is null ? RenderMode.Standalone : RenderMode.ReadmeFragment);
+        if (options.OutputPath is not null)
+        {
+            var outputPath = Path.GetFullPath(options.OutputPath);
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath) ?? Directory.GetCurrentDirectory());
+            File.WriteAllText(outputPath, markdown, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            Console.WriteLine($"Generated {outputPath}");
+        }
+        else
+        {
+            ReadmeFragment.Replace(Path.GetFullPath(options.ReadmePath!), markdown);
+            Console.WriteLine($"Updated generated API fragment in {Path.GetFullPath(options.ReadmePath!)}");
+        }
+
+        var typeCount = reports.Sum(static report => report.Types.Count);
+        var memberCount = reports.Sum(static report => report.Types.Sum(static type => type.Members.Count));
+        Console.WriteLine($"Assemblies: {reports.Length}; exported public types: {typeCount}; declared public members: {memberCount}.");
+        loadContext.Unload();
+    }
+
+    private sealed class DocumentationLoadContext : AssemblyLoadContext
+    {
+        private readonly Dictionary<string, string> _assemblies;
+        private readonly AssemblyDependencyResolver[] _dependencyResolvers;
+
+        public DocumentationLoadContext(IEnumerable<string> rootAssemblies)
+            : base("IoTDriverCoreApiReference", isCollectible: true)
+        {
+            var roots = rootAssemblies.ToArray();
+            _assemblies = roots
+                .SelectMany(path => Directory.EnumerateFiles(Path.GetDirectoryName(path)!, "*.dll"))
+                .Concat(roots)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .GroupBy(static path => Path.GetFileNameWithoutExtension(path) ?? path, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.OrdinalIgnoreCase);
+            AddNuGetRuntimeDependencies(roots, _assemblies);
+            _dependencyResolvers = roots.Select(static path => new AssemblyDependencyResolver(path)).ToArray();
+        }
+
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            if (assemblyName.Name is not null && _assemblies.TryGetValue(assemblyName.Name, out var localPath))
+            {
+                return LoadFromAssemblyPath(localPath);
+            }
+
+            foreach (var resolver in _dependencyResolvers)
+            {
+                var dependencyPath = resolver.ResolveAssemblyToPath(assemblyName);
+                if (dependencyPath is not null)
+                {
+                    return LoadFromAssemblyPath(dependencyPath);
+                }
+            }
+
+            return null;
+        }
+
+        private static void AddNuGetRuntimeDependencies(
+            IEnumerable<string> roots,
+            IDictionary<string, string> assemblies)
+        {
+            var packageRoot = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+            if (string.IsNullOrWhiteSpace(packageRoot))
+            {
+                packageRoot = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
+            }
+
+            foreach (var root in roots)
+            {
+                var depsPath = Path.ChangeExtension(root, ".deps.json");
+                if (!File.Exists(depsPath))
+                {
+                    continue;
+                }
+
+                using var document = JsonDocument.Parse(File.ReadAllText(depsPath));
+                var documentRoot = document.RootElement;
+                if (!documentRoot.TryGetProperty("targets", out var targets)
+                    || !documentRoot.TryGetProperty("libraries", out var libraries))
+                {
+                    continue;
+                }
+
+                foreach (var target in targets.EnumerateObject())
+                {
+                    foreach (var library in target.Value.EnumerateObject())
+                    {
+                        if (!libraries.TryGetProperty(library.Name, out var libraryMetadata)
+                            || !libraryMetadata.TryGetProperty("path", out var libraryPath)
+                            || !library.Value.TryGetProperty("runtime", out var runtime))
+                        {
+                            continue;
+                        }
+
+                        foreach (var asset in runtime.EnumerateObject())
+                        {
+                            if (!asset.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                            {
+                                continue;
+                            }
+
+                            var dependencyPath = Path.Combine(packageRoot, libraryPath.GetString()!, asset.Name.Replace('/', Path.DirectorySeparatorChar));
+                            if (File.Exists(dependencyPath))
+                            {
+                                _ = assemblies.TryAdd(Path.GetFileNameWithoutExtension(dependencyPath), dependencyPath);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private sealed class Options
+    {
+        public const string Usage = "Usage: dotnet run --project tools/ApiReferenceGenerator -- --assembly <built.dll> [--assembly <built.dll> ...] [--xml <xml-for-preceding-assembly>] (--output <reference.md> | --readme <package-readme.md>)";
+
+        public List<string> Assemblies { get; } = [];
+
+        public Dictionary<string, string> XmlPaths { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        public string? OutputPath { get; private set; }
+
+        public string? ReadmePath { get; private set; }
+
+        public static Options Parse(string[] args)
+        {
+            var options = new Options();
+            string? currentAssembly = null;
+            for (var index = 0; index < args.Length; index++)
+            {
+                var argument = args[index];
+                if (argument is "--help" or "-h")
+                {
+                    throw new ArgumentException(Usage);
+                }
+
+                if (index + 1 >= args.Length)
+                {
+                    throw new ArgumentException($"Missing value for {argument}.");
+                }
+
+                var value = args[++index];
+                switch (argument)
+                {
+                    case "--assembly":
+                        currentAssembly = Path.GetFullPath(value);
+                        options.Assemblies.Add(currentAssembly);
+                        break;
+                    case "--xml" when currentAssembly is not null:
+                        options.XmlPaths[currentAssembly] = Path.GetFullPath(value);
+                        break;
+                    case "--xml":
+                        throw new ArgumentException("--xml must follow its --assembly.");
+                    case "--output":
+                        options.OutputPath = value;
+                        break;
+                    case "--readme":
+                        options.ReadmePath = value;
+                        break;
+                    default:
+                        throw new ArgumentException($"Unknown option: {argument}");
+                }
+            }
+
+            if (options.Assemblies.Count == 0)
+            {
+                throw new ArgumentException("At least one --assembly is required.");
+            }
+
+            if (string.IsNullOrWhiteSpace(options.OutputPath) == string.IsNullOrWhiteSpace(options.ReadmePath))
+            {
+                throw new ArgumentException("Specify exactly one of --output or --readme.");
+            }
+
+            return options;
+        }
+    }
+}
+
+internal static class ReadmeFragment
+{
+    public const string BeginMarker = "<!-- BEGIN GENERATED PUBLIC API -->";
+    public const string EndMarker = "<!-- END GENERATED PUBLIC API -->";
+
+    public static void Replace(string readmePath, string fragment)
+    {
+        if (!File.Exists(readmePath))
+        {
+            throw new ArgumentException($"README does not exist: {readmePath}");
+        }
+
+        var original = File.ReadAllText(readmePath);
+        var begin = original.IndexOf(BeginMarker, StringComparison.Ordinal);
+        var end = original.IndexOf(EndMarker, StringComparison.Ordinal);
+        if ((begin < 0) != (end < 0))
+        {
+            throw new ArgumentException($"README markers are incomplete in {readmePath}.");
+        }
+
+        if (begin >= 0 && (end < begin || original.IndexOf(BeginMarker, begin + BeginMarker.Length, StringComparison.Ordinal) >= 0 || original.IndexOf(EndMarker, end + EndMarker.Length, StringComparison.Ordinal) >= 0))
+        {
+            throw new ArgumentException($"README must contain exactly one ordered generated API marker pair: {readmePath}.");
+        }
+
+        var newline = original.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n";
+        var rendered = fragment
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace("\r", "\n", StringComparison.Ordinal)
+            .Replace("\n", newline, StringComparison.Ordinal);
+        var trimmedFragment = rendered.TrimEnd('\r', '\n');
+        var replacement = begin < 0
+            ? original + (original.EndsWith("\n", StringComparison.Ordinal) ? newline : newline + newline) + trimmedFragment + newline
+            : original[..begin] + trimmedFragment + original[(end + EndMarker.Length)..];
+        File.WriteAllText(readmePath, replacement, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+    }
+}
+
+internal sealed class AssemblyReport
+{
+    public AssemblyReport(Assembly assembly, XmlDocumentation documentation)
+    {
+        Name = assembly.GetName().Name ?? assembly.FullName ?? "Unknown assembly";
+        Path = assembly.Location;
+        Types = assembly.GetExportedTypes()
+            .OrderBy(TypeFormatting.XmlTypeName, StringComparer.Ordinal)
+            .Select(type => new TypeReport(type, documentation))
+            .ToArray();
+    }
+
+    public string Name { get; }
+
+    public string Path { get; }
+
+    public IReadOnlyList<TypeReport> Types { get; }
+}
+
+internal sealed class TypeReport
+{
+    public TypeReport(Type type, XmlDocumentation documentation)
+    {
+        Type = type;
+        DocumentationId = "T:" + TypeFormatting.XmlTypeName(type);
+        Documentation = documentation.Lookup(DocumentationId);
+        Members = GetMembers(type)
+            .OrderBy(static member => member.DocumentationId, StringComparer.Ordinal)
+            .ToArray();
+
+        IEnumerable<MemberReport> GetMembers(Type declaredType)
+        {
+            foreach (var constructor in declaredType.GetConstructors(ApiReferenceProgram.DeclaredPublic))
+            {
+                yield return new MemberReport(constructor, documentation);
+            }
+
+            foreach (var field in declaredType.GetFields(ApiReferenceProgram.DeclaredPublic)
+                .Where(static field => !(field.IsSpecialName && field.Name == "value__")))
+            {
+                yield return new MemberReport(field, documentation);
+            }
+
+            foreach (var property in declaredType.GetProperties(ApiReferenceProgram.DeclaredPublic)
+                .Where(static property => property.GetMethod?.IsPublic == true || property.SetMethod?.IsPublic == true))
+            {
+                yield return new MemberReport(property, documentation);
+            }
+
+            foreach (var eventInfo in declaredType.GetEvents(ApiReferenceProgram.DeclaredPublic)
+                .Where(static eventInfo => eventInfo.AddMethod?.IsPublic == true || eventInfo.RemoveMethod?.IsPublic == true))
+            {
+                yield return new MemberReport(eventInfo, documentation);
+            }
+
+            foreach (var method in declaredType.GetMethods(ApiReferenceProgram.DeclaredPublic)
+                .Where(static method =>
+                    (!method.IsSpecialName || method.Name.StartsWith("op_", StringComparison.Ordinal))
+                    && !method.Name.StartsWith("<", StringComparison.Ordinal)))
+            {
+                yield return new MemberReport(method, documentation);
+            }
+        }
+    }
+
+    public Type Type { get; }
+
+    public string DocumentationId { get; }
+
+    public XmlMemberDocumentation Documentation { get; }
+
+    public IReadOnlyList<MemberReport> Members { get; }
+}
+
+internal sealed class MemberReport
+{
+    public MemberReport(MemberInfo member, XmlDocumentation documentation)
+    {
+        Member = member;
+        DocumentationId = TypeFormatting.XmlMemberName(member);
+        Signature = TypeFormatting.Signature(member);
+        Documentation = documentation.Lookup(DocumentationId);
+    }
+
+    public MemberInfo Member { get; }
+
+    public string DocumentationId { get; }
+
+    public string Signature { get; }
+
+    public XmlMemberDocumentation Documentation { get; }
+}
+
+internal sealed class XmlDocumentation
+{
+    private readonly IReadOnlyDictionary<string, XmlMemberDocumentation> _members;
+
+    private XmlDocumentation(IReadOnlyDictionary<string, XmlMemberDocumentation> members) => _members = members;
+
+    public static XmlDocumentation Load(string xmlPath)
+    {
+        var members = XDocument.Load(xmlPath)
+            .Root?
+            .Element("members")?
+            .Elements("member")
+            .Where(static element => element.Attribute("name")?.Value is not null)
+            .ToDictionary(
+                static element => element.Attribute("name")!.Value,
+                static element => XmlMemberDocumentation.FromElement(element),
+                StringComparer.Ordinal)
+            ?? new Dictionary<string, XmlMemberDocumentation>(StringComparer.Ordinal);
+        return new XmlDocumentation(members);
+    }
+
+    public XmlMemberDocumentation Lookup(string documentationId) =>
+        _members.TryGetValue(documentationId, out var documentation)
+            ? documentation
+            : XmlMemberDocumentation.Empty;
+}
+
+internal sealed class XmlMemberDocumentation
+{
+    public static readonly XmlMemberDocumentation Empty = new(
+        null,
+        new Dictionary<string, string>(StringComparer.Ordinal),
+        null,
+        null,
+        isInheritDoc: false);
+
+    private XmlMemberDocumentation(
+        string? summary,
+        IReadOnlyDictionary<string, string> parameters,
+        string? returns,
+        string? value,
+        bool isInheritDoc)
+    {
+        Summary = summary;
+        Parameters = parameters;
+        Returns = returns;
+        Value = value;
+        IsInheritDoc = isInheritDoc;
+    }
+
+    public string? Summary { get; }
+
+    public IReadOnlyDictionary<string, string> Parameters { get; }
+
+    public string? Returns { get; }
+
+    public string? Value { get; }
+
+    public bool IsInheritDoc { get; }
+
+    public static XmlMemberDocumentation FromElement(XElement element)
+    {
+        var parameters = element.Elements("param")
+            .Where(static parameter => parameter.Attribute("name")?.Value is not null)
+            .Select(static parameter => new KeyValuePair<string, string>(
+                parameter.Attribute("name")!.Value,
+                Normalize(parameter.Nodes()) ?? string.Empty))
+            .ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal);
+        return new XmlMemberDocumentation(
+            NormalizeElement(element, "summary"),
+            parameters,
+            NormalizeElement(element, "returns"),
+            NormalizeElement(element, "value"),
+            element.Element("inheritdoc") is not null);
+    }
+
+    private static string? NormalizeElement(XElement element, string name)
+    {
+        var child = element.Element(name);
+        return child is null ? null : Normalize(child.Nodes());
+    }
+
+    private static string? Normalize(IEnumerable<XNode> nodes)
+    {
+        var value = string.Join(" ", nodes
+            .Select(RenderNode)
+            .SelectMany(static text => text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)));
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    private static string RenderNode(XNode node) => node switch
+    {
+        XCData cdata => cdata.Value,
+        XText text => text.Value,
+        XElement { Name.LocalName: "see" } element => RenderReference(element, "cref"),
+        XElement { Name.LocalName: "paramref" } element => RenderReference(element, "name"),
+        XElement element => string.Concat(element.Nodes().Select(RenderNode)),
+        _ => string.Empty,
+    };
+
+    private static string RenderReference(XElement element, string attributeName)
+    {
+        var value = element.Attribute(attributeName)?.Value;
+        return string.IsNullOrWhiteSpace(value) ? string.Concat(element.Nodes().Select(RenderNode)) : $"`{value}`";
+    }
+}
+
+internal static class TypeFormatting
+{
+    public static string XmlMemberName(MemberInfo member) => member switch
+    {
+        Type type => "T:" + XmlTypeName(type),
+        ConstructorInfo constructor => "M:" + XmlTypeName(constructor.DeclaringType!) + ".#ctor" + XmlParameters(constructor.GetParameters()),
+        MethodInfo method => "M:" + XmlTypeName(method.DeclaringType!) + "." + XmlMethodName(method) + XmlParameters(method.GetParameters()) + XmlConversionReturn(method),
+        PropertyInfo property => "P:" + XmlTypeName(property.DeclaringType!) + "." + property.Name + XmlParameters(property.GetIndexParameters()),
+        FieldInfo field => "F:" + XmlTypeName(field.DeclaringType!) + "." + field.Name,
+        EventInfo eventInfo => "E:" + XmlTypeName(eventInfo.DeclaringType!) + "." + eventInfo.Name,
+        _ => throw new ArgumentOutOfRangeException(nameof(member), member, "Unsupported public member kind."),
+    };
+
+    public static string XmlTypeName(Type type)
+    {
+        var fullName = type.FullName ?? type.Name;
+        return fullName.Replace('+', '.');
+    }
+
+    public static string Signature(MemberInfo member) => member switch
+    {
+        ConstructorInfo constructor => $"public {TypeDisplayName(constructor.DeclaringType!)}({Parameters(constructor.GetParameters())})",
+        MethodInfo method => $"public {(method.IsStatic ? "static " : string.Empty)}{TypeDisplayName(method.ReturnType)} {method.Name}{GenericParameters(method)}({Parameters(method.GetParameters())})",
+        PropertyInfo property => $"public {TypeDisplayName(property.PropertyType)} {property.Name}{IndexParameters(property)} {{ {Accessors(property)} }}",
+        FieldInfo field => $"public {(field.IsStatic ? "static " : string.Empty)}{(field.IsLiteral ? "const " : string.Empty)}{TypeDisplayName(field.FieldType)} {field.Name}",
+        EventInfo eventInfo => $"public event {TypeDisplayName(eventInfo.EventHandlerType!)} {eventInfo.Name}",
+        _ => throw new ArgumentOutOfRangeException(nameof(member), member, "Unsupported public member kind."),
+    };
+
+    private static string XmlMethodName(MethodInfo method)
+    {
+        var name = method.Name;
+        if (method.IsGenericMethodDefinition)
+        {
+            name += "``" + method.GetGenericArguments().Length;
+        }
+
+        return name;
+    }
+
+    private static string XmlConversionReturn(MethodInfo method) =>
+        method.Name is "op_Implicit" or "op_Explicit" ? "~" + XmlTypeReference(method.ReturnType) : string.Empty;
+
+    private static string XmlParameters(ParameterInfo[] parameters) =>
+        parameters.Length == 0 ? string.Empty : "(" + string.Join(",", parameters.Select(static parameter => XmlTypeReference(parameter.ParameterType))) + ")";
+
+    private static string XmlTypeReference(Type type)
+    {
+        if (type.IsByRef)
+        {
+            return XmlTypeReference(type.GetElementType()!) + "@";
+        }
+
+        if (type.IsPointer)
+        {
+            return XmlTypeReference(type.GetElementType()!) + "*";
+        }
+
+        if (type.IsArray)
+        {
+            var rank = type.GetArrayRank();
+            return XmlTypeReference(type.GetElementType()!) + (rank == 1 ? "[]" : "[" + string.Join(",", Enumerable.Repeat("0:", rank)) + "]");
+        }
+
+        if (type.IsGenericParameter)
+        {
+            return (type.DeclaringMethod is null ? "`" : "``") + type.GenericParameterPosition;
+        }
+
+        if (type.IsGenericType)
+        {
+            var definition = type.GetGenericTypeDefinition();
+            return XmlTypeName(definition) + "{" + string.Join(",", type.GetGenericArguments().Select(XmlTypeReference)) + "}";
+        }
+
+        return XmlTypeName(type);
+    }
+
+    private static string GenericParameters(MethodInfo method) =>
+        method.IsGenericMethodDefinition ? "<" + string.Join(", ", method.GetGenericArguments().Select(static argument => argument.Name)) + ">" : string.Empty;
+
+    private static string IndexParameters(PropertyInfo property)
+    {
+        var parameters = property.GetIndexParameters();
+        return parameters.Length == 0 ? string.Empty : "[" + Parameters(parameters) + "]";
+    }
+
+    private static string Accessors(PropertyInfo property)
+    {
+        var accessors = new List<string>();
+        if (property.GetMethod?.IsPublic == true) accessors.Add("get;");
+        if (property.SetMethod?.IsPublic == true) accessors.Add("set;");
+        return string.Join(" ", accessors);
+    }
+
+    private static string Parameters(ParameterInfo[] parameters) =>
+        string.Join(", ", parameters.Select(static parameter =>
+        {
+            var modifier = parameter.IsOut ? "out " : parameter.ParameterType.IsByRef ? "ref " : string.Empty;
+            return modifier + TypeDisplayName(parameter.ParameterType) + " " + parameter.Name;
+        }));
+
+    public static string TypeDisplayName(Type type)
+    {
+        if (type.IsByRef) return TypeDisplayName(type.GetElementType()!);
+        if (type.IsArray) return TypeDisplayName(type.GetElementType()!) + "[" + new string(',', type.GetArrayRank() - 1) + "]";
+        if (type.IsPointer) return TypeDisplayName(type.GetElementType()!) + "*";
+        if (type.IsGenericParameter) return type.Name;
+
+        var aliases = new Dictionary<Type, string>
+        {
+            [typeof(void)] = "void", [typeof(bool)] = "bool", [typeof(byte)] = "byte", [typeof(sbyte)] = "sbyte",
+            [typeof(short)] = "short", [typeof(ushort)] = "ushort", [typeof(int)] = "int", [typeof(uint)] = "uint",
+            [typeof(long)] = "long", [typeof(ulong)] = "ulong", [typeof(float)] = "float", [typeof(double)] = "double",
+            [typeof(decimal)] = "decimal", [typeof(char)] = "char", [typeof(string)] = "string", [typeof(object)] = "object",
+        };
+        if (aliases.TryGetValue(type, out var alias)) return alias;
+        if (!type.IsGenericType) return (type.FullName ?? type.Name).Replace('+', '.');
+
+        var genericName = (type.GetGenericTypeDefinition().FullName ?? type.Name).Replace('+', '.');
+        genericName = genericName[..genericName.IndexOf('`')];
+        return genericName + "<" + string.Join(", ", type.GetGenericArguments().Select(TypeDisplayName)) + ">";
+    }
+}
+
+internal static class MarkdownRenderer
+{
+    public static string Render(IReadOnlyList<AssemblyReport> reports, RenderMode mode)
+    {
+        var builder = new StringBuilder();
+        if (mode == RenderMode.Standalone)
+        {
+            builder.AppendLine("# Public API Reference");
+            builder.AppendLine();
+            builder.AppendLine("Generated from the supplied built assemblies and their XML documentation. Only exported public types and public members declared directly on those types are included; inherited members and non-public implementation details are intentionally omitted.");
+        }
+        else
+        {
+            builder.AppendLine(ReadmeFragment.BeginMarker);
+            builder.AppendLine();
+            builder.AppendLine("## Exhaustive public API reference");
+            builder.AppendLine();
+            builder.AppendLine("This catalogue is generated from the packaged runtime assemblies and their XML documentation. It includes exported public types and their declared public members; inherited members and non-public implementation details are intentionally omitted.");
+        }
+
+        builder.AppendLine();
+
+        foreach (var report in reports)
+        {
+            builder.AppendLine($"{Heading(mode, standalone: "##", readme: "###")} `{report.Name}`");
+            builder.AppendLine();
+            if (mode == RenderMode.Standalone)
+            {
+                builder.AppendLine($"Assembly: `{report.Path}`  ");
+            }
+
+            builder.AppendLine($"Exported public types: {report.Types.Count}; declared public members: {report.Types.Sum(static type => type.Members.Count)}.");
+            builder.AppendLine();
+
+            foreach (var type in report.Types)
+            {
+                builder.AppendLine($"{Heading(mode, standalone: "###", readme: "####")} `{type.DocumentationId}`");
+                builder.AppendLine();
+                builder.AppendLine("```csharp");
+                builder.AppendLine($"public {TypeKeyword(type.Type)} {TypeFormatting.XmlTypeName(type.Type)}");
+                builder.AppendLine("```");
+                AppendDocumentation(builder, type.Documentation, type.Type);
+
+                if (type.Members.Count == 0)
+                {
+                    continue;
+                }
+
+                builder.AppendLine($"{Heading(mode, standalone: "####", readme: "#####")} Declared public members");
+                builder.AppendLine();
+                foreach (var member in type.Members)
+                {
+                    builder.AppendLine($"{Heading(mode, standalone: "#####", readme: "######")} `{member.DocumentationId}`");
+                    builder.AppendLine();
+                    builder.AppendLine("```csharp");
+                    builder.AppendLine(member.Signature);
+                    builder.AppendLine("```");
+                    AppendDocumentation(builder, member.Documentation, member.Member);
+                }
+            }
+        }
+
+        if (mode == RenderMode.ReadmeFragment)
+        {
+            builder.AppendLine(ReadmeFragment.EndMarker);
+        }
+
+        return builder.ToString();
+    }
+
+    private static string Heading(RenderMode mode, string standalone, string readme) =>
+        mode == RenderMode.Standalone ? standalone : readme;
+
+    private static string TypeKeyword(Type type) =>
+        type.IsInterface ? "interface" : type.IsEnum ? "enum" : typeof(MulticastDelegate).IsAssignableFrom(type.BaseType) ? "delegate" : type.IsValueType ? "struct" : "class";
+
+    private static void AppendDocumentation(
+        StringBuilder builder,
+        XmlMemberDocumentation documentation,
+        MemberInfo declaration)
+    {
+        if (documentation.Summary is not null)
+        {
+            builder.AppendLine(documentation.Summary);
+            builder.AppendLine();
+        }
+        else if (documentation.IsInheritDoc)
+        {
+            builder.AppendLine("Inherits XML documentation from its implemented or overridden member.");
+            builder.AppendLine();
+        }
+        else
+        {
+            builder.AppendLine(FallbackSummary(declaration));
+            builder.AppendLine();
+        }
+
+        var parameters = declaration switch
+        {
+            MethodBase method => method.GetParameters(),
+            PropertyInfo property => property.GetIndexParameters(),
+            _ => [],
+        };
+        var wroteDetails = false;
+        foreach (var parameter in parameters)
+        {
+            var parameterName = parameter.Name ?? $"arg{parameter.Position}";
+            var description = documentation.Parameters.TryGetValue(parameterName, out var documented)
+                ? documented
+                : $"The `{parameterName}` value.";
+            builder.AppendLine($"- Parameter `{parameterName}`: {description}");
+            wroteDetails = true;
+        }
+
+        if (documentation.Returns is not null)
+        {
+            builder.AppendLine($"- Returns: {documentation.Returns}");
+            wroteDetails = true;
+        }
+        else if (declaration is MethodInfo { ReturnType: var returnType } && returnType != typeof(void))
+        {
+            builder.AppendLine($"- Returns: A `{TypeFormatting.TypeDisplayName(returnType)}` result.");
+            wroteDetails = true;
+        }
+
+        if (documentation.Value is not null)
+        {
+            builder.AppendLine($"- Value: {documentation.Value}");
+            wroteDetails = true;
+        }
+        else if (declaration is PropertyInfo property)
+        {
+            builder.AppendLine($"- Value: The `{property.Name}` value.");
+            wroteDetails = true;
+        }
+
+        if (wroteDetails)
+        {
+            builder.AppendLine();
+        }
+    }
+
+    private static string FallbackSummary(MemberInfo declaration) => declaration switch
+    {
+        Type type => $"Public {TypeKeyword(type)} `{TypeFormatting.XmlTypeName(type)}`.",
+        ConstructorInfo constructor => $"Initializes a new instance of `{TypeFormatting.XmlTypeName(constructor.DeclaringType!)}`.",
+        PropertyInfo property when property.GetMethod?.IsPublic == true && property.SetMethod?.IsPublic == true =>
+            $"Gets or sets `{property.Name}`.",
+        PropertyInfo property when property.GetMethod?.IsPublic == true => $"Gets `{property.Name}`.",
+        PropertyInfo property => $"Sets `{property.Name}`.",
+        FieldInfo field when field.DeclaringType?.IsEnum == true => $"Represents the `{field.Name}` enum value.",
+        FieldInfo field => $"Exposes the public `{field.Name}` field.",
+        EventInfo eventInfo => $"Occurs when `{eventInfo.Name}` is raised.",
+        MethodInfo { Name: "Deconstruct" } => "Deconstructs the value into its component values.",
+        MethodInfo { Name: "Equals" } => "Determines whether the supplied value is equal to the current value.",
+        MethodInfo { Name: "GetHashCode" } => "Returns the hash code for the current value.",
+        MethodInfo { Name: "ToString" } => "Returns a string representation of the current value.",
+        MethodInfo { Name: "op_Equality" } => "Determines whether the two supplied values are equal.",
+        MethodInfo { Name: "op_Inequality" } => "Determines whether the two supplied values are not equal.",
+        MethodInfo { Name: "op_Implicit" } => "Converts the supplied value using the implicit conversion operator.",
+        MethodInfo { Name: "op_Explicit" } => "Converts the supplied value using the explicit conversion operator.",
+        MethodInfo method => $"Executes the `{method.Name}` operation.",
+        _ => "Public API declaration.",
+    };
+}
+
+internal enum RenderMode
+{
+    Standalone,
+    ReadmeFragment,
+}

--- a/tools/ApiReferenceGenerator/README.md
+++ b/tools/ApiReferenceGenerator/README.md
@@ -1,0 +1,47 @@
+# API reference generator
+
+This tool generates a Markdown API reference from built runtime assemblies and their compiler-produced XML documentation. It uses reflection to enumerate `Assembly.GetExportedTypes()` and `DeclaredOnly | Public` members, so it excludes private and internal implementation types and inherited members.
+
+Run it after building the desired target framework:
+
+```powershell
+dotnet run --project tools/ApiReferenceGenerator -- `
+  --assembly src/ABPlcRx/bin/Release/net10.0/ABPlcRx.dll `
+  --output artifacts/docs/ABPlcRx-api.md
+```
+
+The XML file is assumed to sit beside each DLL with the same base name. Pass `--xml <path>` immediately after an `--assembly` to override that association.
+
+Multiple `--assembly` inputs create one combined document. This is intended for TwinCAT's runtime split; use assemblies built for the same target framework:
+
+```powershell
+dotnet run --project tools/ApiReferenceGenerator -- `
+  --assembly src/TwinCATRx.Core/bin/Release/net10.0/TwinCATRx.Core.dll `
+  --assembly src/TwinCATRx/bin/Release/net10.0/TwinCATRx.dll `
+  --output artifacts/docs/TwinCATRx-api.md
+```
+
+Each entry includes its XML documentation ID, a C#-style reflection signature, summary, parameter descriptions, return description, and value description. XML comments are preferred; when a public declaration has no emitted comment, the tool supplies a conservative signature-derived description instead of leaving a documentation hole. Compiler-only record clone methods are omitted. Generated files are reports, not hand-authored package READMEs.
+
+## Package README fragments
+
+Use `--readme` instead of `--output` to maintain an exhaustive API catalogue inside a package README:
+
+```powershell
+dotnet run --project tools/ApiReferenceGenerator -- `
+  --assembly src/ABPlcRx/bin/Release/net10.0/ABPlcRx.dll `
+  --readme packagereadme/ABPlcRx/README.md
+```
+
+The modes are mutually exclusive. README mode appends a marked block when it is absent and replaces precisely that block on later runs:
+
+```markdown
+<!-- BEGIN GENERATED PUBLIC API -->
+## Exhaustive public API reference
+...
+<!-- END GENERATED PUBLIC API -->
+```
+
+The fragment uses heading levels that nest below the package README (`##` catalogue, `###` assembly, `####` type, and `######` member) and intentionally omits local absolute assembly paths. Keep hand-authored explanation, safety guidance, and examples outside the markers; the generator owns only the marked block.
+
+Limitations: reflection reports the public surface of the supplied build only, so select the intended target framework and ensure its dependent assemblies remain beside the DLLs. XML `<inheritdoc/>` is identified but is not resolved across assemblies. C#-style signatures reflect runtime metadata and can therefore omit source-only syntax such as nullable annotations, `required`, default parameter values, and custom attributes.


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is a documentation and NuGet packaging update for the repository's industrial IoT protocol drivers.

It expands the root and package documentation, adds AI-agent skills, introduces reproducible API-reference generation, and makes the Mitsubishi and TwinCAT source generators available as standalone analyzer packages.

## What is the new behavior?

- The root README starts with a wordless industrial IoT hero and lists version/download badges for all 23 produced NuGet packages, including `MitsubishiRx.Generators` and `TwinCATRx.Generators`.
- All seven protocol-family package READMEs use a common detailed structure and contain 187 narrative C# examples covering individual features and combined workflows.
- Exhaustive generated API catalogues document 329 exported types and 3,266 declared public members, including signatures, XML documentation identifiers, parameters, return values, and conservative signature-derived descriptions where XML comments are unavailable.
- Seven protocol-specific `SKILL.md` files provide source-grounded guidance for AI agents and are packed into all 22 relevant protocol packages.
- `MitsubishiRx.Generators` and `TwinCATRx.Generators` are publishable standalone Roslyn analyzer packages while remaining embedded in their applicable runtime packages.
- A reproducible reflection/XML-based API reference generator can idempotently regenerate each package README catalogue.
- `CP.IoT.Core` carries the repository hero asset in its package.

## What is the current behavior?

The package documentation is condensed and inconsistent, omits feature-specific and combined C# workflows, and does not provide exhaustive public API coverage. The root package table omits the Mitsubishi and TwinCAT generator packages. Protocol-specific AI-agent skills are not included in the NuGet packages, and the public API documentation has no reproducible generation path.

## Checklist

- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows Conventional Commits

## Additional information

Validation completed:

- `dotnet pack src/IoT-DriverCore.slnx --configuration Release --no-restore` succeeded.
- All 23 generated NuGet archives passed README, skill, hero, and analyzer payload checks.
- The seven skills passed validation.
- Final targeted TUnit/Microsoft Testing Platform runs passed 514/514.
- The repository suite reconciled to 10,188/10,188 passing tests when S7 target frameworks were serialized.
- Coverage is 74.65% line and 71.75% branch.
- `git diff --check` passed.

The unrelated local edit to `src/IoT-DriverCore.slnx` is intentionally excluded from this PR.
