### PR TITLE
Upgrade CrissCross.WPF.UI to v4.0.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -38,7 +38,7 @@
 
     <PackageVersion Include="YamlDotNet" Version="18.1.0" />
 
-    <PackageVersion Include="CrissCross.WPF.UI" Version="3.3.6" />
+    <PackageVersion Include="CrissCross.WPF.UI" Version="4.0.0" />
 
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="IndexRange" Version="1.1.1" />

--- a/src/ModbusRx.Server.UI/App.xaml
+++ b/src/ModbusRx.Server.UI/App.xaml
@@ -8,8 +8,8 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <!--  CrissCross UI Theme  -->
-                <ui:ThemesDictionary Theme="Dark" />
                 <ui:ControlsDictionary />
+                <ui:ThemesDictionary Theme="Dark" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/src/ModbusRx.Server.UI/App.xaml.cs
+++ b/src/ModbusRx.Server.UI/App.xaml.cs
@@ -2,6 +2,8 @@
 // Chris Pulman and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Windows;
+using ReactiveUI.Builder;
 using Splat;
 
 namespace IoT.DriverCore.ModbusRx.Server.UI;
@@ -12,4 +14,14 @@ public partial class App
     /// <summary>Initializes a new instance of the <see cref="App"/> class.</summary>
     public App() =>
         Locator.CurrentMutable.RegisterConstant<ILogger>(new DebugLogger());
+
+    /// <inheritdoc />
+    protected override void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
+
+        _ = RxAppBuilder.CreateReactiveUIBuilder()
+            .WithWpf()
+            .BuildApp();
+    }
 }

--- a/src/ModbusRx.Server.UI/ModbusRx.Server.UI.csproj
+++ b/src/ModbusRx.Server.UI/ModbusRx.Server.UI.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <Using Include="ReactiveUI.Primitives.Reactive" />
     <Using Include="ReactiveUI.Primitives.Disposables.MultipleDisposable" Alias="CompositeDisposable" />
+    <Using Include="ReactiveUI.Primitives.RxVoid" Alias="Unit" />
   </ItemGroup>
 
 </Project>

--- a/src/ModbusRx.Server.UI/Visualization/ModbusServerViewModel.cs
+++ b/src/ModbusRx.Server.UI/Visualization/ModbusServerViewModel.cs
@@ -144,6 +144,15 @@ public partial class ModbusServerViewModel : ReactiveObject, IDisposable
     /// <summary>Gets the remove client command.</summary>
     public ReactiveCommand<object?, object?> RemoveClientCommand { get; private set; } = null!;
 
+    /// <summary>Gets the save configuration command.</summary>
+    public ReactiveCommand<Unit, Unit> SaveConfigurationCommand { get; private set; } = null!;
+
+    /// <summary>Gets the load configuration command.</summary>
+    public ReactiveCommand<Unit, Unit> LoadConfigurationCommand { get; private set; } = null!;
+
+    /// <summary>Gets the exit application command.</summary>
+    public ReactiveCommand<Unit, Unit> ExitApplicationCommand { get; private set; } = null!;
+
     /// <summary>Performs resource cleanup.</summary>
     public void Dispose()
     {
@@ -262,7 +271,7 @@ public partial class ModbusServerViewModel : ReactiveObject, IDisposable
         var canStop = this.WhenAnyValue(x => x.IsServerRunning);
         var hasSelectedClient = this.WhenAnyValue(x => x.SelectedClientConfiguration).Select(c => c is not null);
         var canAddClient = this.WhenAnyValue(x => x.NewClientName, x => x.NewClientAddress)
-            .Select(x => !string.IsNullOrWhiteSpace(x.Item1) && !string.IsNullOrWhiteSpace(x.Item2));
+            .Select(x => !string.IsNullOrWhiteSpace(x.Value1) && !string.IsNullOrWhiteSpace(x.Value2));
 
         StartServerCommand = CreateCommand(StartServerAsync, canStart);
         StopServerCommand = CreateCommand(StopServerAsync, canStop);
@@ -270,6 +279,9 @@ public partial class ModbusServerViewModel : ReactiveObject, IDisposable
         ClearDataCommand = CreateCommand(ClearData);
         AddClientCommand = CreateCommand(AddClientAsync, canAddClient);
         RemoveClientCommand = CreateCommand(RemoveClientAsync, hasSelectedClient);
+        SaveConfigurationCommand = ReactiveCommand.CreateFromTask(SaveConfigurationAsync);
+        LoadConfigurationCommand = ReactiveCommand.CreateFromTask(LoadConfigurationAsync);
+        ExitApplicationCommand = ReactiveCommand.Create(ExitApplication);
 
         // Subscribe to command results
         _ = StartServerCommand.Subscribe(_ => StatusMessage = "Server started successfully");
@@ -290,6 +302,9 @@ public partial class ModbusServerViewModel : ReactiveObject, IDisposable
         _disposables.Add(ClearDataCommand);
         _disposables.Add(AddClientCommand);
         _disposables.Add(RemoveClientCommand);
+        _disposables.Add(SaveConfigurationCommand);
+        _disposables.Add(LoadConfigurationCommand);
+        _disposables.Add(ExitApplicationCommand);
     }
 
     /// <summary>Initializes configuration and server state asynchronously.</summary>
