### PR TITLE
fix(twincat): serialize service polling with disposal

### DIFF
--- a/src/TwinCATRx.Reactive/TwinCATRx.Reactive.csproj
+++ b/src/TwinCATRx.Reactive/TwinCATRx.Reactive.csproj
@@ -37,6 +37,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>TwinCATRx.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\TwinCATRx.Core.Reactive\TwinCATRx.Core.Reactive.csproj" />
     <ProjectReference Include="..\TwinCATRx.Generators\TwinCATRx.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
     <ProjectReference Include="..\CP.IoT.Core\CP.IoT.Core.csproj" />

--- a/src/TwinCATRx.Tests/Rx/LeanServiceControllerCoverageTests.cs
+++ b/src/TwinCATRx.Tests/Rx/LeanServiceControllerCoverageTests.cs
@@ -24,6 +24,12 @@ public class LeanServiceControllerCoverageTests
     /// <summary>The TwinCAT system service name.</summary>
     private const string TwinCatServiceName = "TcSysSrv";
 
+    /// <summary>The bounded time allowed for race-test coordination.</summary>
+    private static readonly TimeSpan RaceTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>The interval used to prove disposal is waiting for an in-flight poll.</summary>
+    private static readonly TimeSpan RaceObservationInterval = TimeSpan.FromMilliseconds(250);
+
     /// <summary>Verifies composed service commands and deterministic polling.</summary>
     /// <returns>The test task.</returns>
     [Test]
@@ -103,6 +109,70 @@ public class LeanServiceControllerCoverageTests
         await TUnitAssert.That(unsupported.Completed).IsTrue();
     }
 
+    /// <summary>Verifies disposal cannot invalidate the status signal while polling is publishing an error.</summary>
+    /// <returns>The test task.</returns>
+    [Test]
+    public async Task Dispose_During_A_Failing_Status_Read_Is_Serialized_With_PollingAsync()
+    {
+        using var statusReadEntered = new ManualResetEventSlim();
+        using var allowStatusRead = new ManualResetEventSlim();
+        using var disposalTaskStarted = new ManualResetEventSlim();
+        var expectedError = new InvalidOperationException("service disposed during status read");
+        var runtime = new FakeServiceControllerRuntime
+        {
+            AllowStatusRead = allowStatusRead,
+            StatusError = expectedError,
+            StatusReadEntered = statusReadEntered,
+        };
+        var ticks = new ManualObservable<long>();
+        using var controller = new ObservableServiceController(runtime, ticks);
+        var statuses = new RecordingObserver<ServiceControllerStatus>();
+        using var subscription = controller.StatusObserver.Subscribe(statuses);
+
+        var pollingTask = Task.Run(() => ticks.Emit(0));
+        var statusReadWasObserved = statusReadEntered.Wait(RaceTimeout);
+        Task? disposeTask = null;
+        var disposalTaskWasObserved = false;
+        var disposalWaitedForPolling = false;
+        if (statusReadWasObserved)
+        {
+            disposeTask = Task.Run(() =>
+            {
+                disposalTaskStarted.Set();
+                controller.Dispose();
+            });
+            disposalTaskWasObserved = disposalTaskStarted.Wait(RaceTimeout);
+            if (disposalTaskWasObserved)
+            {
+                var firstCompleted = await Task.WhenAny(disposeTask, Task.Delay(RaceObservationInterval));
+                disposalWaitedForPolling = !ReferenceEquals(firstCompleted, disposeTask);
+            }
+        }
+
+        allowStatusRead.Set();
+        Exception? pollingException = null;
+        try
+        {
+            await pollingTask;
+        }
+        catch (Exception ex)
+        {
+            pollingException = ex;
+        }
+
+        if (disposeTask is not null)
+        {
+            await disposeTask;
+        }
+
+        await TUnitAssert.That(statusReadWasObserved).IsTrue();
+        await TUnitAssert.That(disposalTaskWasObserved).IsTrue();
+        await TUnitAssert.That(disposalWaitedForPolling).IsTrue();
+        await TUnitAssert.That(pollingException).IsNull();
+        await TUnitAssert.That(statuses.Errors).Count().IsEqualTo(1);
+        await TUnitAssert.That(statuses.Errors[0]).IsSameReferenceAs(expectedError);
+    }
+
     /// <summary>Verifies null-state getters and disposed command guards without querying Windows services.</summary>
     /// <returns>The test task.</returns>
     [Test]
