### PR TITLE
fix(twincatrx): load and reuse generated PLC assemblies safely

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="ReactiveUI.Primitives.Async" Version="7.1.0" />
     <PackageVersion Include="ReactiveUI.Primitives.Async.Reactive" Version="7.1.0" />
     <PackageVersion Include="ReactiveUI.WPF" Version="24.1.0" />
-    <PackageVersion Include="Splat" Version="20.2.0" />
+    <PackageVersion Include="Splat" Version="21.0.0" />
     <PackageVersion Include="ReactiveUI.SourceGenerators" Version="3.2.0" />
 
     <!--Microsoft-->
@@ -32,7 +32,7 @@
 
     <!--PLC Base-->
     <PackageVersion Include="libplctag.NativeImport" Version="2.0.0-alpha.8" />
-    <PackageVersion Include="Beckhoff.TwinCAT.Ads" Version="7.0.292" />
+    <PackageVersion Include="Beckhoff.TwinCAT.Ads" Version="7.0.303" />
     <PackageVersion Include="HashTableRx" Version="4.0.0" />
     <PackageVersion Include="HashTableRx.Reactive" Version="4.0.0" />
 
@@ -46,9 +46,9 @@
 
     <PackageVersion Include="Mono.Cecil" Version="0.11.6" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="StyleSharp.Analyzers" Version="3.40.1" />
-    <PackageVersion Include="PerformanceSharp.Analyzers" Version="3.40.1" />
-    <PackageVersion Include="SecuritySharp.Analyzers" Version="3.40.1" />
+    <PackageVersion Include="StyleSharp.Analyzers" Version="3.40.2" />
+    <PackageVersion Include="PerformanceSharp.Analyzers" Version="3.40.2" />
+    <PackageVersion Include="SecuritySharp.Analyzers" Version="3.40.2" />
 
     <!--Build and Test-->
     <PackageVersion Include="CP.Nuke.BuildTools" Version="3.0.2" />

--- a/src/ModbusRx.Tests/SerialFactoryCoverageTests.cs
+++ b/src/ModbusRx.Tests/SerialFactoryCoverageTests.cs
@@ -25,6 +25,9 @@ public sealed class SerialFactoryCoverageTests
     /// <summary>The number of bytes transferred by adapter tests.</summary>
     private const int PayloadLength = 3;
 
+    /// <summary>The maximum time allowed for an in-memory serial operation.</summary>
+    private static readonly TimeSpan SerialOperationTimeout = TimeSpan.FromSeconds(5);
+
     /// <summary>Creates every serial master overload and validates their null and connection guards.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [TUnit.Core.Test]
@@ -103,20 +106,23 @@ public sealed class SerialFactoryCoverageTests
         pair.Second.EnableAutoDataReceive = false;
         await pair.First.OpenAsync();
         await pair.Second.OpenAsync();
-        using var adapter = new SerialPortAdapter(pair.First)
-        {
-            ReadTimeout = StreamTimeout,
-            WriteTimeout = StreamTimeout,
-        };
+        using var adapter = new SerialPortAdapter(pair.First);
         var request = new byte[] { UnitId, PayloadLength, UnitId };
         var peerBuffer = new byte[PayloadLength];
         var responseBuffer = new byte[PayloadLength];
 
         adapter.DiscardInBuffer();
         adapter.Write(request, 0, request.Length);
-        var peerRead = await pair.Second.ReadAsync(peerBuffer, 0, peerBuffer.Length);
+        var peerRead = await pair.Second
+            .ReadAsync(peerBuffer, 0, peerBuffer.Length)
+            .WaitAsync(SerialOperationTimeout);
         pair.Second.Write(request, 0, request.Length);
-        var responseRead = await adapter.ReadAsync(responseBuffer, 0, responseBuffer.Length);
+        var responseRead = await adapter
+            .ReadAsync(responseBuffer, 0, responseBuffer.Length)
+            .WaitAsync(SerialOperationTimeout);
+
+        adapter.ReadTimeout = StreamTimeout;
+        adapter.WriteTimeout = StreamTimeout;
 
         await NativeAssert.That(adapter.ReadTimeout).IsEqualTo(StreamTimeout);
         await NativeAssert.That(adapter.WriteTimeout).IsEqualTo(StreamTimeout);

