### PR TITLE
feat: add package docs, artwork, and CI stabilization

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,11 @@ Keep subscriptions alive for the required session and dispose them with the owni
 
 ## AI-agent skills
 
-Every protocol-family NuGet package includes a concise skill at `skills/<skill-name>/SKILL.md`. The skills tell an AI agent which namespace and package variant to use, which safety and lifecycle rules are mandatory, how to choose the protocol workflow, and where to find the full packaged README.
+Every NuGet package includes a detailed skill at `skills/<skill-name>/SKILL.md`. The skills tell an AI agent which namespace and package variant to use, how to configure and operate the driver, which safety and lifecycle rules are mandatory, how to test without hardware, and where to find the full packaged README.
 
 | Family | Packaged skill |
 | --- | --- |
+| Shared core | [`cp-iot-core`](skills/cp-iot-core/SKILL.md) |
 | Allen-Bradley | [`ab-plc-rx`](skills/ab-plc-rx/SKILL.md) |
 | Mitsubishi | [`mitsubishi-rx`](skills/mitsubishi-rx/SKILL.md) |
 | Modbus | [`modbus-rx`](skills/modbus-rx/SKILL.md) |

--- a/images/ab-plc-rx.png
+++ b/images/ab-plc-rx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07a5791a7aa07bc8d84c2e05e4f5e163e19325b3fc58fe72a5f82182591d03d6
+size 536598

--- a/images/cp-iot-core.png
+++ b/images/cp-iot-core.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e8754f5cd0e8887c63960c154aadf1fa46425ffe39bb76b79ef95cb1c709377
+size 535726

--- a/images/mitsubishi-rx.png
+++ b/images/mitsubishi-rx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:790ecc4db71ebd20b4798fc7da20b83c522292798f052bfde4b47d9f18f8d252
+size 533948

--- a/images/modbus-rx.png
+++ b/images/modbus-rx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ba8773f5155144b98ef4128adc337bc657fed59ece61602b68ebb170dd66786
+size 546188

--- a/images/omron-plc-rx.png
+++ b/images/omron-plc-rx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12b4b7a54af58294a46e25e4b6cb4b9c1cb36d0d882ef303b8a9bbace498bd98
+size 523738

--- a/images/s7-plc-rx.png
+++ b/images/s7-plc-rx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5e5283f35f00ddd9566471d421f75d988b9414961e5887fc5f96a541f844f53
+size 528546

--- a/images/serial-port-rx.png
+++ b/images/serial-port-rx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:522e632059aa5c08e80f76ccbe902f12fb1182088e23a3978cde324d3995288c
+size 543401

--- a/images/twincat-rx.png
+++ b/images/twincat-rx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb8bcf11973fc80fae08d631385678a70869e5f271bf4d6224aeff427fdc81cc
+size 525356

--- a/packagereadme/ABPlcRx/README.md
+++ b/packagereadme/ABPlcRx/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ChrisPulman/IoT-DriverCore/main/images/ab-plc-rx.png" alt="ABPlcRx package logo" width="320" />
+</p>
+
 # ABPlcRx
 
 ## Overview