@@ -505,7 +520,6 @@ public partial class ModbusServerViewModel : ReactiveObject, IDisposable
 
     /// <summary>Saves the current server configuration.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    [ReactiveCommand]
     private async Task SaveConfigurationAsync()
     {
         if (ServerConfiguration is null)
@@ -528,7 +542,6 @@ public partial class ModbusServerViewModel : ReactiveObject, IDisposable
 
     /// <summary>Loads server and client configuration.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    [ReactiveCommand]
     private async Task LoadConfigurationAsync()
     {
         try
@@ -553,7 +566,6 @@ public partial class ModbusServerViewModel : ReactiveObject, IDisposable
     }
 
     /// <summary>Exits the application after stopping the server when needed.</summary>
-    [ReactiveCommand]
     private void ExitApplication()
     {
         try

--- a/src/S7PlcRx/RxS7.Read.cs
+++ b/src/S7PlcRx/RxS7.Read.cs
@@ -163,7 +163,15 @@ public partial class RxS7
                     return false;
                 }
 
-                _ = _socketRx.Receive(tag, receiveBuffer, WriteResponseBufferSize);
+                var received = _socketRx.ReceiveIsoData(tag, ref receiveBuffer);
+                if (received <= ResponseReturnCodeOffset)
+                {
+                    _lastErrorCode.OnNext(ErrorCode.WriteData);
+                    _lastError.OnNext(
+                        $"Tag {tag.Name} failed to write - {nameof(ErrorCode.WrongNumberReceivedBytes)} " +
+                        $"received {received} bytes.");
+                    return false;
+                }
 
                 if (receiveBuffer[ResponseReturnCodeOffset] != 0xff)
                 {

--- a/src/TwinCATRx/RxTcAdsClient.Variables.cs
+++ b/src/TwinCATRx/RxTcAdsClient.Variables.cs
@@ -24,6 +24,9 @@ namespace IoT.DriverCore.TwinCATRx;
 /// <summary>Observable TwinCAT ADS Client.</summary>
 public partial class RxTcAdsClient
 {
+    /// <summary>Synchronizes generated data-type cleanup, creation, and loading across client instances.</summary>
+    private static readonly object GeneratedDataTypeFileLock = new();
+
     /// <summary>Builds the generated data type file prefix.</summary>
     /// <param name="variable">The PLC variable name.</param>
     /// <returns>The generated data type file prefix.</returns>
@@ -215,10 +218,14 @@ public partial class RxTcAdsClient
 
         var identifier = _timeProvider.GetUtcNow().UtcTicks.ToString(CultureInfo.InvariantCulture);
         var dataTypesBaseName = BuildDataTypesFileName(notificationVariable);
-        DeleteGeneratedDataTypeFiles(dataTypesBaseName);
-
         var dataTypesFileName = $"{dataTypesBaseName}{identifier}.dll";
-        var type = ResolveNotificationType(notificationVariable, dataTypesFileName, identifier, isTwinCat3);
+        Type? type;
+        lock (GeneratedDataTypeFileLock)
+        {
+            DeleteGeneratedDataTypeFiles(dataTypesBaseName);
+            type = ResolveNotificationType(notificationVariable, dataTypesFileName, identifier, isTwinCat3);
+        }
+
         if (type is null)
         {
             return;


### PR DESCRIPTION
- Bump CrissCross.WPF.UI package from 3.3.6 to 4.0.0
- Reorder resource dictionaries in App.xaml for v4 compatibility
- Add ReactiveUI builder initialization in App.OnStartup
- Replace [ReactiveCommand] attributes with explicit ReactiveCommand properties
- Fix tuple property access (Item1/Item2 → Value1/Value2)
- Add Unit alias for RxVoid in global usings