--- a/src/OmronPlcRx.Tests/CoreProtocolCoverageTests.Helpers.cs
+++ b/src/OmronPlcRx.Tests/CoreProtocolCoverageTests.Helpers.cs
@@ -113,7 +113,10 @@ public sealed partial class CoreProtocolCoverageTests
     private static async Task<int> EchoTcpAsync(NetTcpListener listener)
     {
         using var acceptedSocket = await listener.AcceptSocketAsync().ConfigureAwait(false);
-        using var server = new CoreTcpClient(acceptedSocket);
+        using var server = new CoreTcpClient(acceptedSocket)
+        {
+            LingerState = new(false, 0),
+        };
         var receiveBuffer = new byte[3];
         var received = await server.ReceiveAsync(
             receiveBuffer,

--- a/src/OmronPlcRx.Tests/CoreProtocolCoverageTests.Runtime.Constants.cs
+++ b/src/OmronPlcRx.Tests/CoreProtocolCoverageTests.Runtime.Constants.cs
@@ -53,7 +53,7 @@ public sealed partial class CoreProtocolCoverageTests
     private const int InvalidPort = 65_536;
 
     /// <summary>Provides the socket timeout used by loopback tests.</summary>
-    private const int SocketTimeoutMilliseconds = 1000;
+    private const int SocketTimeoutMilliseconds = 5_000;
 
     /// <summary>Provides the first invalid weekday value.</summary>
     private const int MaximumWeekday = 7;

--- a/src/TwinCATRx.Core/TwinCatRxExtensions.cs
+++ b/src/TwinCATRx.Core/TwinCatRxExtensions.cs
@@ -4,6 +4,9 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+#if NET8_0_OR_GREATER
+using System.Runtime.Loader;
+#endif
 using TwinCAT.Ads;
 
 #if REACTIVE_SHIM
@@ -234,7 +237,7 @@ public static class TwinCatRxExtensions
     [RequiresUnreferencedCode("Uses reflection-based assembly loading which may be trimmed.")]
     public static Assembly? AssemblyLoad(string dllFullName) =>
         File.Exists(dllFullName)
-            ? Assembly.Load(AssemblyName.GetAssemblyName(Path.GetFullPath(dllFullName)))
+            ? LoadAssembly(Path.GetFullPath(dllFullName))
             : null;
 
     /// <summary>Gets a type from an assembly file.</summary>
@@ -245,6 +248,28 @@ public static class TwinCatRxExtensions
     [RequiresUnreferencedCode("Uses reflection to access type by name which may be trimmed in AOT.")]
     public static Type? GetType(string dllFullName, string engineType) =>
         AssemblyLoad(dllFullName)?.GetType(engineType);
+
+    /// <summary>Loads the assembly at the normalized file path.</summary>
+    /// <param name="fullPath">The normalized assembly file path.</param>
+    /// <returns>The loaded assembly.</returns>
+    [RequiresDynamicCode("Loads an assembly into the current process which requires dynamic code.")]
+    [RequiresUnreferencedCode("The loaded assembly may depend on members removed by trimming.")]
+    [SuppressMessage(
+        "Security",
+        "SES1402",
+        Justification = "AssemblyLoad accepts a caller-supplied DLL path and must honor that exact path on .NET Framework.")]
+    [SuppressMessage(
+        "Usage",
+        "SST2486",
+        Justification = "Assembly.LoadFrom is the .NET Framework equivalent of exact-path AssemblyLoadContext loading.")]
+    private static Assembly LoadAssembly(string fullPath)
+    {
+#if NET8_0_OR_GREATER
+        return AssemblyLoadContext.Default.LoadFromAssemblyPath(fullPath);
+#else
+        return Assembly.LoadFrom(fullPath);
+#endif
+    }
 
     /// <summary>Returns a value or throws when it is null.</summary>
     /// <typeparam name="T">The value type.</typeparam>

--- a/src/TwinCATRx.Tests/Core/CoreExtensionsDeterministicCoverageTests.cs
+++ b/src/TwinCATRx.Tests/Core/CoreExtensionsDeterministicCoverageTests.cs
@@ -149,7 +149,7 @@ public class CoreExtensionsDeterministicCoverageTests
         await TUnitAssert.That(attempts).IsEqualTo(ExpectedAttemptCount);
     }
 
-    /// <summary>Verifies null settings are ignored and existing assemblies load.</summary>
+    /// <summary>Verifies null settings are ignored and generated assemblies load from their supplied path.</summary>
     /// <returns>The test task.</returns>
     [Test]
     public async Task Settings_Null_Guards_And_Assembly_Load_Success_Are_CoveredAsync()
@@ -158,26 +158,26 @@ public class CoreExtensionsDeterministicCoverageTests
         CoreTwinCatRxExtensions.AddNotification(nullSettings, ".Ignored");
         CoreTwinCatRxExtensions.AddWriteVariable(nullSettings, ".Ignored");
 
-        var sourcePath = typeof(Settings).Assembly.Location;
-        var assemblyPath = Path.Combine(Path.GetTempPath(), $"TwinCATRx_Core_{Guid.NewGuid()}.dll");
-        try
-        {
-            await Task.Run(() => File.Copy(sourcePath, assemblyPath));
-            var assembly = CoreTwinCatRxExtensions.AssemblyLoad(assemblyPath);
-            var typeName = typeof(Settings).FullName
-                ?? throw new InvalidOperationException("The settings type has no full name.");
-            var resolvedType = CoreTwinCatRxExtensions.GetType(assemblyPath, typeName);
+        var directory = Path.Combine(AppContext.BaseDirectory, "AssemblyLoadPathTests");
+        _ = Directory.CreateDirectory(directory);
+        var generatedTypeName = $"GeneratedType_{Guid.NewGuid():N}";
+        var assemblyPath = Path.Combine(directory, $"{generatedTypeName}.dll");
+        using var generator = new CodeGenerator();
+        await TUnitAssert.That(generator.CreateDll($"public sealed class {generatedTypeName} {{ }}", assemblyPath)).IsTrue();
+        var assemblyName = AssemblyName.GetAssemblyName(assemblyPath);
 
-            await TUnitAssert.That(assembly).IsNotNull();
-            await TUnitAssert.That(resolvedType).IsNotNull();
-            var checkedResolvedType = resolvedType
-                ?? throw new InvalidOperationException("The settings type was not resolved.");
-            await TUnitAssert.That(checkedResolvedType.Name).IsEqualTo(nameof(Settings));
-        }
-        finally
-        {
-            File.Delete(assemblyPath);
-        }
+#if NET8_0_OR_GREATER
+        await TUnitAssert.That(() => System.Reflection.Assembly.Load(assemblyName)).Throws<FileNotFoundException>();
+#else
+        _ = assemblyName;
+#endif
+
+        var assembly = CoreTwinCatRxExtensions.AssemblyLoad(assemblyPath);
+        var resolvedType = CoreTwinCatRxExtensions.GetType(assemblyPath, generatedTypeName);
+
+        await TUnitAssert.That(assembly).IsNotNull();
+        await TUnitAssert.That(resolvedType).IsNotNull();
+        await TUnitAssert.That(assembly?.Location).IsEqualTo(Path.GetFullPath(assemblyPath));
     }
 
     /// <summary>Verifies internal node disposal recursively clears state and is idempotent.</summary>