--- a/packagereadme/CP.IoT.Core/README.md
+++ b/packagereadme/CP.IoT.Core/README.md
@@ -1,0 +1,134 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ChrisPulman/IoT-DriverCore/main/images/cp-iot-core.png" alt="CP.IoT.Core package logo" width="320" />
+</p>
+
+# CP.IoT.Core
+
+## Overview
+
+`CP.IoT.Core` is the protocol-neutral composition layer shared by the IoT-DriverCore PLC drivers. It gives applications stable logical names while each protocol adapter remains responsible for physical addresses, value conversion, batching, and transport failures.
+
+Use it to define logical tags once, compose clients from different PLC families, persist definitions, plan contiguous transfers, or test application behavior without PLC hardware.
+
+## Install
+
+```bash
+dotnet add package CP.IoT.Core
+```
+
+The public namespace is `IoT.DriverCore.Core`.
+
+## Core model
+
+- `LogicalTag` is an immutable definition containing a logical name, protocol address, data type, access mode, optional scan interval, group, description, and metadata.
+- `LogicalTagKey<T>` adds compile-time value typing to a logical name.
+- `LogicalTagCatalog` is a thread-safe in-memory catalogue with add, update, remove, list, and change notification operations.
+- `ILogicalTagClient` composes the read, write, observable, and async-observable contracts implemented by protocol adapters.
+- `TagOperationResult<T>` reports expected operation failures through `Succeeded`, `Value`, and `Error`.
+- `LogicalTagSqliteStore` persists tag and group definitions and can reconstruct a catalogue.
+- `TagTransferPlanner` groups compatible adjacent or overlapping addresses within protocol limits.
+- `SimulatorLogicalTagClient`, `SimulatorMemoryImage`, clocks, and scripts provide deterministic hardware-free execution.
+
+## Define and catalogue tags
+
+```csharp
+using IoT.DriverCore.Core;
+
+using var catalog = new LogicalTagCatalog();
+
+var temperature = new LogicalTag(
+    "Reactor.Temperature",
+    "DB10.DBD0",
+    "Single",
+    new LogicalTagOptions
+    {
+        GroupName = "Reactor",
+        Description = "Process temperature",
+        AccessMode = LogicalTagAccessMode.Read,
+        ScanInterval = TimeSpan.FromSeconds(1),
+    });
+
+catalog.Upsert(temperature);
+
+var temperatureKey = new LogicalTagKey<float>(temperature);
+```
+
+The address string remains protocol-specific. Create it with the syntax expected by the selected driver; the core library deliberately does not reinterpret it.
+
+## Read and write through a driver
+
+Protocol packages expose or compose an `ILogicalTagClient`. Typed extension methods preserve the logical key type:
+
+```csharp
+using IoT.DriverCore.Core;
+
+static async Task<float> ReadTemperatureAsync(
+    ILogicalTagClient client,
+    LogicalTagKey<float> key,
+    CancellationToken cancellationToken)
+{
+    var result = await client.ReadAsync(key, cancellationToken);
+    if (!result.Succeeded || result.Value is null)
+    {
+        throw new InvalidOperationException(result.Error);
+    }
+
+    return result.Value;
+}
+```
+
+Inspect every result before using its value. Expected PLC, address, conversion, and transport failures are returned as unsuccessful results; argument and lifecycle errors may still throw.
+
+## Observe changes
+
+`ILogicalTagObserver` supports both `IObservable<LogicalTagValue>` and cancellation-aware `IAsyncEnumerable<LogicalTagValue>`:
+
+```csharp
+await foreach (var change in client.ObserveAsync(
+    temperatureKey.Name,
+    cancellationToken))
+{
+    Console.WriteLine($"{change.TagName}: {change.Value} at {change.TimestampUtc:O}");
+}
+```
+
+Dispose observable subscriptions and cancel async enumeration when the owning component stops.
+
+## Persist definitions
+
+```csharp
+var store = new LogicalTagSqliteStore("Data Source=logical-tags.db");
+await store.UpsertTagAsync(temperature, cancellationToken);
+
+using var restoredCatalog = await store.LoadCatalogAsync(cancellationToken);
+```
+
+`LogicalTagCsv` provides import and export when definitions must be reviewed or exchanged as text. Validate imported addresses against the target protocol before connecting to equipment.
+
+## Batch planning
+
+`TagTransferPlanner` consumes addresses already parsed by a protocol adapter. It preserves caller result positions while coalescing compatible ranges subject to `TagTransferCapabilities`.
+
+```csharp
+var planner = new TagTransferPlanner(
+    new TagTransferCapabilities(maximumRangeLength: 120, maximumItemsPerRange: 32));
+```
+
+Adapters should use distinct transport partitions, memory areas, encodings, access directions, and routes so the planner never combines incompatible requests.
+
+## Simulation and testing
+
+Use `SimulatorLogicalTagClient` with a `SimulatorMemoryImage`, typed `SimulatorTagBinding` instances, a transfer planner, and optionally a `ManualSimulatorClock` or `SimulatorScript`. This exercises the same logical read, write, batch, and observation contracts without opening a network or serial connection.
+
+Prefer the simulator for unit and integration tests. Before production use, validate the final tag catalogue, write permissions, byte ordering, ranges, and failure handling on a safe test rig.
+
+## Lifetime and cancellation
+
+- Pass a meaningful `CancellationToken` to I/O, persistence, and async observation operations.
+- Dispose `LogicalTagCatalog` and every subscription owned by the application.
+- Treat tag definitions as immutable; use `WithAddress`, `WithDataType`, or `WithOptions`, then update the catalogue.
+- Keep protocol-specific address parsing and codecs in the protocol adapter rather than in application-domain models.
+
+## Agent skill
+
+The package includes the detailed `skills/cp-iot-core/SKILL.md` guide for coding agents. The complete repository documentation is available at [IoT-DriverCore](https://github.com/ChrisPulman/IoT-DriverCore).

--- a/packagereadme/MitsubishiRx/README.md
+++ b/packagereadme/MitsubishiRx/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ChrisPulman/IoT-DriverCore/main/images/mitsubishi-rx.png" alt="MitsubishiRx package logo" width="320" />
+</p>
+
 # MitsubishiRx
 
 ## Overview

--- a/packagereadme/ModbusRx/README.md
+++ b/packagereadme/ModbusRx/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ChrisPulman/IoT-DriverCore/main/images/modbus-rx.png" alt="ModbusRx package logo" width="320" />
+</p>
+
 # ModbusRx
 
 ## Overview

--- a/packagereadme/OmronPlcRx/README.md
+++ b/packagereadme/OmronPlcRx/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ChrisPulman/IoT-DriverCore/main/images/omron-plc-rx.png" alt="OmronPlcRx package logo" width="320" />
+</p>
+
 # OmronPlcRx
 
 ## Overview

--- a/packagereadme/S7PlcRx/README.md
+++ b/packagereadme/S7PlcRx/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ChrisPulman/IoT-DriverCore/main/images/s7-plc-rx.png" alt="S7PlcRx package logo" width="320" />
+</p>
+
 # S7PlcRx
 
 Reactive Siemens S7 PLC communication for .NET. S7PlcRx provides tag-based S7 reads/writes, Primitives-based observable streams, optimized batch helpers, caching, diagnostics, production reliability helpers, high-availability helpers, PLC byte conversion utilities, and source-generator assisted property bindings. Version 3 moves the core package to ReactiveUI.Primitives and adds a companion `S7PlcRx.Reactive` package for System.Reactive-compatible applications.

--- a/packagereadme/SerialPortRx/README.md
+++ b/packagereadme/SerialPortRx/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ChrisPulman/IoT-DriverCore/main/images/serial-port-rx.png" alt="SerialPortRx package logo" width="320" />
+</p>
+
 # SerialPortRx
 A Reactive Serial, TCP, and UDP I/O library that exposes incoming data as IObservable streams and accepts writes via simple methods. Ideal for event-driven, message-framed, and polling scenarios.
 

--- a/packagereadme/TwinCATRx/README.md
+++ b/packagereadme/TwinCATRx/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ChrisPulman/IoT-DriverCore/main/images/twincat-rx.png" alt="TwinCATRx package logo" width="320" />
+</p>
+
 # TwinCATRx
 
 ## Overview

--- a/skills/ab-plc-rx/SKILL.md
+++ b/skills/ab-plc-rx/SKILL.md
@@ -1,16 +1,82 @@
 ---
 name: ab-plc-rx
-description: Implement, review, or troubleshoot reactive Allen-Bradley PLC access with ABPlcRx. Use for libplctag tag registration, scanning, reads, writes, observables, simulator tests, and generated PLC stream models.
+description: Implement, review, or troubleshoot Allen-Bradley PLC access with ABPlcRx, including libplctag registration, scanning, typed reads and writes, observables, logical tags, simulation, and generated models.
 ---
 
 # ABPlcRx
 
-Use `IoT.DriverCore.ABPlcRx` for the default package surface. Register each physical tag with an explicit logical variable, group, and generic type witness before reading, writing, or subscribing.
+## Use this skill when
 
-Treat writes as safety-critical. Validate addressing, route, data type, bit index, and operational interlocks against a non-production controller. Use `short` plus a 0–15 bit index for SLC/PLC-5 word bits; do not apply word-bit access to a native boolean tag.
+Use this skill for ControlLogix, CompactLogix, MicroLogix, SLC, or PLC-5 access through libplctag.
 
-Manage client and subscription lifetimes explicitly. Use `AutoWriteValue = false` with `Write` for deliberate staged writes; inspect `PlcTagResult.StatusCode`, `PlcTagStatus.DecodeError`, and `ObserveErrors` rather than ignoring failures. Prefer `ReadManyAsync`, `WriteManyAsync`, or grouped scans for multi-tag work.
+Read the co-packaged `../../README.md` first. In a repository checkout use `packagereadme/ABPlcRx/README.md`; inspect `src/ABPlcRx` before describing undocumented members.
 
-Use `ABPlcSimulator` to test registrations, values, reconnect behavior, and injected faults without hardware. For constructor, API, and source-generator details, read the co-packaged `../../README.md`; in a repository checkout use `packagereadme/ABPlcRx/README.md`.
+## Package choice
 
-`ABPlcRx` and `ABPlcRx.Reactive` already embed the matching source generator. Install `ABPlcRx.Generators` only when the analyzer must be pinned or managed independently, and never load a second generator version alongside the embedded analyzer.
+- Use `ABPlcRx` and `IoT.DriverCore.ABPlcRx` for the ReactiveUI.Primitives surface.
+- Use `ABPlcRx.Reactive` and its `.Reactive` namespace only for the System.Reactive-oriented surface.
+- Both runtime packages embed the generator. Install `ABPlcRx.Generators` only to version the analyzer independently, and never load a duplicate generator version.
+
+## Connection and registration
+
+Construct `ABPlcRx` with `PlcType`, IP address, scan interval, and optional timeout/path. Choose `LGX`, `SLC`, or `PLC5` deliberately and verify the Logix route such as `"1,0"` where required.
+
+```csharp
+using IoT.DriverCore.ABPlcRx;
+
+using var plc = new ABPlcRx(
+    PlcType.LGX,
+    "192.168.1.60",
+    TimeSpan.FromMilliseconds(200));
+
+plc.AddUpdateTagItem("Counter", "MyDINT", "Default", 0);
+
+using var errors = plc.ObserveErrors.Subscribe(Console.Error.WriteLine);
+using var changes = plc.Observe("Counter", 0, -1)
+    .Subscribe(value => Console.WriteLine($"Counter = {value}"));
+```
+
+Register each physical tag under a unique logical variable and group before use. The final argument is the generic type witness. For an SLC/PLC-5 word bit, register a `short` and use bit index 0–15; do not use word-bit indexing for a native Logix boolean.
+
+## Read and write workflow
+
+- Prefer cancellation-aware `ReadValueAsync`/`WriteValueAsync` and typed methods for application operations.
+- Inspect `PlcTagResult.StatusCode`; use `PlcTagStatus.IsError` and `PlcTagStatus.DecodeError`.
+- Use `ReadManyAsync`, `WriteManyAsync`, or grouped scans for multiple variables.
+- `Value` updates the cache. With `AutoWriteValue = true` it also writes.
+- For deliberate staging, set `AutoWriteValue = false`, set values, then call `Write(variable)` or `Write()`.
+
+```csharp
+plc.AutoWriteValue = false;
+plc.Value("Counter", 42, -1);
+var result = plc.Write("Counter");
+if (result is not null && PlcTagStatus.IsError(result.StatusCode))
+    throw new InvalidOperationException(PlcTagStatus.DecodeError(result.StatusCode));
+```
+
+Treat a staged value as uncommitted until the write result confirms success. Do not retry a non-idempotent command blindly.
+
+## Observation and lifetime
+
+Use `Observe`, `ObserveMany`, grouped streams, sampling, or `IObservableAsync<T>` according to workload. Subscribe to `ObserveErrors` and health/ping streams before operational writes. Dispose every subscription and the client, and pass meaningful cancellation tokens to async I/O.
+
+Use `ScanEnabled` to control registered scans. Start with a conservative interval, group variables by cadence, and avoid high-frequency polling that overloads the controller or route.
+
+## Logical tags
+
+Use `LogicalTagKey<T>` from `IoT.DriverCore.Core` to keep application names typed. The AB adapter owns libplctag addresses and conversions. Use its catalogue, access policy, CSV, SQLite, and bulk logical-tag surfaces instead of duplicating protocol logic.
+
+## Simulator and generated models
+
+Use `ABPlcSimulator` to exercise registration, reads, writes, scans, batches, disconnect/reconnect behavior, and injected faults without hardware. Assert error delivery and recovery as well as successful values.
+
+For generation, declare the documented partial model and attributes, build once, inspect generator diagnostics and generated members, then test observations, writes, and disposal against the simulator.
+
+## Safety checklist
+
+- Verify PLC type, route, physical address, CLR type, array/string length, and bit index.
+- Require controller-side and application-side write interlocks.
+- Check every result and subscribe to the error stream.
+- Make cancellation, subscription, and client ownership explicit.
+- Test timeout, fault, reconnect, and cancellation paths.
+- Commission on a safe controller or test rig before production equipment.

--- a/skills/cp-iot-core/SKILL.md
+++ b/skills/cp-iot-core/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: cp-iot-core
+description: Design, implement, review, or test protocol-neutral logical-tag workflows with CP.IoT.Core, including catalogues, typed keys, operation results, observation, persistence, batching, and simulation.
+---
+
+# CP.IoT.Core
+
+## Use this skill when
+
+Use this skill when application code must work with logical PLC names independently of a specific wire protocol, share tag definitions across several drivers, persist a catalogue, plan adjacent transfers, or run deterministic tests without hardware.
+
+Read the co-packaged `../../README.md` for examples. In a repository checkout, use `packagereadme/CP.IoT.Core/README.md` and inspect `src/CP.IoT.Core` before describing members not covered there.
+
+## Package and namespace
+
+- Install `CP.IoT.Core`.
+- Import `IoT.DriverCore.Core`.
+- Protocol runtime packages reference these contracts and expose or compose `ILogicalTagClient`.
+- Keep protocol address parsing, byte order, conversion, and transport retries in the protocol adapter.
+
+## Model a tag
+
+Create an immutable `LogicalTag(name, address, dataType[, options])`. The name is application-owned; the address and data-type strings must match the selected protocol adapter.
+
+Use `LogicalTagOptions` for `GroupName`, `Description`, `Metadata`, `AccessMode`, and `ScanInterval`. Required strings are validated, access modes must be defined, and scan intervals must be positive.
+
+Use `LogicalTagKey<T>` whenever the application knows the expected CLR type:
+
+```csharp
+using IoT.DriverCore.Core;
+
+var definition = new LogicalTag(
+    "Line.Speed",
+    "DB20.DBD0",
+    "Single",
+    new LogicalTagOptions
+    {
+        AccessMode = LogicalTagAccessMode.ReadWrite,
+        ScanInterval = TimeSpan.FromMilliseconds(250),
+    });
+
+var speed = new LogicalTagKey<float>(definition);
+```
+
+Treat definitions as immutable. Use `WithAddress`, `WithDataType`, or `WithOptions`, then update the catalogue.
+
+## Catalogue and setup
+
+`LogicalTagCatalog` is a thread-safe `ILogicalTagCatalog`. Use `TryAdd`, `Upsert`, `TryGet`, `TryRemove`, and `List`; subscribe to `Changed` when application state must follow catalogue edits. Dispose the catalogue when its owner stops.
+
+Drivers that implement `IManagedLogicalTagClient` also implement `ILogicalTagSetup`: register tags through their setup surface instead of maintaining an unrelated second catalogue.
+
+## Read, write, and observe
+
+`ILogicalTagClient` combines `ILogicalTagReader`, `ILogicalTagWriter`, and `ILogicalTagObserver`.
+
+- Call typed `ReadAsync<T>(LogicalTagKey<T>, CancellationToken)` and `WriteAsync<T>(LogicalTagKey<T>, T, CancellationToken)` when possible.
+- Use `ReadManyAsync`, `WriteManyAsync`, `ReadAllAsync`, and `WriteAllAsync` for batches supported by the adapter.
+- Check `TagOperationResult<T>.Succeeded` before using `Value`; log or surface `Error` on failure.
+- Use `Observe`/`ObserveMany` for `IObservable<LogicalTagValue>`.
+- Use `ObserveAsync`/`ObserveManyAsync` for cancellation-aware `IAsyncEnumerable<LogicalTagValue>`.
+- Dispose subscriptions and cancel async enumeration with the owning component.
+
+Expected PLC, conversion, access, and transport failures may be returned as failed results. Invalid arguments and disposed-object usage may still throw.
+
+## Persistence and definition exchange
+
+Use `LogicalTagSqliteStore` to get, list, upsert, edit, delete, and load tag and group definitions. Pass cancellation tokens to persistence work. Use `LoadCatalogAsync` to reconstruct an in-memory catalogue.
+
+Use `LogicalTagCsv.ExportAsync` and `ImportAsync` for reviewable definition exchange. Treat imported files as untrusted configuration: validate names, addresses, types, access permissions, and scan rates before deployment.
+
+## Transfer planning
+
+`TagTransferPlanner` does not parse PLC syntax. Give it `TagTransferRequest` values containing adapter-produced `TagTransportAddress` instances.
+
+Set `TagTransferCapabilities.MaximumRangeLength` and `MaximumItemsPerRange` to actual protocol limits. Partition by transport, memory area, encoding, access direction, and route so incompatible operations cannot be coalesced. Preserve the plan's input indexes when mapping results back to callers.
+
+## Simulation workflow
+
+Compose a `SimulatorMemoryImage`, typed `SimulatorTagBinding.Create<T>` entries, a `TagTransferPlanner`, a `SimulatorLogicalTagClient`, and optionally a `ManualSimulatorClock` and `SimulatorScript`.
+
+Test single and batch reads/writes, access-mode rejection, observations, latency, injected errors, and caller cancellation. Use a safe PLC or test rig only after the simulator workflow is green.
+
+## Safety checklist
+
+- Never assume that identical logical names imply identical protocol addresses.
+- Verify write access, machine interlocks, scaling, endianness, string lengths, and array bounds.
+- Keep cancellation and disposal ownership explicit.
+- Batch only compatible addresses within adapter limits.
+- Persist definitions outside active I/O transactions and review changes before rollout.
+- Prefer composition through `ILogicalTagClient` over inheritance between concrete protocol clients.

--- a/skills/mitsubishi-rx/SKILL.md
+++ b/skills/mitsubishi-rx/SKILL.md
@@ -1,18 +1,88 @@
 ---
 name: mitsubishi-rx
-description: Implement, review, or document Mitsubishi MC Protocol and SLMP integrations using MitsubishiRx or MitsubishiRx.Reactive. Use when configuring Mitsubishi PLC transports, direct devices, tags, polling, write pipelines, serial frames, or simulator-backed tests.
+description: Implement, review, or troubleshoot Mitsubishi MC Protocol and SLMP integrations with MitsubishiRx, including Ethernet and serial frames, device and tag operations, observations, logical tags, simulation, and generation.
 ---
 
 # MitsubishiRx
 
-Before changing an integration, read the co-packaged `../../README.md`; in a repository checkout use `packagereadme/MitsubishiRx/README.md`.
+## Use this skill when
 
-- Import `IoT.DriverCore.MitsubishiRx` or the `.Reactive` namespace that matches the selected package; never mix both surfaces casually.
-- Both runtime packages carry the analyzer, but the current generator emits the base `IoT.DriverCore.MitsubishiRx` surface and requires the base `MitsubishiRx` runtime. Install `MitsubishiRx.Generators` only alongside that base runtime when the analyzer must be versioned independently; use handwritten APIs in a `.Reactive`-only project and never load duplicate analyzer versions.
-- Construct `MitsubishiRx` with `MitsubishiClientOptions`, an optional `IMitsubishiTransport`, and an optional scheduler. Check `Responce.IsSucceed` before reading `Value`.
-- Match frame, data code, transport, route, serial format, and X/Y notation to the real PLC/module configuration. Require `MitsubishiSerialOptions` for serial transport.
-- Use cancellation tokens, dispose clients/subscriptions, batch contiguous reads, and serialize or coalesce writes.
-- Treat remote control, passwords, memory, raw commands, and writes as safety-sensitive; require explicit interlocks and audit evidence.
-- Validate tag databases and preview diffs before rollout. Use `MitsubishiSimulatorTransport` / `MitsubishiSimulatorMemory` for deterministic tests.
-- For generated clients, define and validate the supported Mitsubishi attributes, build once to inspect the generated surface, then exercise generated reads, writes, and observations against a simulator before connecting to a PLC.
-- Inspect `src/MitsubishiRx` before describing an API; shared reactive source changes namespaces under `REACTIVE_SHIM`.
+Use this skill for MELSEC MC Protocol or SLMP using 1E/3E/4E Ethernet frames or 1C/3C/4C serial frames over TCP, UDP, or serial transports.
+
+Read the co-packaged `../../README.md`; in a repository checkout use `packagereadme/MitsubishiRx/README.md`. Inspect `src/MitsubishiRx` before describing an API because the reactive build changes namespaces through shared source.
+
+## Package choice
+
+- Use `MitsubishiRx` with `IoT.DriverCore.MitsubishiRx` by default.
+- Use `MitsubishiRx.Reactive` and its `.Reactive` namespace for System.Reactive applications.
+- Both runtime packages carry an analyzer, but the current generator emits the base namespace and requires the base runtime.
+- Install `MitsubishiRx.Generators` only with the base runtime when independently versioning the analyzer. Never load duplicate analyzers.
+
+## Configure and open
+
+Match `FrameType`, `DataCode`, `TransportKind`, route, monitoring timer, CPU hint, and X/Y notation to the PLC or communication module. For serial, provide validated `MitsubishiSerialOptions`.
+
+```csharp
+using IoT.DriverCore.MitsubishiRx;
+
+var options = new MitsubishiClientOptions(
+    Host: "192.168.0.10",
+    Port: 5000,
+    FrameType: MitsubishiFrameType.ThreeE,
+    DataCode: CommunicationDataCode.Binary,
+    TransportKind: MitsubishiTransportKind.Tcp,
+    Timeout: TimeSpan.FromSeconds(3));
+
+await using var plc = new MitsubishiRx(options, transport: null, scheduler: null);
+var opened = await plc.OpenAsync(CancellationToken.None);
+if (!opened.IsSucceed)
+    throw new InvalidOperationException(opened.Err);
+```
+
+Do not infer framing from the CPU family alone. Confirm network/serial module settings and routing.
+
+## Responses and I/O
+
+Operations return `Responce` or `Responce<T>`. Always check `IsSucceed` before reading `Value`, and report `Err` with operation/address context.
+
+```csharp
+var read = await plc.ReadWordsAsync("D100", 2, CancellationToken.None);
+if (!read.IsSucceed || read.Value is null)
+    throw new InvalidOperationException(read.Err);
+
+var write = await plc.WriteWordsAsync(
+    "D100",
+    new ushort[] { 42 },
+    CancellationToken.None);
+if (!write.IsSucceed)
+    throw new InvalidOperationException(write.Err);
+```
+
+Use word/bit APIs for direct devices and typed tag APIs when the tag database owns conversion. Batch contiguous addresses, keep X/Y notation explicit, and serialize or coalesce competing writes.
+
+## Tags, observation, and logical names
+
+Create and validate tag definitions before polling. Use `ConnectionStates` and `OperationLogs` for operational visibility. Dispose observation subscriptions.
+
+Use `CreateLogicalTagClient` to compose protocol-neutral `LogicalTagKey<T>` workflows. Keep MC/SLMP device syntax in the adapter and use catalogue access modes to reject unintended writes.
+
+## Diagnostics and sensitive commands
+
+Treat PLC run/stop/reset control, password operations, memory commands, raw commands, and writes as safety-sensitive. Subscribe to logs/state before invoking them, require explicit authorization and machine interlocks, and preserve an audit trail.
+
+Pass cancellation tokens to open and I/O operations. `await using` the client so the transport and polling work are released.
+
+## Simulation and generation
+
+Use `MitsubishiSimulatorTransport` and `MitsubishiSimulatorMemory` for deterministic tests of reads, writes, tag conversion, batches, logging, cancellation, timeout, and injected failures.
+
+For generated clients, define only supported Mitsubishi attributes, build once to inspect diagnostics and the generated base-namespace surface, then test generated reads, writes, observations, and disposal against the simulator.
+
+## Safety checklist
+
+- Verify frame, binary/ASCII data code, transport, route, station, and serial format.
+- Validate device syntax, X/Y notation, value type, word order, and range.
+- Check `IsSucceed` before every `Value`.
+- Batch only compatible contiguous addresses.
+- Protect every control/write operation with interlocks and authorization.
+- Commission with simulator and safe test hardware before production.

--- a/skills/modbus-rx/SKILL.md
+++ b/skills/modbus-rx/SKILL.md
@@ -1,17 +1,87 @@
 ---
 name: modbus-rx
-description: Implement, review, or document Modbus TCP, UDP, RTU, ASCII, server, simulation, logical-tag, or observable integrations using ModbusRx or ModbusRx.Reactive.
+description: Implement, review, or troubleshoot Modbus TCP, UDP, RTU, ASCII, master, slave, simulation, logical-tag, observable, and generated register-map workflows with ModbusRx.
 ---
 
 # ModbusRx
 
-Before changing an integration, read the co-packaged `../../README.md`; in a repository checkout use `packagereadme/ModbusRx/README.md`.
+## Use this skill when
 
-- Import `IoT.DriverCore.ModbusRx` or its `.Reactive` counterpart to match the selected package.
-- Install `ModbusRx.Generators` alongside the selected runtime package when attribute-driven register maps are required; the runtime packages do not embed this analyzer.
-- Create masters through `ModbusIpMaster.CreateIp` or `ModbusSerialMaster.CreateRtu` / `CreateAscii`; match endpoint and serial settings to the device.
-- Use zero-based API addresses, correct unit IDs, and protocol limits: 2,000 bits, 125 read registers, 1,968 coils, 123 write registers, and 121 combined-write registers.
-- Batch contiguous ranges, dispose masters/slaves/servers and observable subscriptions, and make retryable writes idempotent.
-- Use `DataStore`, `ModbusSimulator`, or `ModbusTcpLoopbackEndpoint` for tests before a physical device. Synchronize direct `DataStore` access.
-- Treat every write as safety-sensitive; validate function, unit ID, address, value, access permissions, and interlocks.
-- Inspect `src/ModbusRx` before describing an API; the reactive package compiles shared source under a different namespace.
+Use this skill for Modbus clients, servers/slaves, gateways, simulators, logical tags, polling, or generated device maps.
+
+Read the co-packaged `../../README.md`; in a repository checkout use `packagereadme/ModbusRx/README.md`. Inspect `src/ModbusRx` before describing undocumented members because the reactive package compiles shared source under a different namespace.
+
+## Package choice
+
+- Use `ModbusRx` with `IoT.DriverCore.ModbusRx` by default.
+- Use `ModbusRx.Reactive` and its `.Reactive` namespace for System.Reactive applications.
+- Runtime packages do not embed the analyzer. Install `ModbusRx.Generators` alongside the selected runtime only when generated register maps are required.
+
+## Master workflow
+
+Create the transport first, then create the master. Match endpoint, timeouts, unit ID, and serial parameters to the device.
+
+```csharp
+using IoT.DriverCore.ModbusRx.Device;
+using IoT.DriverCore.Serial;
+
+using var tcp = new TcpClientRx("192.168.0.20", 502);
+using var master = ModbusIpMaster.CreateIp(tcp);
+
+var registers = await master.ReadHoldingRegistersAsync(
+    slaveAddress: 1,
+    startAddress: 0,
+    numberOfPoints: 2);
+
+await master.WriteSingleRegisterAsync(
+    slaveAddress: 1,
+    registerAddress: 0,
+    value: 42);
+```
+
+For serial links, configure `SerialPortRx`, then call `ModbusSerialMaster.CreateRtu` or `CreateAscii`. Dispose both the master and its owned/non-owned transport according to the constructor contract.
+
+## Addressing and limits
+
+API addresses are zero-based offsets; do not pass display references such as 40001 directly. Preserve the unit ID for serial devices and TCP/UDP gateways.
+
+Respect protocol limits:
+
+- read up to 2,000 bits or 125 registers;
+- write up to 1,968 coils or 123 registers;
+- combined read/write supports up to 121 write registers.
+
+Batch contiguous coils/registers and decode byte/word order explicitly. Do not assume every vendor uses the same 32-bit or floating-point ordering.
+
+## Function families and failures
+
+Use `ReadCoilsAsync`, `ReadInputsAsync`, `ReadHoldingRegistersAsync`, `ReadInputRegistersAsync`, single/multiple write methods, and `ReadWriteMultipleRegistersAsync` for their matching function codes.
+
+Catch and classify `SlaveException`, `InvalidModbusRequestException`, and `ModbusCommunicationException`. Include unit ID, function, and zero-based range in diagnostics without exposing secrets. Retry only idempotent work unless the application can prove the original write was not accepted.
+
+## Logical tags and observables
+
+Use the logical-tag catalogue/client surfaces for stable typed application names. The adapter owns unit ID, table, address, conversion, and batch planning. Use observable connection/polling helpers with bounded intervals and dispose subscriptions.
+
+When using Enron helpers or custom conversion, verify that the target device implements the non-standard convention.
+
+## Slave/server workflow
+
+Use `DataStore` with `ModbusTcpSlave`, `ModbusUdpSlave`, or `ModbusSerialSlave`; compose multiple units with the server/aggregator APIs. Synchronize direct `DataStore` access and validate writes before applying them to physical outputs.
+
+Subscribe to request/operation observation when auditing or testing. Dispose listeners and transports so ports are released.
+
+## Simulation and generation
+
+Use `DataStore`, `ModbusSimulator`, or `ModbusTcpLoopbackEndpoint` for deterministic tests. Cover each used function, unit routing, exception responses, timeouts, malformed requests, word order, boundary ranges, and reconnect behavior.
+
+For generated maps, install `ModbusRx.Generators`, declare supported attributes on partial types, build once, inspect diagnostics and generated members, then test the map against a simulator.
+
+## Safety checklist
+
+- Verify transport, unit ID, table, zero-based address, count, type, and word order.
+- Treat every coil/register write as safety-sensitive.
+- Require access control and equipment interlocks at the server boundary.
+- Batch within protocol limits and keep retries idempotent.
+- Synchronize shared data stores.
+- Test with a simulator and safe rig before production devices.

--- a/skills/omron-plc-rx/SKILL.md
+++ b/skills/omron-plc-rx/SKILL.md
@@ -1,18 +1,91 @@
 ---
 name: omron-plc-rx
-description: Use when implementing, reviewing, or troubleshooting Omron FINS TCP, UDP, Host Link FINS, or Toolbus serial integrations with OmronPlcRx or OmronPlcRx.Reactive.
+description: Implement, review, or troubleshoot Omron FINS TCP, UDP, Host Link FINS, and Toolbus serial integrations with typed tags, logical tags, clock and memory operations, simulation, and generated bindings.
 ---
 
 # OmronPlcRx
 
-Use `IoT.DriverCore.OmronPlcRx` for the base package; use the `.Reactive` namespace only with `OmronPlcRx.Reactive`.
+## Use this skill when
 
-The runtime packages already embed the matching source generator. Install `OmronPlcRx.Generators` only when the analyzer must be pinned or managed independently, and do not load a duplicate generator version.
+Use this skill for typed Omron FINS network access, Host Link FINS or Toolbus serial access, polling, logical tags, memory-area batches, PLC clock operations, simulators, or generated bindings.
 
-Create `OmronConnectionOptions`, construct `OmronPlcRx(options, pollInterval)`, register `PlcTag<T>`, and use the same-name, same-type `LogicalTagKey<T>` for `Observe`, `ReadValueAsync`, `WriteValueAsync`, `GetValue`, and `SetValue`.
+Read the co-packaged `../../README.md`; in a repository checkout use `packagereadme/OmronPlcRx/README.md`. Inspect `src/OmronPlcRx` before describing undocumented members.
 
-Subscribe to `Errors`. Prefer `WriteValueAsync` for commands that require an observable result; regard `SetValue` as queued background work. Validate serial settings with `OmronSerialOptions.Validate()` and use `CreateToolbus` only for Toolbus endpoints.
+## Package choice
 
-Treat PLC writes as safety-sensitive. Verify node IDs, transport, endpoint, address, tag type, and PLC permissions before enabling writes or reducing poll intervals.
+- Use `OmronPlcRx` and `IoT.DriverCore.OmronPlcRx` by default.
+- Use `OmronPlcRx.Reactive` and its `.Reactive` namespace for System.Reactive applications.
+- Runtime packages embed their matching generator. Install `OmronPlcRx.Generators` only to version it independently, and never load a duplicate analyzer.
 
-For the complete public API, address/type guidance, examples, and troubleshooting, read the co-packaged `../../README.md`; in a repository checkout use `packagereadme/OmronPlcRx/README.md`.
+## Network workflow
+
+Create `OmronConnectionOptions(localNodeId, remoteNodeId, connectionMethod, remoteHost)` and set port, timeout, retries, and optional serial settings.
+
+```csharp
+using IoT.DriverCore.Core;
+using IoT.DriverCore.OmronPlcRx;
+using IoT.DriverCore.OmronPlcRx.Enums;
+using IoT.DriverCore.OmronPlcRx.Tags;
+
+var options = new OmronConnectionOptions(
+    11, 1, ConnectionMethod.UDP, "192.168.250.1")
+{
+    Port = 9600,
+    Timeout = 2000,
+    Retries = 1,
+};
+
+using var plc = new OmronPlcRx(options, TimeSpan.FromMilliseconds(200));
+using var errors = plc.Errors.Subscribe(Console.Error.WriteLine);
+
+plc.AddUpdateTagItem(new PlcTag<bool>("MotorRun", "D100.0"));
+plc.AddUpdateTagItem(new PlcTag<short>("Temperature", "D200"));
+
+var motor = new LogicalTagKey<bool>("MotorRun");
+await plc.WriteValueAsync(motor, true, CancellationToken.None);
+var value = await plc.ReadValueAsync(
+    new LogicalTagKey<short>("Temperature"),
+    CancellationToken.None);
+```
+
+The `PlcTag<T>` name and `LogicalTagKey<T>` name/type must match. Register before read, write, cache access, or observation.
+
+## Serial workflow
+
+Use `OmronSerialOptions` for Host Link FINS or `OmronSerialOptions.CreateToolbus("COM3")` for Toolbus. Call `Validate()` when composing settings dynamically.
+
+Host Link defaults to 9600/7E2; Toolbus uses its documented 115200/8N1/RTS settings. Confirm frame mode, node IDs, station, port, and PLC configuration. Classic C-mode Host Link is not the surface exposed by this driver.
+
+## Tags, values, and errors
+
+- Use `Observe(LogicalTagKey<T>)` for cached/polled changes.
+- Prefer `ReadValueAsync` and `WriteValueAsync` for commands with explicit completion.
+- Treat `SetValue` as queued background work, not proof that the PLC accepted a write.
+- Use `GetValue` only after registering the tag and confirming its type.
+- Subscribe to `Errors` before connection activity and include tag/address context in diagnostics.
+- Dispose subscriptions and the client; pass cancellation tokens to async commands.
+
+## Memory and clock operations
+
+Use documented bulk word/bit memory-area APIs for contiguous work instead of loops. Verify Omron area, address, bit offset, element type, BCD rules, and count.
+
+Clock read/write and cycle-time commands affect or expose controller state. Verify PLC mode and privileges, validate BCD conversion, and protect clock writes with explicit authorization.
+
+## Logical tags and persistence
+
+Use the driver logical-tag client and `IoT.DriverCore.Core` catalogues, typed keys, CSV, SQLite, and batch APIs. Keep FINS/serial syntax and codecs inside the Omron adapter.
+
+## Simulation and generation
+
+Use the Omron simulator and Host Link/Toolbus codec tests to exercise tag polling, reads/writes, word/bit batches, timeouts, retries, malformed frames, BCD conversion, and cancellation without hardware.
+
+For generated bindings, declare documented partial types/attributes, build once, inspect diagnostics and generated members, then verify reads, writes, observation, error handling, and disposal against simulation.
+
+## Safety checklist
+
+- Verify local/remote node IDs, method, endpoint, serial settings, and frame mode.
+- Verify memory area, address, bit, type, count, and BCD conversion.
+- Treat queued setters as unconfirmed until a read or explicit result verifies state.
+- Protect writes and clock commands with PLC/application interlocks.
+- Keep poll rates conservative and dispose all resources.
+- Commission with simulation and a safe PLC or test rig.

--- a/skills/s7-plc-rx/SKILL.md
+++ b/skills/s7-plc-rx/SKILL.md
@@ -1,18 +1,93 @@
 ---
 name: s7-plc-rx
-description: Use when implementing, reviewing, or troubleshooting Siemens S7 integrations with S7PlcRx or S7PlcRx.Reactive, including typed tags, polling, bindings, batch work, and diagnostics.
+description: Implement, review, or troubleshoot Siemens S7 integrations with S7PlcRx, including typed tags, addressing, polling, reads and writes, logical tags, diagnostics, batching, bindings, and generation.
 ---
 
 # S7PlcRx
 
-Use `IoT.DriverCore.S7PlcRx` for the base package; use the `.Reactive` namespace only with `S7PlcRx.Reactive`.
+## Use this skill when
 
-Install `S7PlcRx.Generators` alongside the selected runtime package when generated bindings are required; the runtime packages do not embed this analyzer.
+Use this skill for S7-200/300/400/1200/1500 communication over ISO-on-TCP, including tag registration, observables, manual and batched I/O, logical tags, production diagnostics, or generated bindings.
 
-Create an `IRxS7` through the CPU factory or `RxS7Options` and dispose it: `using IRxS7 plc = S71500.Create(...)`. `IRxS7` inherits disposable `ReactiveUI.Primitives.Disposables.ICancelable`. Register tags with `TagOperations.AddUpdateTagItem(plc, typeof(T), name, address[, length])`, then use a matching `LogicalTagKey<T>` with `Observe<T>` and `ReadAsync<T>`; use `Value<T>` only after the tag and type have been verified.
+Read the co-packaged `../../README.md`; in a repository checkout use `packagereadme/S7PlcRx/README.md`. Inspect `src/S7PlcRx` before describing undocumented members.
 
-Subscribe to `IsConnected`, `LastError`, and `LastErrorCode`. Configure watchdogs only with a reviewed `DBW` address and safe interval. Confirm CPU family, rack/slot, DB/bit address syntax, PLC protection, and machine interlocks before writing.
+## Package choice
 
-Use generator attributes only on partial binding types. Use batch, logical-tag, optimisation, and production APIs after establishing a baseline with the basic tag flow.
+- Use `S7PlcRx` with `IoT.DriverCore.S7PlcRx` by default.
+- Use `S7PlcRx.Reactive` and its `.Reactive` namespace for System.Reactive applications.
+- Runtime packages do not embed the analyzer. Install `S7PlcRx.Generators` alongside the selected runtime only when generated bindings are required.
 
-For the complete public API, supported addressing, examples, operational guidance, and troubleshooting, read the co-packaged `../../README.md`; in a repository checkout use `packagereadme/S7PlcRx/README.md`.
+## Connect and register
+
+Create `IRxS7` through a CPU factory or `RxS7Options`, then dispose it. Confirm CPU family, IP address, rack, slot, and PLC protection.
+
+```csharp
+using IoT.DriverCore.Core;
+using IoT.DriverCore.S7PlcRx;
+using IoT.DriverCore.S7PlcRx.Enums;
+using ReactiveUI.Primitives;
+
+var options = new RxS7Options(
+    new S7ConnectionOptions(
+        CpuType.S71500,
+        "192.168.1.100",
+        rack: 0,
+        slot: 1));
+
+using var plc = new RxS7(options);
+
+TagOperations.AddUpdateTagItem(
+    plc, typeof(float), "Temperature", "DB1.DBD0");
+TagOperations.AddUpdateTagItem(
+    plc, typeof(bool), "Running", "DB1.DBX4.0");
+
+using var errors = plc.LastError.Subscribe(Console.Error.WriteLine);
+using var values = plc.Observe(new LogicalTagKey<float>("Temperature"))
+    .Where(value => value.HasValue)
+    .Subscribe(value => Console.WriteLine(value));
+```
+
+Factory equivalent: `using IRxS7 plc = S71500.Create(...)`.
+
+## Addressing and types
+
+Match address width to the CLR type:
+
+- `DBX` bits use bit indexes 0–7 and `bool`;
+- `DBB` is byte-oriented;
+- `DBW` maps to 16-bit values;
+- `DBD` maps to 32-bit values, while `double` consumes eight bytes;
+- `I/E`, `Q/A`, and `M` address inputs, outputs, and markers;
+- timers and counters use their documented forms.
+
+Pass array length when registering byte arrays or other variable-sized values. Validate DB layout and optimized/non-optimized access settings on the PLC.
+
+## Read, write, and observe
+
+- Register the tag and correct type before calling `Value<T>`, `ReadAsync<T>`, `Observe<T>`, or writes.
+- Use `LogicalTagKey<T>` to prevent name/type drift.
+- Prefer batch, optimized, and logical-tag APIs for multiple adjacent values.
+- Observe `IsConnected`, `LastError`, and `LastErrorCode`.
+- There is no general invented cancellation surface: use only cancellation overloads actually exposed by the selected API.
+- Treat `IsDisposed` as state; call `Dispose`/`using` to end the client.
+
+Configure watchdogs only with a reviewed `DBW` address and safe interval. A watchdog is operational equipment interaction, not merely diagnostics.
+
+## Bindings and generation
+
+Use runtime binding APIs after a basic registered-tag workflow is proven. For generated binding, install `S7PlcRx.Generators`, mark binding types partial, use documented attributes, build once, and inspect diagnostics and generated members.
+
+Test generated reads, queued writes, observations, byte-array grouping, conversion, and disposal. Do not assume generated code fixes an incorrect PLC address or CLR type.
+
+## Logical tags and testing
+
+Use driver logical-tag, CSV, SQLite, catalogue, and batch surfaces for protocol-neutral application names. Test conversion and application logic using provided abstractions/mocks and a safe S7 simulator or test PLC; cover disconnect, stale cache, malformed address, timeout, and write rejection.
+
+## Safety checklist
+
+- Verify CPU family, rack/slot, protection, DB layout, address, bit, type, and length.
+- Require machine and application interlocks before writes.
+- Monitor connection and error streams before operational I/O.
+- Keep scan/watchdog rates within controller capacity.
+- Dispose the client and every subscription.
+- Validate on simulation and a safe rig before production.

--- a/skills/serial-port-rx/SKILL.md
+++ b/skills/serial-port-rx/SKILL.md
@@ -1,16 +1,94 @@
 ---
 name: serial-port-rx
-description: Implement, review, or troubleshoot reactive serial, TCP, and UDP I/O with SerialPortRx. Use for port configuration, receive ownership, message framing, connection streams, and deterministic in-memory port tests.
+description: Implement, review, or troubleshoot reactive serial, TCP, and UDP I/O with SerialPortRx, including configuration, receive ownership, framing, request-response coordination, errors, deterministic links, and generation.
 ---
 
 # SerialPortRx
 
-Use `IoT.DriverCore.Serial` for the default package surface. Configure serial settings before `OpenAsync`, subscribe to errors before opening, and dispose subscriptions with the port.
+## Use this skill when
 
-The source generator is embedded in `SerialPortRx` and `SerialPortRx.Reactive`; there is no standalone `SerialPortRx.Generators` NuGet package to install.
+Use this skill for serial instruments, barcode readers, scales, gateways, TCP streams, UDP datagrams, message framing, command/response devices, or deterministic in-memory transport tests.
 
-Choose exactly one receive owner. Leave `EnableAutoDataReceive` enabled for `DataReceived`, `DataReceivedBytes`, and `DataReceivedBatches`; set it to false before opening for manual read APIs. Do not mix automatic parsing with competing manual reads.
+Read the co-packaged `../../README.md`; in a repository checkout use `packagereadme/SerialPortRx/README.md`. Inspect `src/SerialPortRx` before describing undocumented members.
 
-Frame TCP and serial payloads explicitly. Treat TCP read batches as arbitrary transport chunks, use bounded `BufferUntil` or a protocol parser, and select finite timeouts for commands. Treat UDP batches as datagrams but still validate their source and content.
+## Package choice
 
-Use `InMemoryPortRxPair` for deterministic tests. For complete contracts, network client APIs, and platform restrictions, read the co-packaged `../../README.md`; in a repository checkout use `packagereadme/SerialPortRx/README.md`.
+- Use `SerialPortRx` with `IoT.DriverCore.Serial` by default.
+- Use `SerialPortRx.Reactive` and `IoT.DriverCore.Serial.Reactive` for System.Reactive applications.
+- The generator is embedded in both runtimes. There is no standalone `SerialPortRx.Generators` package.
+- Check the package matrix for target-framework and Windows-only serial features.
+
+## Serial workflow
+
+Set baud rate, data bits, parity, stop bits, handshake, timeouts, encoding, and delimiters before `OpenAsync`. Subscribe to state and errors before opening.
+
+```csharp
+using IoT.DriverCore.Serial;
+
+using var port = new SerialPortRx("COM3", 115200)
+{
+    ReadTimeout = -1,
+    WriteTimeout = -1,
+};
+
+using var state = port.IsOpenObservable
+    .Subscribe(open => Console.WriteLine($"Open: {open}"));
+using var errors = port.ErrorReceived
+    .Subscribe(error => Console.Error.WriteLine(error.Message));
+using var data = port.DataReceived.Subscribe(Console.Write);
+
+await port.OpenAsync();
+port.WriteLine("AT");
+port.Close();
+```
+
+Dispose the port and subscriptions. Use `PortNames` only as a discovery stream; still handle disappearance and open failures.
+
+## Choose one receive owner
+
+Choose exactly one model per connection:
+
+1. automatic receive through `DataReceived`, `DataReceivedBytes`, `DataReceivedBatches`, or `Lines`;
+2. an explicit `StartDataReception` lease;
+3. manual `Read*` calls with `EnableAutoDataReceive = false` before opening.
+
+Do not mix owners. Competing consumers split bytes unpredictably and corrupt protocol framing.
+
+## Framing and command coordination
+
+Serial and TCP receive batches are arbitrary transport chunks, not application messages. Use bounded `BufferUntil`, line framing, or a protocol parser that handles partial and multiple frames. Enforce maximum frame sizes and finite request timeouts.
+
+Use `SerialPortRxMessageHandler` for line-oriented request/response ownership. Configure device error prefixes, echo/response handling, and polling coordination. Use `WithPollingStoppedAsync` for exclusive commands and dispose the handler to stop polling.
+
+## TCP and UDP
+
+`TcpClientRx` and `UdpClientRx` implement `IPortRx`:
+
+```csharp
+using var tcp = new TcpClientRx("example.com", 80);
+await tcp.OpenAsync();
+
+using var udp = new UdpClientRx(12345);
+await udp.OpenAsync();
+```
+
+TCP is a byte stream: frame across arbitrary chunks. UDP batch events correspond to datagrams, but validate source, expected length, sequence, and content. Handle disconnect/reconnect and socket errors explicitly.
+
+## Writes and concurrency
+
+Serialize writes when device protocols do not support pipelining. Respect encoding and terminators for text commands; use byte overloads for binary protocols. Bound queues so a slow connection cannot grow memory without limit.
+
+## Testing and generation
+
+Use `InMemoryPortRxPair` and related deterministic links for framing, request/response, timeout, cancellation, disconnect, partial-frame, multiple-frame, and error tests.
+
+For generated serial properties, use documented attributes on partial types, build once, inspect diagnostics and generated members, and verify parsing, output, errors, and disposal against an in-memory link.
+
+## Safety checklist
+
+- Verify port/endpoint, electrical/interface standard, serial format, and handshake.
+- Choose one receive owner and one framing authority.
+- Bound frames, buffers, queues, retries, and timeouts.
+- Validate every inbound message before acting on it.
+- Treat protocol commands as potentially safety-sensitive writes.
+- Dispose ports, socket clients, handlers, and subscriptions.

--- a/skills/twincat-rx/SKILL.md
+++ b/skills/twincat-rx/SKILL.md
@@ -1,18 +1,84 @@
 ---
 name: twincat-rx
-description: Implement, review, or troubleshoot reactive TwinCAT ADS access with CP.TwinCATRx. Use for ADS routes, notification settings, correlated reads/writes, typed observables, structured tags, and in-memory ADS tests.
+description: Implement, review, or troubleshoot Beckhoff TwinCAT ADS access with CP.TwinCATRx, including routes, settings, notifications, correlated reads and writes, structures, logical tags, simulation, and generation.
 ---
 
 # TwinCATRx
 
-Use `IoT.DriverCore.TwinCATRx` and `IoT.DriverCore.TwinCATRx.Core`. Configure the ADS address, port, and settings id; register notifications and writable variables before `Connect`; wait for `InitializeComplete` before operational I/O.
+## Use this skill when
 
-`CP.TwinCATRx` and `CP.TwinCATRx.Reactive` already embed the matching source generator. Install `TwinCATRx.Generators` only when the analyzer must be pinned or managed independently, and do not load a duplicate generator version.
+Use this skill for TwinCAT 2/3 ADS connections, notifications, one-shot reads/writes, correlated results, structured symbols, logical tags, service monitoring, in-memory tests, or generated models.
 
-Treat PLC writes as safety-critical. Validate every variable name, value type, string/array length, route, and controller-side interlock. Observe `ErrorReceived` and `OnWrite`; use correlation ids when concurrent one-shot reads or writes need distinct results.
+Read the co-packaged `../../README.md`; in a repository checkout use `packagereadme/TwinCATRx/README.md`. Inspect `src/TwinCATRx` and `src/TwinCATRx.Core` before describing undocumented members.
 
-Use typed `Observe`/`ObserveAsyncObservable` with explicit conversion. Use `CreateStruct` and `WriteValues` only after checking trimming/AOT implications; register required members when publishing trimmed applications. Use `InMemoryAdsClient` to test symbols, faults, reconnection, and metrics without an ADS runtime.
+## Package choice
 
-For generated clients, choose `[TwinCatReactiveStream]` or `[TwinCatPlcConnection]` deliberately, declare direct, structured, and write-only members with the documented attributes, build once to inspect diagnostics and generated members, then verify reads, writes, observations, and disposal against `InMemoryAdsClient`.
+- `CP.TwinCATRx` / `CP.TwinCATRx.Reactive` provide Windows ADS integrations.
+- `TwinCATRx.Core` / `TwinCATRx.Core.Reactive` provide core abstractions and testable composition.
+- Import `IoT.DriverCore.TwinCATRx` and `IoT.DriverCore.TwinCATRx.Core`, or the corresponding `.Reactive` namespaces.
+- Runtime ADS packages embed the generator. Install `TwinCATRx.Generators` only to version it independently; never load duplicate analyzers.
 
-For the complete public API, generator attribute matrix, configuration overloads, and service-monitoring constraints, read the co-packaged `../../README.md`; in a repository checkout use `packagereadme/TwinCATRx/README.md`.
+## Configure and connect
+
+Set ADS address, port, and settings ID. Register every notification and writable variable before `Connect`.
+
+```csharp
+using IoT.DriverCore.TwinCATRx;
+using IoT.DriverCore.TwinCATRx.Core;
+
+using var client = new RxTcAdsClient();
+var settings = new Settings
+{
+    AdsAddress = "5.35.59.10.1.1",
+    Port = 851,
+    SettingsId = "Default",
+};
+
+settings.AddNotification(".AInt");
+settings.AddWriteVariable(".AInt");
+
+using var errors = client.ErrorReceived.Subscribe(Console.Error.WriteLine);
+using var ready = client.InitializeComplete
+    .Subscribe(_ => Console.WriteLine("ADS handles ready"));
+using var values = client.Observe<short>(
+        ".AInt",
+        value => Convert.ToInt16(value))
+    .Subscribe(value => Console.WriteLine(value));
+
+client.Connect(settings);
+```
+
+Wait for `InitializeComplete` before operational I/O. Validate the local/remote ADS route and runtime port; 851 commonly targets TwinCAT 3 runtime 1 but must not be assumed.
+
+## Reads, writes, and correlation
+
+Use `Read(variable[, id])`, `Write(variable, value[, id])`, and `Observe`/async-observable methods. Use correlation IDs when concurrent one-shot operations need distinct results. `DataReceived` contains variable, data, and ID; `OnWrite` reports written variable names.
+
+Subscribe to `ErrorReceived` before `Connect`. Synchronous ADS operations do not expose a general cancellation token: cancel higher-level observation/composition by disposing subscriptions or the client.
+
+Register a positive size for strings and arrays when ADS cannot infer it. Verify value type, string encoding/length, array length, structure layout, and symbol name before writes.
+
+## Structures and dynamic code
+
+Use `CreateStruct` and coordinated `WriteValues` only with validated layouts. Dynamic materialization carries trimming/AOT annotations; preserve/register required members and validate the published application rather than suppressing warnings.
+
+## Logical tags and lifetime
+
+Compose logical-tag clients from the Core package so application code uses `LogicalTagKey<T>` while ADS symbol names stay in the adapter. Use bulk/group APIs for compatible work.
+
+`Disconnect()` releases ADS handles and permits reconnect. `Dispose()` is terminal. Observe `Connected`, `IsDisposed`, pause state, and handle information; dispose every subscription and client.
+
+## In-memory testing and generation
+
+Use `InMemoryAdsClient` to define symbols and test notification flow, correlated reads/writes, faults, reconnection, pause windows, metrics, and disposal without an ADS runtime.
+
+For generation, choose `[TwinCatReactiveStream]` or `[TwinCatPlcConnection]` deliberately, declare documented direct/structured/write-only members on partial types, build once, inspect diagnostics and generated members, then test against `InMemoryAdsClient`.
+
+## Safety checklist
+
+- Verify ADS route, target runtime port, settings ID, symbol name, type, and size.
+- Register notifications/writes before connection and wait for initialization.
+- Require machine and application interlocks for writes.
+- Preserve correlation context and observe errors.
+- Address trimming/AOT diagnostics correctly.
+- Validate with `InMemoryAdsClient` and safe TwinCAT test hardware.

--- a/src/CP.IoT.Core/CP.IoT.Core.csproj
+++ b/src/CP.IoT.Core/CP.IoT.Core.csproj
@@ -4,6 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
+    <PackageIcon>cp-iot-core.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
@@ -15,11 +16,14 @@
     <None Include="buildTransitive\CP.IoT.Core.targets"
           Pack="true"
           PackagePath="buildTransitive\CP.IoT.Core.targets" />
-    <None Include="..\..\README.md"
+    <None Include="..\..\packagereadme\CP.IoT.Core\README.md"
           Pack="true"
           PackagePath="README.md" />
-    <None Include="..\..\images\iot-drivercore-hero.png"
+    <None Include="..\..\images\cp-iot-core.png"
           Pack="true"
-          PackagePath="images\iot-drivercore-hero.png" />
+          PackagePath="\" />
+    <None Include="..\..\skills\cp-iot-core\SKILL.md"
+          Pack="true"
+          PackagePath="skills/cp-iot-core/SKILL.md" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -98,12 +98,12 @@
     <Description>Reactive Allen-Bradley PLC driver for ControlLogix, CompactLogix, MicroLogix, PLC-5, and compatible controllers.</Description>
     <PackageReleaseNotes>Allen-Bradley PLC communication with logical tags, reactive observation, and bulk operations across supported target frameworks.</PackageReleaseNotes>
     <PackageTags>Allen-Bradley;Rockwell;ControlLogix;CompactLogix;MicroLogix;PLC-5;PLC;IoT;reactive;observable</PackageTags>
-    <PackageIcon>abplclogo.png</PackageIcon>
+    <PackageIcon>ab-plc-rx.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'ABPlcRx' or '$(MSBuildProjectName)' == 'ABPlcRx.Reactive' or '$(MSBuildProjectName)' == 'ABPlcRx.Generators'">
-    <None Include="$(MSBuildThisFileDirectory)..\images\abplclogo.png" Pack="true" PackagePath="\"/>
+    <None Include="$(MSBuildThisFileDirectory)..\images\ab-plc-rx.png" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\packagereadme\ABPlcRx\README.md" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\skills\ab-plc-rx\SKILL.md" Pack="true" PackagePath="skills/ab-plc-rx/SKILL.md"/>
   </ItemGroup>
@@ -112,12 +112,12 @@
     <Description>Reactive Mitsubishi MELSEC PLC driver using MC Protocol and SLMP over Ethernet and serial transports.</Description>
     <PackageReleaseNotes>Mitsubishi MC Protocol and SLMP support for 1E, 3E, 4E, 1C, 3C, and 4C frames with reactive logical tags.</PackageReleaseNotes>
     <PackageTags>Mitsubishi;MELSEC;MC Protocol;SLMP;PLC;Ethernet;serial;IoT;reactive;observable</PackageTags>
-    <PackageIcon>mitplclogo.png</PackageIcon>
+    <PackageIcon>mitsubishi-rx.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'MitsubishiRx' or '$(MSBuildProjectName)' == 'MitsubishiRx.Reactive' or '$(MSBuildProjectName)' == 'MitsubishiRx.Generators'">
-    <None Include="$(MSBuildThisFileDirectory)..\images\mitplclogo.png" Pack="true" PackagePath="\"/>
+    <None Include="$(MSBuildThisFileDirectory)..\images\mitsubishi-rx.png" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\packagereadme\MitsubishiRx\README.md" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\skills\mitsubishi-rx\SKILL.md" Pack="true" PackagePath="skills/mitsubishi-rx/SKILL.md"/>
   </ItemGroup>
@@ -126,12 +126,12 @@
     <Description>Reactive Modbus driver for TCP, UDP, RTU, ASCII, master, slave, and gateway communications.</Description>
     <PackageReleaseNotes>Modbus transport, logical-tag, and contiguous coil/register bulk operations across supported target frameworks.</PackageReleaseNotes>
     <PackageTags>Modbus;TCP;UDP;RTU;ASCII;master;slave;coils;registers;PLC;IoT;reactive</PackageTags>
-    <PackageIcon>ModbusRx.png</PackageIcon>
+    <PackageIcon>modbus-rx.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'ModbusRx' or '$(MSBuildProjectName)' == 'ModbusRx.Reactive' or '$(MSBuildProjectName)' == 'ModbusRx.Generators'">
-    <None Include="$(MSBuildThisFileDirectory)..\images\ModbusRx.png" Pack="true" PackagePath="\"/>
+    <None Include="$(MSBuildThisFileDirectory)..\images\modbus-rx.png" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\packagereadme\ModbusRx\README.md" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\skills\modbus-rx\SKILL.md" Pack="true" PackagePath="skills/modbus-rx/SKILL.md"/>
   </ItemGroup>
@@ -140,12 +140,12 @@
     <Description>Reactive Omron PLC driver for FINS, Host Link, Toolbus, Ethernet, and serial communications.</Description>
     <PackageReleaseNotes>Omron logical-tag support with FINS, Host Link, Toolbus, Ethernet, serial, and bulk memory-area operations.</PackageReleaseNotes>
     <PackageTags>Omron;FINS;Host Link;Toolbus;PLC;Ethernet;serial;memory area;IoT;reactive</PackageTags>
-    <PackageIcon>OmronPLCRx-icon.png</PackageIcon>
+    <PackageIcon>omron-plc-rx.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'OmronPlcRx' or '$(MSBuildProjectName)' == 'OmronPlcRx.Reactive' or '$(MSBuildProjectName)' == 'OmronPlcRx.Generators'">
-    <None Include="$(MSBuildThisFileDirectory)..\images\OmronPLCRx-icon.png" Pack="true" PackagePath="\"/>
+    <None Include="$(MSBuildThisFileDirectory)..\images\omron-plc-rx.png" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\packagereadme\OmronPlcRx\README.md" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\skills\omron-plc-rx\SKILL.md" Pack="true" PackagePath="skills/omron-plc-rx/SKILL.md"/>
   </ItemGroup>
@@ -154,12 +154,12 @@
     <Description>Reactive Siemens S7 PLC driver for S7-200, S7-300, S7-400, S7-1200, and S7-1500 controllers.</Description>
     <PackageReleaseNotes>Siemens S7 logical-tag communication, native multi-variable operations, and reactive observation across supported target frameworks.</PackageReleaseNotes>
     <PackageTags>Siemens;S7;S7-200;S7-300;S7-400;S7-1200;S7-1500;PLC;IoT;reactive</PackageTags>
-    <PackageIcon>S7PlcRx.png</PackageIcon>
+    <PackageIcon>s7-plc-rx.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'S7PlcRx' or '$(MSBuildProjectName)' == 'S7PlcRx.Reactive' or '$(MSBuildProjectName)' == 'S7PlcRx.Generators'">
-    <None Include="$(MSBuildThisFileDirectory)..\images\S7PlcRx.png" Pack="true" PackagePath="\"/>
+    <None Include="$(MSBuildThisFileDirectory)..\images\s7-plc-rx.png" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\packagereadme\S7PlcRx\README.md" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\skills\s7-plc-rx\SKILL.md" Pack="true" PackagePath="skills/s7-plc-rx/SKILL.md"/>
   </ItemGroup>
@@ -167,31 +167,31 @@
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'ABPlcRx.Generators'">
     <Description>Compile-time source generators for strongly typed Allen-Bradley PLC models.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageIcon>abplclogo.png</PackageIcon>
+    <PackageIcon>ab-plc-rx.png</PackageIcon>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'ModbusRx.Generators'">
     <Description>Compile-time source generators for strongly typed Modbus device models.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageIcon>ModbusRx.png</PackageIcon>
+    <PackageIcon>modbus-rx.png</PackageIcon>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'OmronPlcRx.Generators'">
     <Description>Compile-time source generators for strongly typed Omron PLC models.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageIcon>OmronPLCRx-icon.png</PackageIcon>
+    <PackageIcon>omron-plc-rx.png</PackageIcon>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'S7PlcRx.Generators'">
     <Description>Compile-time source generators for strongly typed Siemens S7 PLC models.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageIcon>S7PlcRx.png</PackageIcon>
+    <PackageIcon>s7-plc-rx.png</PackageIcon>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'MitsubishiRx.Generators'">
     <Description>Compile-time source generators for strongly typed Mitsubishi MELSEC tag clients.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageIcon>mitplclogo.png</PackageIcon>
+    <PackageIcon>mitsubishi-rx.png</PackageIcon>
     <PackageTags>Mitsubishi;MELSEC;MC Protocol;SLMP;PLC;source generator;Roslyn;IoT</PackageTags>
   </PropertyGroup>
 
@@ -199,12 +199,12 @@
     <Description>Reactive, cross-platform serial-port driver with asynchronous observable streams and source-generated helpers.</Description>
     <PackageReleaseNotes>Cross-platform serial communication for .NET 8 through .NET 11 with Windows-specific framework targets, async observables, and generated streams.</PackageReleaseNotes>
     <PackageTags>SerialPort;serial;cross-platform;IoT;reactive;observable;async;source generator</PackageTags>
-    <PackageIcon>serlogo.png</PackageIcon>
+    <PackageIcon>serial-port-rx.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'SerialPortRx' or '$(MSBuildProjectName)' == 'SerialPortRx.Reactive'">
-    <None Include="$(MSBuildThisFileDirectory)..\images\serlogo.png" Pack="true" PackagePath="\"/>
+    <None Include="$(MSBuildThisFileDirectory)..\images\serial-port-rx.png" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\packagereadme\SerialPortRx\README.md" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\skills\serial-port-rx\SKILL.md" Pack="true" PackagePath="skills/serial-port-rx/SKILL.md"/>
   </ItemGroup>
@@ -213,18 +213,18 @@
     <Description>Reactive Beckhoff TwinCAT ADS PLC driver with core and Windows ADS integrations.</Description>
     <PackageReleaseNotes>Beckhoff TwinCAT ADS logical-tag communication, structured-variable access, reactive observation, and grouped bulk operations.</PackageReleaseNotes>
     <PackageTags>Beckhoff;TwinCAT;ADS;PLC;structured variables;IoT;reactive;observable</PackageTags>
-    <PackageIcon>TwinCATRx.png</PackageIcon>
+    <PackageIcon>twincat-rx.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'TwinCATRx' or '$(MSBuildProjectName)' == 'TwinCATRx.Reactive'">
-    <None Include="$(MSBuildThisFileDirectory)..\images\TwinCATRx.png" Pack="true" PackagePath="\"/>
+    <None Include="$(MSBuildThisFileDirectory)..\images\twincat-rx.png" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\packagereadme\TwinCATRx\README.md" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\skills\twincat-rx\SKILL.md" Pack="true" PackagePath="skills/twincat-rx/SKILL.md"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'TwinCATRx.Core' or '$(MSBuildProjectName)' == 'TwinCATRx.Core.Reactive'">
-    <None Include="$(MSBuildThisFileDirectory)..\images\TwinCATRx.png" Pack="true" PackagePath="\"/>
+    <None Include="$(MSBuildThisFileDirectory)..\images\twincat-rx.png" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\packagereadme\TwinCATRx\README.md" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\skills\twincat-rx\SKILL.md" Pack="true" PackagePath="skills/twincat-rx/SKILL.md"/>
   </ItemGroup>
@@ -232,12 +232,12 @@
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'TwinCATRx.Generators'">
     <Description>Compile-time source generators for strongly typed Beckhoff TwinCAT ADS models and reactive streams.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageIcon>TwinCATRx.png</PackageIcon>
+    <PackageIcon>twincat-rx.png</PackageIcon>
     <PackageTags>Beckhoff;TwinCAT;ADS;PLC;source generator;Roslyn;IoT;reactive</PackageTags>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'TwinCATRx.Generators'">
-    <None Include="$(MSBuildThisFileDirectory)..\images\TwinCATRx.png" Pack="true" PackagePath="\"/>
+    <None Include="$(MSBuildThisFileDirectory)..\images\twincat-rx.png" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\packagereadme\TwinCATRx\README.md" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)..\skills\twincat-rx\SKILL.md" Pack="true" PackagePath="skills/twincat-rx/SKILL.md"/>
   </ItemGroup>

--- a/src/TwinCATRx/RxTcAdsClient.cs
+++ b/src/TwinCATRx/RxTcAdsClient.cs
@@ -136,7 +136,7 @@ public partial class RxTcAdsClient : IRxTcAdsClient
 
     /// <summary>Gets error received.</summary>
     /// <returns>A Value.</returns>
-    public IObservable<Exception> ErrorReceived => _errorReceived.Retry(int.MaxValue).Publish().RefCount();
+    public IObservable<Exception> ErrorReceived => _errorReceived;
 
     /// <inheritdoc/>
     public IObservableAsync<Exception> ErrorReceivedAsync =>


### PR DESCRIPTION
﻿## Summary

- add a coherent Omron-inspired, wordless artwork set for AB, Mitsubishi, Modbus, Omron, S7, Serial, TwinCAT, and CP.IoT.Core
- place the matching image at the top of every package-family README and map all runtime, reactive, core, and generator packages to the correct NuGet icon
- add or expand detailed `SKILL.md` guidance for all eight package families and include it in every applicable NuGet package
- give CP.IoT.Core its own package README, icon, and skill instead of reusing repository-wide assets
- fix the TwinCAT `ErrorReceived` publication race reproduced by the full CI-style test run

## Why

NuGet packages previously used inconsistent or text-heavy artwork, their READMEs did not display the package image at the top, and CP.IoT.Core lacked a package-specific skill and icon. The updated package set gives every driver family consistent documentation and a clearly identifiable visual treatment while retaining protocol-specific cues for Modbus and Serial.

The CI-style suite also exposed an intermittent TwinCAT failure while observing native ADS errors. `ErrorReceived` created a new `Retry().Publish().RefCount()` pipeline on every property access around an already-hot `Signal<Exception>`. Under concurrent coverage execution, the transient ref-count boundary could miss a publication. Returning the existing hot signal directly removes that unnecessary observation window.

## User and developer impact

- NuGet consumers see the relevant package-family image and README immediately.
- Each of the 23 packages carries its matching detailed driver skill.
- Modbus and Serial artwork remains visually consistent with the PLC libraries while clearly representing their protocols.
- TwinCAT error publications remain observable during concurrent CI execution.

## Validation

- clean Release NUKE compile: **0 warnings, 0 errors**
- focused TwinCAT matrix: **2,008 passed, 0 failed** across eight target modules
- full Microsoft Testing Platform/TUnit solution run: **10,188 passed, 0 failed, 0 skipped**
- merged coverage: **74.45% line**, **71.37% branch**
- NuGet pack and archive audit: **23 packages, 0 issues**
  - root `README.md` present
  - correct package-family icon and NuSpec metadata
  - README begins with the matching raw GitHub image
  - matching `skills/<family>/SKILL.md` present

## Commits

- `feat(packaging): add driver-specific docs and artwork`
- `fix(twincat): preserve hot error publications`
