### PR TITLE
fix(packaging): preserve core assembly identity

### DIFF
--- a/src/CP.IoT.Core.Tests/AssemblyIdentityTests.cs
+++ b/src/CP.IoT.Core.Tests/AssemblyIdentityTests.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using IoT.Driver.Core;
+using TUnit.Assertions;
+using TUnit.Core;
+
+namespace IoT.Driver.Core.Tests;
+
+/// <summary>Verifies the assembly identity consumed by downstream driver packages.</summary>
+public sealed class AssemblyIdentityTests
+{
+    /// <summary>Verifies the published core assembly retains its supported assembly version.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task CoreAssemblyUsesCompatibleVersionAsync()
+    {
+        var identity = typeof(LogicalTag).Assembly.GetName();
+        Version expectedVersion = new(1, 0, 0, 0);
+
+        await Assert.That(identity.Name).IsEqualTo("CP.IoT.Core");
+        await Assert.That(identity.Version).IsEqualTo(expectedVersion);
+    }
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -35,6 +35,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'CP.IoT.Core'">


### PR DESCRIPTION
## What kind of change does this PR introduce?

This fixes NuGet package versioning metadata for IoT-Driver.Core and adds a regression test for its binary assembly identity.

## What is the new behavior?

MinVer recognizes the repository's v-prefixed release tags. A 1.0.1 package can advance its file and product versions while retaining the compatible CP.IoT.Core assembly identity 1.0.0.0.

## What is the current behavior?

MinVer ignores the v1.0.0 tag, causing ordinary builds to emit CP.IoT.Core.dll with assembly version 0.0.0.0 even though downstream driver packages reference version 1.0.0.0.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (not required for this package metadata fix)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

- Strict Release build: 0 warnings, 0 errors.
- TUnit: 32 passed, 0 failed, 0 skipped.
- Package validation: IoT-Driver.Core 1.0.1 contains CP.IoT.Core with assembly version 1.0.0.0 and file version 1.0.1.0.
- Vulnerable and deprecated package audits for the affected projects are clean.