--- a/src/TwinCATRx.Tests/Core/ReactiveCoreExtensionParityCoverageTests.cs
+++ b/src/TwinCATRx.Tests/Core/ReactiveCoreExtensionParityCoverageTests.cs
@@ -2,6 +2,7 @@
 // Chris Pulman and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Reflection;
 using ReactiveCoreExtensions = IoT.Driver.TwinCATRx.Core.Reactive.TwinCatRxExtensions;
 using ReactiveNode = IoT.Driver.TwinCATRx.Core.Reactive.INodeEmulator;
 using ReactiveSettings = IoT.Driver.TwinCATRx.Core.Reactive.Settings;
@@ -50,7 +51,7 @@ public class ReactiveCoreExtensionParityCoverageTests
             .Throws<ArgumentNullException>();
     }
 
-    /// <summary>Verifies null settings guards and successful dynamic assembly loading.</summary>
+    /// <summary>Verifies null settings guards and path-based dynamic assembly loading.</summary>
     /// <returns>The test task.</returns>
     [Test]
     public async Task Settings_And_Assembly_Helpers_Match_Lean_CoreAsync()
@@ -59,23 +60,26 @@ public class ReactiveCoreExtensionParityCoverageTests
         ReactiveCoreExtensions.AddNotification(nullSettings, ".Ignored");
         ReactiveCoreExtensions.AddWriteVariable(nullSettings, ".Ignored");
 
-        var sourcePath = typeof(ReactiveSettings).Assembly.Location;
-        var assemblyPath = Path.Combine(Path.GetTempPath(), $"TwinCATRx_Core_Reactive_{Guid.NewGuid()}.dll");
-        try
-        {
-            await Task.Run(() => File.Copy(sourcePath, assemblyPath));
-            var assembly = ReactiveCoreExtensions.AssemblyLoad(assemblyPath);
-            var typeName = typeof(ReactiveSettings).FullName
-                ?? throw new InvalidOperationException("The Reactive settings type has no full name.");
-            var resolvedType = ReactiveCoreExtensions.GetType(assemblyPath, typeName);
+        var directory = Path.Combine(AppContext.BaseDirectory, "AssemblyLoadPathTests");
+        _ = Directory.CreateDirectory(directory);
+        var generatedTypeName = $"GeneratedReactiveType_{Guid.NewGuid():N}";
+        var assemblyPath = Path.Combine(directory, $"{generatedTypeName}.dll");
+        using var generator = new IoT.Driver.TwinCATRx.Core.Reactive.CodeGenerator();
+        await TUnitAssert.That(generator.CreateDll($"public sealed class {generatedTypeName} {{ }}", assemblyPath)).IsTrue();
+        var assemblyName = AssemblyName.GetAssemblyName(assemblyPath);
 
-            await TUnitAssert.That(assembly).IsNotNull();
-            await TUnitAssert.That(resolvedType).IsNotNull();
-        }
-        finally
-        {
-            File.Delete(assemblyPath);
-        }
+#if NET8_0_OR_GREATER
+        await TUnitAssert.That(() => System.Reflection.Assembly.Load(assemblyName)).Throws<FileNotFoundException>();
+#else
+        _ = assemblyName;
+#endif
+
+        var assembly = ReactiveCoreExtensions.AssemblyLoad(assemblyPath);
+        var resolvedType = ReactiveCoreExtensions.GetType(assemblyPath, generatedTypeName);
+
+        await TUnitAssert.That(assembly).IsNotNull();
+        await TUnitAssert.That(resolvedType).IsNotNull();
+        await TUnitAssert.That(assembly?.Location).IsEqualTo(Path.GetFullPath(assemblyPath));
     }
 
     /// <summary>Verifies recursive Reactive node disposal.</summary>

--- a/src/TwinCATRx.Tests/Rx/NativeClientVariableResidualCoverageTests.cs
+++ b/src/TwinCATRx.Tests/Rx/NativeClientVariableResidualCoverageTests.cs
@@ -11,6 +11,7 @@ using System.Runtime.Versioning;
 using System.Reflection;
 using IoT.Driver.TwinCATRx.Core;
 using TwinCAT.Ads;