@@ -179,6 +249,8 @@ public class LeanServiceControllerCoverageTests
         {
             get
             {
+                StatusReadEntered?.Set();
+                AllowStatusRead?.Wait();
                 if (StatusError is not null)
                 {
                     throw StatusError;
@@ -193,8 +265,14 @@ public class LeanServiceControllerCoverageTests
         /// <summary>Gets or sets the status assigned by refresh.</summary>
         public ServiceControllerStatus? RefreshedStatus { get; set; }
 
+        /// <summary>Gets or sets the gate that releases a blocked status read.</summary>
+        public ManualResetEventSlim? AllowStatusRead { get; set; }
+
         /// <summary>Gets or sets the status query error.</summary>
         public Exception? StatusError { get; set; }
+
+        /// <summary>Gets or sets the signal raised when a status read begins.</summary>
+        public ManualResetEventSlim? StatusReadEntered { get; set; }
 
         /// <summary>Gets the refresh count.</summary>
         public int RefreshCount { get; private set; }

--- a/src/TwinCATRx.Tests/Rx/ReactiveServiceControllerParityCoverageTests.cs
+++ b/src/TwinCATRx.Tests/Rx/ReactiveServiceControllerParityCoverageTests.cs
@@ -8,6 +8,7 @@ using System.ServiceProcess;
 using System.Runtime.Versioning;
 #endif
 using ReactiveServiceController = IoT.Driver.TwinCATRx.Reactive.ObservableServiceController;
+using ReactiveServiceControllerRuntime = IoT.Driver.TwinCATRx.Reactive.IServiceControllerRuntime;
 
 namespace IoT.Driver.TwinCATRx.Tests.Rx;
 
@@ -17,6 +18,74 @@ namespace IoT.Driver.TwinCATRx.Tests.Rx;
 #endif
 public class ReactiveServiceControllerParityCoverageTests
 {
+    /// <summary>The bounded time allowed for race-test coordination.</summary>
+    private static readonly TimeSpan RaceTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>The interval used to prove disposal is waiting for an in-flight poll.</summary>
+    private static readonly TimeSpan RaceObservationInterval = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>Verifies the Reactive build serializes status publication with disposal.</summary>
+    /// <returns>The test task.</returns>
+    [Test]
+    public async Task Dispose_During_A_Failing_Status_Read_Is_Serialized_With_Reactive_PollingAsync()
+    {
+        using var statusReadEntered = new ManualResetEventSlim();
+        using var allowStatusRead = new ManualResetEventSlim();
+        using var disposalTaskStarted = new ManualResetEventSlim();
+        var expectedError = new InvalidOperationException("service disposed during reactive status read");
+        var runtime = new BlockingServiceControllerRuntime(
+            statusReadEntered,
+            allowStatusRead,
+            expectedError);
+        var ticks = new ManualObservable<long>();
+        using var controller = new ReactiveServiceController(runtime, ticks);
+        var statuses = new RecordingObserver<ServiceControllerStatus>();
+        using var subscription = controller.StatusObserver.Subscribe(statuses);
+
+        var pollingTask = Task.Run(() => ticks.Emit(0));
+        var statusReadWasObserved = statusReadEntered.Wait(RaceTimeout);
+        Task? disposeTask = null;
+        var disposalTaskWasObserved = false;
+        var disposalWaitedForPolling = false;
+        if (statusReadWasObserved)
+        {
+            disposeTask = Task.Run(() =>
+            {
+                disposalTaskStarted.Set();
+                controller.Dispose();
+            });
+            disposalTaskWasObserved = disposalTaskStarted.Wait(RaceTimeout);
+            if (disposalTaskWasObserved)
+            {
+                var firstCompleted = await Task.WhenAny(disposeTask, Task.Delay(RaceObservationInterval));
+                disposalWaitedForPolling = !ReferenceEquals(firstCompleted, disposeTask);
+            }
+        }
+
+        allowStatusRead.Set();
+        Exception? pollingException = null;
+        try
+        {
+            await pollingTask;
+        }
+        catch (Exception ex)
+        {
+            pollingException = ex;
+        }
+
+        if (disposeTask is not null)
+        {
+            await disposeTask;
+        }
+
+        await TUnitAssert.That(statusReadWasObserved).IsTrue();
+        await TUnitAssert.That(disposalTaskWasObserved).IsTrue();
+        await TUnitAssert.That(disposalWaitedForPolling).IsTrue();
+        await TUnitAssert.That(pollingException).IsNull();
+        await TUnitAssert.That(statuses.Errors).Count().IsEqualTo(1);
+        await TUnitAssert.That(statuses.Errors[0]).IsSameReferenceAs(expectedError);
+    }
+
     /// <summary>Verifies null-state getters and disposed commands never query Windows services.</summary>
     /// <returns>The test task.</returns>
     [Test]
@@ -68,5 +137,114 @@ public class ReactiveServiceControllerParityCoverageTests
         /// <summary>Invokes the protected disposal path.</summary>
         /// <param name="disposing">Whether managed resources should be disposed.</param>
         public void ExposeDispose(bool disposing) => Dispose(disposing);
+    }
+
+    /// <summary>Reactive service runtime that blocks a failing status read.</summary>
+    /// <remarks>Initializes a new instance of the <see cref="BlockingServiceControllerRuntime"/> class.</remarks>
+    /// <param name="statusReadEntered">The signal raised when a status read begins.</param>
+    /// <param name="allowStatusRead">The gate that releases the status read.</param>
+    /// <param name="statusError">The error raised after release.</param>
+    private sealed class BlockingServiceControllerRuntime(
+        ManualResetEventSlim statusReadEntered,
+        ManualResetEventSlim allowStatusRead,
+        Exception statusError) : ReactiveServiceControllerRuntime
+    {
+        /// <inheritdoc/>
+        public event EventHandler? Disposed;
+
+        /// <inheritdoc/>
+        public bool CanStop => false;
+
+        /// <inheritdoc/>
+        public string DisplayName => "TwinCAT System";
+
+        /// <inheritdoc/>
+        public string ServiceName => "TcSysSrv";
+
+        /// <inheritdoc/>
+        public ServiceControllerStatus Status
+        {
+            get
+            {
+                statusReadEntered.Set();
+                allowStatusRead.Wait();
+                throw statusError;
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose() => Disposed?.Invoke(this, EventArgs.Empty);
+
+        /// <inheritdoc/>
+        public void Refresh()
+        {
+        }
+
+        /// <inheritdoc/>
+        public void Start()
+        {
+        }
+
+        /// <inheritdoc/>
+        public void Stop()
+        {
+        }
+
+        /// <inheritdoc/>
+        public void WaitForStatus(ServiceControllerStatus status) => _ = status;
+    }
+
+    /// <summary>Manually triggered observable sequence.</summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    private sealed class ManualObservable<T> : IObservable<T>
+    {
+        /// <summary>Stores observers.</summary>
+        private readonly List<IObserver<T>> _observers = [];
+
+        /// <summary>Emits one value.</summary>
+        /// <param name="value">The value.</param>
+        public void Emit(T value)
+        {
+            foreach (var observer in _observers.ToArray())
+            {
+                observer.OnNext(value);
+            }
+        }
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            _observers.Add(observer);
+            return new Subscription(_observers, observer);
+        }
+
+        /// <summary>Removes one observer.</summary>
+        /// <remarks>Initializes a new instance of the <see cref="Subscription"/> class.</remarks>
+        /// <param name="observers">The observer collection.</param>
+        /// <param name="observer">The observer to remove.</param>
+        private sealed class Subscription(List<IObserver<T>> observers, IObserver<T> observer) : IDisposable
+        {
+            /// <inheritdoc/>
+            public void Dispose() => _ = observers.Remove(observer);
+        }
+    }
+
+    /// <summary>Records observable errors.</summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    private sealed class RecordingObserver<T> : IObserver<T>
+    {
+        /// <summary>Gets observed errors.</summary>
+        public List<Exception> Errors { get; } = [];
+
+        /// <inheritdoc/>
+        public void OnCompleted()
+        {
+        }
+
+        /// <inheritdoc/>
+        public void OnError(Exception error) => Errors.Add(error);
+
+        /// <inheritdoc/>
+        public void OnNext(T value) => _ = value;
     }
 }

--- a/src/TwinCATRx/ObservableServiceController.cs
+++ b/src/TwinCATRx/ObservableServiceController.cs
@@ -28,8 +28,14 @@ public class ObservableServiceController : IObservableServiceController
     /// <summary>Publishes service status changes.</summary>
     private readonly Signal<ServiceControllerStatus> _statusChanged = new();
 
+    /// <summary>Serializes service polling with disposal and status publication.</summary>
+    private readonly Lock _stateGate = new();
+
     /// <summary>Stores the wrapped service controller.</summary>
     private IServiceControllerRuntime? _serviceController;
+
+    /// <summary>Tracks whether the wrapped service controller has been disposed.</summary>
+    private bool _serviceControllerIsDisposed;
 
     /// <summary>Initializes a new instance of the <see cref="ObservableServiceController"/> class.</summary>
     /// <param name="service">The service.</param>
@@ -179,14 +185,21 @@ public class ObservableServiceController : IObservableServiceController
     /// </param>
     protected virtual void Dispose(bool disposing)
     {
-        if (_cleanup.IsDisposed || !disposing)
+        if (!disposing)
         {
             return;
         }
 
-        _serviceController?.Dispose();
-        _cleanup.Dispose();
-        _statusChanged.Dispose();
+        lock (_stateGate)
+        {
+            if (_cleanup.IsDisposed)
+            {
+                return;
+            }
+
+            _cleanup.Dispose();
+            _statusChanged.Dispose();
+        }
     }
 
     /// <summary>Creates the object.</summary>
@@ -196,34 +209,49 @@ public class ObservableServiceController : IObservableServiceController
     {
         _serviceController = service;
         _ = _serviceController.DisposeWith(_cleanup);
-        var serviceControllerIsDisposed = false;
-        _serviceController.Disposed += (e, o) => serviceControllerIsDisposed = true;
+        _serviceController.Disposed += ServiceControllerDisposed;
 
         _ = ObservableBridgeExtensions.SubscribeTo(refreshTicks.Retry(int.MaxValue), _ =>
         {
-            try
+            lock (_stateGate)
             {
-                if (!serviceControllerIsDisposed)
+                try
                 {
-                    var currentStatus = _serviceController?.Status;
-                    _serviceController?.Refresh();
-
-                    if (_serviceController is not null &&
-                        currentStatus.HasValue &&
-                        currentStatus.Value != _serviceController.Status)
+                    if (!_serviceControllerIsDisposed && !_cleanup.IsDisposed)
                     {
-                        _statusChanged.OnNext(_serviceController.Status);
+                        var currentStatus = _serviceController?.Status;
+                        _serviceController?.Refresh();
+
+                        if (_serviceController is not null &&
+                            currentStatus.HasValue &&
+                            currentStatus.Value != _serviceController.Status)
+                        {
+                            _statusChanged.OnNext(_serviceController.Status);
+                        }
                     }
                 }
-            }
-            catch (InvalidOperationException ex)
-            {
-                _statusChanged.OnError(ex);
-            }
-            catch (Win32Exception ex)
-            {
-                _statusChanged.OnError(ex);
+                catch (InvalidOperationException ex)
+                {
+                    _statusChanged.OnError(ex);
+                }
+                catch (Win32Exception ex)
+                {
+                    _statusChanged.OnError(ex);
+                }
             }
         }).DisposeWith(_cleanup);
+    }
+
+    /// <summary>Marks the wrapped service controller as disposed.</summary>
+    /// <param name="sender">The event sender.</param>
+    /// <param name="eventArgs">The event arguments.</param>
+    private void ServiceControllerDisposed(object? sender, EventArgs eventArgs)
+    {
+        _ = sender;
+        _ = eventArgs;
+        lock (_stateGate)
+        {
+            _serviceControllerIsDisposed = true;
+        }
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix: serialize TwinCAT service-controller polling and disposal, with regression coverage for both lean and Reactive implementations.

## What is the new behavior?

- Service polling, status publication, runtime disposal notification, and controller disposal now share one state gate, preventing a poll from publishing to a disposed status signal.
- The Reactive TwinCATRx assembly exposes internals to `TwinCATRx.Tests` so its behavior can be covered directly.
- Adds deterministic TUnit race regressions that hold a failing status read while disposal begins, explicitly signal that the disposal task has started, then verify disposal waits, the poll does not throw, and the expected error is observed exactly once.

## What is the current behavior?

Previously, disposal could overlap an in-flight service status read and error publication, allowing the status signal to be disposed while polling was still using it. The lean and Reactive variants did not both have deterministic coverage for this race.

## Checklist

- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

## Additional information

Verification on 2026-08-08:

- Full no-incremental Release solution build before the test-only synchronization follow-up: 0 warnings, 0 errors.
- Independent no-restore Release solution build before the test-only synchronization follow-up: 0 warnings, 0 errors.
- All-target `TwinCATRx.Tests` Release build after the follow-up: 0 warnings, 0 errors.
- `TwinCATRx.Tests` on `net11.0`: five consecutive runs of 256 passed, 0 failed, 0 skipped.
- TwinCATRx coverage: 97.66% line and 94.71% branch; the lean `ObservableServiceController` has 100% branch coverage.
- GitHub `BuildOnly / windows-latest` run 31246719738: 10,237 tests passed, 0 failed, 0 skipped; compile, coverage, and upload all succeeded.
- Commit `1711be40717ae6fc4e619cae543e22539c6d61ae` has a verified local OpenPGP signature.

Risk note: disposal intentionally waits for an active polling callback; a permanently blocked runtime status read can therefore delay disposal.