+using ReactiveRxTcAdsClient = IoT.Driver.TwinCATRx.Reactive.RxTcAdsClient;
 using RxNotification = IoT.Driver.TwinCATRx.Core.Notification;
 
 namespace IoT.Driver.TwinCATRx.Tests.Rx;
@@ -47,6 +48,24 @@ public sealed class NativeClientVariableResidualCoverageTests
 
     /// <summary>The private notification-scheduling method name.</summary>
     private const string ScheduleNotificationsMethod = "ScheduleNotifications";
+
+    /// <summary>The private generated-assembly cleanup method name.</summary>
+    private const string TryDeleteGeneratedDataTypeFileMethod = "TryDeleteGeneratedDataTypeFile";
+
+    /// <summary>The private stale generated-assembly cleanup method name.</summary>
+    private const string DeleteGeneratedDataTypeFilesMethod = "DeleteGeneratedDataTypeFiles";
+
+    /// <summary>The private generated-assembly cleanup claim method name.</summary>
+    private const string TryBeginGeneratedDataTypeCleanupMethod = "TryBeginGeneratedDataTypeCleanup";
+
+    /// <summary>The private generated-assembly path method name.</summary>
+    private const string BuildDataTypesFilePathMethod = "BuildDataTypesFilePath";
+
+    /// <summary>The private existing-generated-type lookup method name.</summary>
+    private const string GetExistingGeneratedTypeMethod = "GetExistingGeneratedType";
+
+    /// <summary>The stable identifier used to verify generated assembly paths.</summary>
+    private const string GeneratedAssemblyIdentifier = "123";
 
     /// <summary>The private client type-map field name.</summary>
     private const string TypeInfoField = "_typeInfo";
@@ -111,6 +130,14 @@ public sealed class NativeClientVariableResidualCoverageTests
 
         var dottedPrefix = InvokeStatic("BuildDataTypesFileName", ScalarVariable);
         var plainPrefix = InvokeStatic("BuildDataTypesFileName", "Scalar");
+        var firstGeneratedPath = (string?)InvokeStatic(
+            BuildDataTypesFilePathMethod,
+            dottedPrefix,
+            GeneratedAssemblyIdentifier);
+        var secondGeneratedPath = (string?)InvokeStatic(
+            BuildDataTypesFilePathMethod,
+            dottedPrefix,
+            GeneratedAssemblyIdentifier);
         var matchingLength = InvokeInstance(client, "FindNotificationArrayLength", ArrayVariable);
         var missingLength = InvokeInstance(client, "FindNotificationArrayLength", ".Missing");
         var scalar = InvokeReadTarget(client, ScalarVariable, null);
@@ -126,6 +153,8 @@ public sealed class NativeClientVariableResidualCoverageTests
 
         await TUnitAssert.That(dottedPrefix).IsEqualTo("PLC_Scalar");
         await TUnitAssert.That(plainPrefix).IsEqualTo("PLC_Scalar");
+        await TUnitAssert.That(firstGeneratedPath).IsEqualTo(secondGeneratedPath);
+        await TUnitAssert.That(Path.GetDirectoryName(firstGeneratedPath)).IsEqualTo(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar));
         await TUnitAssert.That(matchingLength).IsEqualTo(ArrayLength);
         await TUnitAssert.That(missingLength).IsEqualTo(-1);
         await TUnitAssert.That(scalar.Resolved).IsTrue();
@@ -136,6 +165,125 @@ public sealed class NativeClientVariableResidualCoverageTests
         await TUnitAssert.That(suppliedStringLength.Length).IsEqualTo(ArrayLength);
         await TUnitAssert.That(blank.Resolved).IsFalse();
         await TUnitAssert.That(missingHandle.Resolved).IsFalse();
+    }
+
+    /// <summary>Verifies generated assembly cleanup tolerates files still loaded by the current process.</summary>
+    /// <returns>The test task.</returns>
+    [Test]
+    public async Task Generated_Assembly_Cleanup_Retries_After_File_Is_ReleasedAsync()
+    {
+        var filePath = Path.Combine(
+            AppContext.BaseDirectory,
+            $"PLC_LockedCleanup_{Guid.NewGuid():N}.dll");
+        await File.WriteAllTextAsync(filePath, "locked").ConfigureAwait(false);
+
+        bool lockedDeleteResult;
+#if NETFRAMEWORK
+        using (File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.None))
+#else
+        await using (File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.None))
+#endif
+        {
+            lockedDeleteResult = (bool)(InvokeStatic(TryDeleteGeneratedDataTypeFileMethod, filePath) ?? true);
+        }
+
+        var releasedDeleteResult = (bool)(InvokeStatic(TryDeleteGeneratedDataTypeFileMethod, filePath) ?? false);
+        var readOnlyPath = Path.Combine(
+            AppContext.BaseDirectory,
+            $"PLC_ReadOnlyCleanup_{Guid.NewGuid():N}.dll");
+        await File.WriteAllTextAsync(readOnlyPath, "read-only").ConfigureAwait(false);
+        File.SetAttributes(readOnlyPath, FileAttributes.ReadOnly);
+        var readOnlyDeleteResult = (bool)(InvokeStatic(TryDeleteGeneratedDataTypeFileMethod, readOnlyPath) ?? true);
+        File.SetAttributes(readOnlyPath, FileAttributes.Normal);
+        File.Delete(readOnlyPath);
+
+        await TUnitAssert.That(lockedDeleteResult).IsFalse();
+        await TUnitAssert.That(releasedDeleteResult).IsTrue();
+        await TUnitAssert.That(readOnlyDeleteResult).IsFalse();
+        await TUnitAssert.That(File.Exists(filePath)).IsFalse();
+    }
+
+    /// <summary>Verifies stale generated assemblies are removed while the current client assembly is retained.</summary>
+    /// <returns>The test task.</returns>
+    [Test]
+    public async Task Generated_Assembly_Cleanup_Retains_Current_Client_AssemblyAsync()
+    {
+        var filePrefix = $"PLC_RetainedCleanup_{Guid.NewGuid():N}";
+        var retainedPath = Path.Combine(AppContext.BaseDirectory, $"{filePrefix}_current.dll");
+        var stalePath = Path.Combine(AppContext.BaseDirectory, $"{filePrefix}{Guid.NewGuid():N}.dll");
+        var relatedPath = Path.Combine(AppContext.BaseDirectory, $"{filePrefix}2{Guid.NewGuid():N}.dll");
+        await File.WriteAllTextAsync(retainedPath, "current").ConfigureAwait(false);
+        await File.WriteAllTextAsync(stalePath, "stale").ConfigureAwait(false);
+        await File.WriteAllTextAsync(relatedPath, "related").ConfigureAwait(false);
+        try
+        {
+            var firstCleanupClaim = (bool)(InvokeStatic(TryBeginGeneratedDataTypeCleanupMethod, filePrefix) ?? false);
+            var secondCleanupClaim = (bool)(InvokeStatic(TryBeginGeneratedDataTypeCleanupMethod, filePrefix) ?? true);
+            _ = InvokeStatic(DeleteGeneratedDataTypeFilesMethod, filePrefix, retainedPath);
+
+            await TUnitAssert.That(firstCleanupClaim).IsTrue();
+            await TUnitAssert.That(secondCleanupClaim).IsFalse();
+            await TUnitAssert.That(File.Exists(retainedPath)).IsTrue();
+            await TUnitAssert.That(File.Exists(stalePath)).IsFalse();
+            await TUnitAssert.That(File.Exists(relatedPath)).IsTrue();
+        }
+        finally
+        {
+            File.Delete(retainedPath);
+            File.Delete(stalePath);
+            File.Delete(relatedPath);
+        }
+    }
+
+    /// <summary>Verifies a previously generated PLC type is reused without regenerating its assembly.</summary>
+    /// <returns>The test task.</returns>
+    [Test]
+#if NET9_0_OR_GREATER
+    [RequiresDynamicCode("Compiles and loads a deterministic generated PLC type assembly.")]
+    [RequiresUnreferencedCode("Loads a deterministic generated PLC type by name.")]
+#endif
+    public async Task Existing_Generated_Assembly_Is_ReusedAsync()
+    {
+        var missingType = InvokeStatic(
+            GetExistingGeneratedTypeMethod,
+            Path.Combine(AppContext.BaseDirectory, "missing-generated-type.dll"),
+            "IoT.Driver.TwinCATRx.MissingGeneratedType");
+        var missingReactiveType = InvokeReactiveStatic(
+            GetExistingGeneratedTypeMethod,
+            Path.Combine(AppContext.BaseDirectory, "missing-generated-reactive-type.dll"),
+            "IoT.Driver.TwinCATRx.MissingGeneratedReactiveType");
+        await TUnitAssert.That(missingType).IsNull();
+        await TUnitAssert.That(missingReactiveType).IsNull();
+
+#if !NETFRAMEWORK
+        var generatedTypeName = $"ReusedGeneratedType_{Guid.NewGuid():N}";
+        var assemblyPath = Path.Combine(
+            AppContext.BaseDirectory,
+            $"PLC_{generatedTypeName}.dll");
+        using var generator = new CodeGenerator();
+        try
+        {
+            var source = $"namespace IoT.Driver.TwinCATRx {{ public sealed class {generatedTypeName} {{ }} }}";
+            await TUnitAssert.That(generator.CreateDll(source, assemblyPath)).IsTrue();
+
+            var existingType = (Type?)InvokeStatic(
+                GetExistingGeneratedTypeMethod,
+                assemblyPath,
+                $"IoT.Driver.TwinCATRx.{generatedTypeName}");
+            var existingReactiveType = (Type?)InvokeReactiveStatic(
+                GetExistingGeneratedTypeMethod,
+                assemblyPath,
+                $"IoT.Driver.TwinCATRx.{generatedTypeName}");
+
+            await TUnitAssert.That(existingType).IsNotNull();
+            await TUnitAssert.That(existingType?.Name).IsEqualTo(generatedTypeName);
+            await TUnitAssert.That(existingReactiveType).IsSameReferenceAs(existingType);
+        }
+        finally
+        {
+            _ = InvokeStatic(TryDeleteGeneratedDataTypeFileMethod, assemblyPath);
+        }
+#endif
     }
 
     /// <summary>Verifies empty registration, primitive conversion, and read-notification guard branches without ADS hardware.</summary>
@@ -167,7 +315,6 @@ public sealed class NativeClientVariableResidualCoverageTests
             "ResolveNotificationType",
             ".Unknown",
             "missing.dll",
-            "residual",
             false);
 
         _ = InvokeInstance(client, ReadNotificationMethod, runtime, new RxNotification(UpdateRate, null));
@@ -198,6 +345,15 @@ public sealed class NativeClientVariableResidualCoverageTests
     {
         await TUnitAssert.That(CreateClientWithNullTimeProvider).Throws<ArgumentNullException>();
         await TUnitAssert.That(static () => _ = new RxTcAdsClient(TimeProvider.System, null!)).Throws<ArgumentNullException>();
+
+        var fixedTimeProvider = new FixedTimeProvider();
+        using var firstIdentifierPlatform = new MinimalPlatform(new RecordingAdsClientRuntime());
+        using var secondIdentifierPlatform = new MinimalPlatform(new RecordingAdsClientRuntime());
+        using var firstIdentifierClient = new RxTcAdsClient(fixedTimeProvider, firstIdentifierPlatform);
+        using var secondIdentifierClient = new RxTcAdsClient(fixedTimeProvider, secondIdentifierPlatform);
+        var firstIdentifier = GetField<string>(firstIdentifierClient, "_generatedAssemblyIdentifier");
+        var secondIdentifier = GetField<string>(secondIdentifierClient, "_generatedAssemblyIdentifier");
+        await TUnitAssert.That(firstIdentifier).IsNotEqualTo(secondIdentifier);
 
         using var guardedClient = new RxTcAdsClient();
         var errors = new List<Exception>();
@@ -371,6 +527,13 @@ public sealed class NativeClientVariableResidualCoverageTests
     private static object? InvokeStatic(string name, params object?[] arguments) =>
         GetMethod(typeof(RxTcAdsClient), name, BindingFlags.Static).Invoke(null, arguments);
 
+    /// <summary>Invokes a private static reactive client method.</summary>
+    /// <param name="name">The method name.</param>
+    /// <param name="arguments">The method arguments.</param>
+    /// <returns>The invocation result.</returns>
+    private static object? InvokeReactiveStatic(string name, params object?[] arguments) =>
+        GetMethod(typeof(ReactiveRxTcAdsClient), name, BindingFlags.Static).Invoke(null, arguments);
+
     /// <summary>Gets one private method with a descriptive failure when its implementation changes.</summary>
     /// <param name="type">The declaring type.</param>
     /// <param name="name">The private method name.</param>
@@ -397,6 +560,14 @@ public sealed class NativeClientVariableResidualCoverageTests
         var property = instance.GetType().GetProperty(name, BindingFlags.Instance | BindingFlags.Public)
             ?? throw new MissingMemberException(instance.GetType().FullName, name);
         property.SetValue(instance, value);
+    }
+
+    /// <summary>Provides one fixed time to prove generated assembly ownership is not time-derived.</summary>
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        /// <inheritdoc/>
+        public override DateTimeOffset GetUtcNow() =>
+            new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
     }
 
     /// <summary>Records native ADS calls while providing deterministic scalar and array responses.</summary>

--- a/src/TwinCATRx.Tests/Rx/RxTcAdsClientCompositionTests.cs
+++ b/src/TwinCATRx.Tests/Rx/RxTcAdsClientCompositionTests.cs
@@ -376,9 +376,11 @@ public sealed class RxTcAdsClientCompositionTests
 #endif
     public async Task Composed_Runtime_Removes_Stale_Generated_Data_Type_FileAsync()
     {
+        var variableName = $".Value_Stale_{Guid.NewGuid():N}";
+        var symbolName = variableName[1..];
         var staleFile = Path.Combine(
             AppDomain.CurrentDomain.BaseDirectory,
-            $"PLC_Value_Coverage_{Guid.NewGuid():N}.tmp");
+            $"PLC_{symbolName}{Guid.NewGuid():N}.dll");
 #if NETFRAMEWORK
         using (var writer = File.CreateText(staleFile))
         {
@@ -395,9 +397,9 @@ public sealed class RxTcAdsClientCompositionTests
         {
             var ads = new FakeAdsClient { Port = TwinCat3Port };
             using var platform = new FakePlatform(ads);
-            platform.AddSymbol(ValueSymbolName, "DINT", DataTypeCategory.Primitive);
+            platform.AddSymbol(symbolName, "DINT", DataTypeCategory.Primitive);
             var settings = new Settings { Port = TwinCat3Port };
-            settings.Notifications.Add(new RxNotification(UpdateRate, ValueVariable));
+            settings.Notifications.Add(new RxNotification(UpdateRate, variableName));
             using var client = new RxTcAdsClient(TimeProvider.System, platform);
 
             client.Connect(settings);

--- a/src/TwinCATRx/RxTcAdsClient.Variables.cs
+++ b/src/TwinCATRx/RxTcAdsClient.Variables.cs
@@ -27,6 +27,10 @@ public partial class RxTcAdsClient
     /// <summary>Synchronizes generated data-type cleanup, creation, and loading across client instances.</summary>
     private static readonly object GeneratedDataTypeFileLock = new();
 
+    /// <summary>Tracks variable prefixes whose stale files were cleaned in this process.</summary>
+    private static readonly HashSet<string> CleanedGeneratedDataTypePrefixes =
+        new(StringComparer.OrdinalIgnoreCase);
+
     /// <summary>Builds the generated data type file prefix.</summary>
     /// <param name="variable">The PLC variable name.</param>
     /// <returns>The generated data type file prefix.</returns>
@@ -43,16 +47,89 @@ public partial class RxTcAdsClient
 #endif
     }
 
+    /// <summary>Builds the stable generated assembly path for a client instance.</summary>
+    /// <param name="dataTypesBaseName">The generated data type file prefix.</param>
+    /// <param name="generatedAssemblyIdentifier">The stable client assembly identifier.</param>
+    /// <returns>The generated assembly path.</returns>
+    private static string BuildDataTypesFilePath(
+        string dataTypesBaseName,
+        string generatedAssemblyIdentifier) =>
+        Path.Combine(
+            AppDomain.CurrentDomain.BaseDirectory,
+            $"{dataTypesBaseName}{generatedAssemblyIdentifier}.dll");
+
+    /// <summary>Resolves a previously generated PLC type assembly when it is available.</summary>
+    /// <param name="dataTypesFileName">The generated assembly path.</param>
+    /// <param name="generatedTypeName">The fully qualified generated type name.</param>
+    /// <returns>The existing generated type, or <see langword="null"/> when it is unavailable.</returns>
+    [RequiresUnreferencedCode("Loads a dynamically generated PLC type by name.")]
+    [RequiresDynamicCode("Loads a dynamically generated PLC assembly.")]
+    private static Type? GetExistingGeneratedType(string dataTypesFileName, string generatedTypeName) =>
+        File.Exists(dataTypesFileName)
+            ? CoreTwinCatRxExtensions.GetType(dataTypesFileName, generatedTypeName)
+            : null;
+
+    /// <summary>Claims the one stale-file cleanup pass for a generated data type prefix.</summary>
+    /// <param name="dataTypesBaseName">The generated data type file prefix.</param>
+    /// <returns><see langword="true"/> only for the first claim in this process.</returns>
+    private static bool TryBeginGeneratedDataTypeCleanup(string dataTypesBaseName) =>
+        CleanedGeneratedDataTypePrefixes.Add(dataTypesBaseName);
+
     /// <summary>Deletes stale generated data type files.</summary>
     /// <param name="dataTypesBaseName">The generated data type file prefix.</param>
-    private static void DeleteGeneratedDataTypeFiles(string dataTypesBaseName)
+    /// <param name="retainedFilePath">The current client's generated assembly path to retain.</param>
+    private static void DeleteGeneratedDataTypeFiles(string dataTypesBaseName, string retainedFilePath)
     {
         var directory = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
         foreach (var file in DirectoryInfoExtensions.GetFilesWhere(
             directory,
-            file => file.Name.Contains(dataTypesBaseName)))
+            file => IsGeneratedDataTypeFile(file.Name, dataTypesBaseName)
+                && !string.Equals(file.FullName, retainedFilePath, StringComparison.OrdinalIgnoreCase)))
         {
-            File.Delete(file.FullName);
+            _ = TryDeleteGeneratedDataTypeFile(file.FullName);
+        }
+    }
+
+    /// <summary>Determines whether a DLL belongs to one exact generated data type prefix.</summary>
+    /// <param name="fileName">The generated assembly file name.</param>
+    /// <param name="dataTypesBaseName">The generated data type file prefix.</param>
+    /// <returns><see langword="true"/> when the filename has a supported generated identifier.</returns>
+    private static bool IsGeneratedDataTypeFile(string fileName, string dataTypesBaseName)
+    {
+        if (!string.Equals(Path.GetExtension(fileName), ".dll", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var nameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
+        if (!nameWithoutExtension.StartsWith(dataTypesBaseName, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var identifier = nameWithoutExtension.Substring(dataTypesBaseName.Length);
+        return (identifier.Length == 32 && Guid.TryParseExact(identifier, "N", out _))
+            || (identifier.Length == 18
+                && long.TryParse(identifier, NumberStyles.None, CultureInfo.InvariantCulture, out _));
+    }
+
+    /// <summary>Attempts to delete a generated type assembly that may still be loaded by the current process.</summary>
+    /// <param name="filePath">The generated assembly path.</param>
+    /// <returns><see langword="true"/> when the file was deleted; otherwise, <see langword="false"/>.</returns>
+    private static bool TryDeleteGeneratedDataTypeFile(string filePath)
+    {
+        try
+        {
+            File.Delete(filePath);
+            return true;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
         }
     }
 
@@ -224,14 +301,17 @@ public partial class RxTcAdsClient
             return;
         }
 
-        var identifier = _timeProvider.GetUtcNow().UtcTicks.ToString(CultureInfo.InvariantCulture);
         var dataTypesBaseName = BuildDataTypesFileName(notificationVariable);
-        var dataTypesFileName = $"{dataTypesBaseName}{identifier}.dll";
+        var dataTypesFileName = BuildDataTypesFilePath(dataTypesBaseName, _generatedAssemblyIdentifier);
         Type? type;
         lock (GeneratedDataTypeFileLock)
         {
-            DeleteGeneratedDataTypeFiles(dataTypesBaseName);
-            type = ResolveNotificationType(notificationVariable, dataTypesFileName, identifier, isTwinCat3);
+            if (TryBeginGeneratedDataTypeCleanup(dataTypesBaseName))
+            {
+                DeleteGeneratedDataTypeFiles(dataTypesBaseName, dataTypesFileName);
+            }
+
+            type = ResolveNotificationType(notificationVariable, dataTypesFileName, isTwinCat3);
         }
 
         if (type is null)
@@ -248,7 +328,6 @@ public partial class RxTcAdsClient
     /// <summary>Resolves the CLR type used by a notification variable.</summary>
     /// <param name="notificationVariable">The notification variable name.</param>
     /// <param name="dataTypesFileName">The generated data type file name.</param>
-    /// <param name="identifier">The generated code identifier.</param>
     /// <param name="isTwinCat3">Whether TwinCAT 3 packing should be used.</param>
     /// <returns>The resolved CLR type.</returns>
     [RequiresUnreferencedCode("Invokes dynamic code generation and reflection to materialize PLC types.")]
@@ -256,21 +335,24 @@ public partial class RxTcAdsClient
     private Type? ResolveNotificationType(
         string notificationVariable,
         string dataTypesFileName,
-        string identifier,
         bool isTwinCat3)
     {
         var nodeEmulator = _codeGenerator?.SearchSymbols(notificationVariable);
         var symbol = (ISymbol?)nodeEmulator?.Tag;
         var notificationType = symbol?.TypeName;
+        var generatedTypeName = $"IoT.Driver.TwinCATRx.{notificationType}";
+        var existingType = GetExistingGeneratedType(dataTypesFileName, generatedTypeName);
+        if (existingType is not null)
+        {
+            return existingType;
+        }
+
         if (_codeGenerator?.CreateDll(nodeEmulator, dataTypesFileName, isTwinCat3: isTwinCat3) == true)
         {
-            var generatedCode = BuildDataTypesFileName(notificationVariable);
             var generatedSource = _codeGenerator.CreateCSharpCodeString(nodeEmulator, isTwinCat3: isTwinCat3);
-            generatedCode += $"{identifier}.dll${generatedSource}";
+            var generatedCode = $"{Path.GetFileName(dataTypesFileName)}${generatedSource}";
             _code.Add(generatedCode);
-            var generatedType = CoreTwinCatRxExtensions.GetType(
-                dataTypesFileName,
-                $"IoT.Driver.TwinCATRx.{notificationType}");
+            var generatedType = CoreTwinCatRxExtensions.GetType(dataTypesFileName, generatedTypeName);
             if (generatedType is not null)
             {
                 return generatedType;

--- a/src/TwinCATRx/RxTcAdsClient.cs
+++ b/src/TwinCATRx/RxTcAdsClient.cs
@@ -70,8 +70,8 @@ public partial class RxTcAdsClient : IRxTcAdsClient
     /// <summary>Stores replaceable platform dependencies.</summary>
     private readonly IRxTcAdsPlatform _platform;
 
-    /// <summary>Stores the time provider used to obtain the current time.</summary>
-    private readonly TimeProvider _timeProvider;
+    /// <summary>Identifies generated assemblies owned by this client instance.</summary>
+    private readonly string _generatedAssemblyIdentifier;
 
     /// <summary>Stores disposable resources owned by this client.</summary>
     private CompositeDisposable? _cleanup;
@@ -103,7 +103,8 @@ public partial class RxTcAdsClient : IRxTcAdsClient
     /// <param name="platform">The replaceable platform dependencies.</param>
     internal RxTcAdsClient(TimeProvider timeProvider, IRxTcAdsPlatform platform)
     {
-        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _ = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _generatedAssemblyIdentifier = Guid.NewGuid().ToString("N");
         _platform = platform ?? throw new ArgumentNullException(nameof(platform));
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

A bug fix for generated TwinCAT PLC assembly loading and lifecycle management across modern .NET and .NET Framework targets.

## What is the new behavior?

Generated assemblies are loaded from the exact requested path. Modern .NET uses `AssemblyLoadContext.Default.LoadFromAssemblyPath`; .NET Framework uses `Assembly.LoadFrom` with narrowly scoped analyzer rationale.

Each `RxTcAdsClient` now owns generated assemblies through a collision-free GUID. Existing generated types are reused, stale files are cleaned once per exact variable prefix, locked or read-only files are tolerated, and cleanup does not remove files owned by another active client.

Focused TUnit coverage verifies exact-path loading, GUID uniqueness, reconnect reuse, stale cleanup retention, and related-prefix isolation.

## What is the current behavior?

Assembly identity loading can resolve a different DLL than the caller-supplied path on .NET Framework. Tick-based generated assembly identifiers can collide when clients are created at the same instant, and broad prefix cleanup can delete another active client's generated DLL.

## Checklist

- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows Conventional Commits

## Additional information

Validation completed locally:

- 254 TUnit tests passed on each of eight target frameworks: net48, net481, net8.0, net9.0, net10.0, net11.0, net9.0-windows10.0.19041.0, and net11.0-windows10.0.19041.0 (2,032 total test executions).
- Focused net10 coverage passed 254/254 tests.
- Both lean and reactive `AssemblyLoad` methods have 100% line and branch coverage in the generated Cobertura report.
- `build.cmd Compile --configuration Release` completed with zero warnings and zero errors.
- `git diff --check` completed cleanly.